### PR TITLE
Infer entry point types, and improve error messages

### DIFF
--- a/internal/schema/meta.go
+++ b/internal/schema/meta.go
@@ -3,9 +3,8 @@ package schema
 var Meta *Schema
 
 func init() {
-	Meta = &Schema{} // bootstrap
 	Meta = New()
-	if err := Meta.Parse(metaSrc); err != nil {
+	if err := Meta.parseWithoutEntryPoints(metaSrc); err != nil {
 		panic(err)
 	}
 }

--- a/internal/tests/all_test.go
+++ b/internal/tests/all_test.go
@@ -40,6 +40,7 @@ func TestAll(t *testing.T) {
 	for i, schemaStr := range testData.Schemas {
 		schemas[i] = schema.New()
 		if err := schemas[i].Parse(schemaStr); err != nil {
+			t.Logf("\n" + schemaStr)
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
Consistent with [schema parsing behavior from graphql-js][1], this commit allows graphql-go to infer entry point types without an explicit `schema` declaration if there are types in the schema named "Query", "Mutation", or "Subscription".

It also returns a more descriptive error message if no query type is declared, which fixes #125. Previously if no `schema` declaration was present a cryptic panic would be thrown at runtime. (`interface conversion: resolvable.Resolvable is nil, not *resolvable.Object`) It now errors at schema parse time with `graphql: must provide "schema" definition with "query" type or a type named "Query"`.

[1]: https://github.com/graphql/graphql-js/blob/master@{2017-11-18}/src/utilities/buildASTSchema.js#L167-L221

---

Let me know what you think! I ran into this discrepancy early in my experimentation with this library and could not for the life of me figure out what was going on (and frankly almost dropped this library and went with [graphql-go/graphql](http://github.com/graphql-go/graphql) because of it). 😕 I had prototyped the schema in JS using [Apollo Launchpad](https://launchpad.graphql.com), which defaults to never declaring `schema { ... }` at all.

Fortunately I was lured back by the simplicity of this library's schema-as-string/simple resolvers approach and gave it another shot. 😄 Overall I'd definitely say (1) more descriptive error messages and (2) more documentation have been my biggest wants. I'm hoping to contribute some toward those goals but thought I'd let you know my thoughts. 🙂 

Thanks for making this!