### PR TITLE
Fail to parse empty field lists for Object, Interface, and Input Object types

### DIFF
--- a/graphql_test.go
+++ b/graphql_test.go
@@ -581,6 +581,10 @@ func TestIncludeDirective(t *testing.T) {
 
 type testDeprecatedDirectiveResolver struct{}
 
+func (r *testDeprecatedDirectiveResolver) Test() string {
+	return ""
+}
+
 func (r *testDeprecatedDirectiveResolver) A() int32 {
 	return 0
 }
@@ -643,6 +647,7 @@ func TestDeprecatedDirective(t *testing.T) {
 				}
 
 				type Query {
+					test: String!
 				}
 
 				enum Test {

--- a/internal/common/arguments.go
+++ b/internal/common/arguments.go
@@ -1,44 +1,5 @@
 package common
 
-import (
-	"github.com/neelance/graphql-go/errors"
-)
-
-type InputValue struct {
-	Name    Ident
-	Type    Type
-	Default Literal
-	Desc    string
-	Loc     errors.Location
-	TypeLoc errors.Location
-}
-
-type InputValueList []*InputValue
-
-func (l InputValueList) Get(name string) *InputValue {
-	for _, v := range l {
-		if v.Name.Name == name {
-			return v
-		}
-	}
-	return nil
-}
-
-func ParseInputValue(l *Lexer) *InputValue {
-	p := &InputValue{}
-	p.Loc = l.Location()
-	p.Desc = l.DescComment()
-	p.Name = l.ConsumeIdentWithLoc()
-	l.ConsumeToken(':')
-	p.TypeLoc = l.Location()
-	p.Type = ParseType(l)
-	if l.Peek() == '=' {
-		l.ConsumeToken('=')
-		p.Default = ParseLiteral(l, true)
-	}
-	return p
-}
-
 type Argument struct {
 	Name  Ident
 	Value Literal

--- a/internal/common/input_values.go
+++ b/internal/common/input_values.go
@@ -1,0 +1,40 @@
+package common
+
+import (
+	"github.com/neelance/graphql-go/errors"
+)
+
+type InputValue struct {
+	Name    Ident
+	Type    Type
+	Default Literal
+	Desc    string
+	Loc     errors.Location
+	TypeLoc errors.Location
+}
+
+type InputValueList []*InputValue
+
+func (l InputValueList) Get(name string) *InputValue {
+	for _, v := range l {
+		if v.Name.Name == name {
+			return v
+		}
+	}
+	return nil
+}
+
+func ParseInputValue(l *Lexer) *InputValue {
+	p := &InputValue{}
+	p.Loc = l.Location()
+	p.Desc = l.DescComment()
+	p.Name = l.ConsumeIdentWithLoc()
+	l.ConsumeToken(':')
+	p.TypeLoc = l.Location()
+	p.Type = ParseType(l)
+	if l.Peek() == '=' {
+		l.ConsumeToken('=')
+		p.Default = ParseLiteral(l, true)
+	}
+	return p
+}

--- a/internal/common/input_values.go
+++ b/internal/common/input_values.go
@@ -38,3 +38,25 @@ func ParseInputValue(l *Lexer) *InputValue {
 	}
 	return p
 }
+
+func ParseArgumentDeclList(l *Lexer) InputValueList {
+	var args InputValueList
+	if l.Peek() == '(' {
+		l.ConsumeToken('(')
+		for l.Peek() != ')' {
+			args = append(args, ParseInputValue(l))
+		}
+		l.ConsumeToken(')')
+	}
+	return args
+}
+
+func ParseInputFieldList(typeName string, l *Lexer) InputValueList {
+	l.ConsumeToken('{')
+	var list InputValueList
+	for l.Peek() != '}' {
+		list = append(list, ParseInputValue(l))
+	}
+	l.ConsumeToken('}')
+	return list
+}

--- a/internal/common/input_values.go
+++ b/internal/common/input_values.go
@@ -1,6 +1,8 @@
 package common
 
 import (
+	"fmt"
+
 	"github.com/neelance/graphql-go/errors"
 )
 
@@ -56,6 +58,9 @@ func ParseInputFieldList(typeName string, l *Lexer) InputValueList {
 	var list InputValueList
 	for l.Peek() != '}' {
 		list = append(list, ParseInputValue(l))
+	}
+	if len(list) == 0 {
+		l.SyntaxError(fmt.Sprintf(`input type %q must define one or more fields`, typeName))
 	}
 	l.ConsumeToken('}')
 	return list

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -363,14 +363,14 @@ func parseObjectDecl(l *common.Lexer) *Object {
 			}
 		}
 	}
-	o.Fields = parseFields(l)
+	o.Fields = parseFields("object", o.Name, l)
 	return o
 }
 
 func parseInterfaceDecl(l *common.Lexer) *Interface {
 	i := &Interface{}
 	i.Name = l.ConsumeIdent()
-	i.Fields = parseFields(l)
+	i.Fields = parseFields("interface", i.Name, l)
 	return i
 }
 
@@ -425,7 +425,7 @@ func parseDirectiveDecl(l *common.Lexer) *DirectiveDecl {
 	return d
 }
 
-func parseFields(l *common.Lexer) FieldList {
+func parseFields(declType, typeName string, l *common.Lexer) FieldList {
 	var fields FieldList
 	l.ConsumeToken('{')
 	for l.Peek() != '}' {
@@ -437,6 +437,9 @@ func parseFields(l *common.Lexer) FieldList {
 		f.Type = common.ParseType(l)
 		f.Directives = common.ParseDirectives(l)
 		fields = append(fields, f)
+	}
+	if len(fields) == 0 {
+		l.SyntaxError(fmt.Sprintf(`%s type %q must define one or more fields`, declType, typeName))
 	}
 	l.ConsumeToken('}')
 	return fields

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -393,11 +393,7 @@ func parseUnionDecl(l *common.Lexer) *Union {
 func parseInputDecl(l *common.Lexer) *InputObject {
 	i := &InputObject{}
 	i.Name = l.ConsumeIdent()
-	l.ConsumeToken('{')
-	for l.Peek() != '}' {
-		i.Values = append(i.Values, common.ParseInputValue(l))
-	}
-	l.ConsumeToken('}')
+	i.Values = common.ParseInputFieldList(i.Name, l)
 	return i
 }
 
@@ -420,14 +416,7 @@ func parseDirectiveDecl(l *common.Lexer) *DirectiveDecl {
 	d := &DirectiveDecl{}
 	l.ConsumeToken('@')
 	d.Name = l.ConsumeIdent()
-	if l.Peek() == '(' {
-		l.ConsumeToken('(')
-		for l.Peek() != ')' {
-			v := common.ParseInputValue(l)
-			d.Args = append(d.Args, v)
-		}
-		l.ConsumeToken(')')
-	}
+	d.Args = common.ParseArgumentDeclList(l)
 	l.ConsumeKeyword("on")
 	for {
 		loc := l.ConsumeIdent()
@@ -446,13 +435,7 @@ func parseFields(l *common.Lexer) FieldList {
 		f := &Field{}
 		f.Desc = l.DescComment()
 		f.Name = l.ConsumeIdent()
-		if l.Peek() == '(' {
-			l.ConsumeToken('(')
-			for l.Peek() != ')' {
-				f.Args = append(f.Args, common.ParseInputValue(l))
-			}
-			l.ConsumeToken(')')
-		}
+		f.Args = common.ParseArgumentDeclList(l)
 		l.ConsumeToken(':')
 		f.Type = common.ParseType(l)
 		f.Directives = common.ParseDirectives(l)

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -363,18 +363,14 @@ func parseObjectDecl(l *common.Lexer) *Object {
 			}
 		}
 	}
-	l.ConsumeToken('{')
 	o.Fields = parseFields(l)
-	l.ConsumeToken('}')
 	return o
 }
 
 func parseInterfaceDecl(l *common.Lexer) *Interface {
 	i := &Interface{}
 	i.Name = l.ConsumeIdent()
-	l.ConsumeToken('{')
 	i.Fields = parseFields(l)
-	l.ConsumeToken('}')
 	return i
 }
 
@@ -431,6 +427,7 @@ func parseDirectiveDecl(l *common.Lexer) *DirectiveDecl {
 
 func parseFields(l *common.Lexer) FieldList {
 	var fields FieldList
+	l.ConsumeToken('{')
 	for l.Peek() != '}' {
 		f := &Field{}
 		f.Desc = l.DescComment()
@@ -441,5 +438,6 @@ func parseFields(l *common.Lexer) FieldList {
 		f.Directives = common.ParseDirectives(l)
 		fields = append(fields, f)
 	}
+	l.ConsumeToken('}')
 	return fields
 }


### PR DESCRIPTION
Per the spec, [Object][1], [Interface][2], and [Input Object][3] types must define at least one field. This commit makes graphql-go fail to parse any of these types if no fields are defined.

[1]: http://facebook.github.io/graphql/October2016/#sec-Object-type-validation
[2]: http://facebook.github.io/graphql/October2016/#sec-Interface-type-validation
[3]: http://facebook.github.io/graphql/October2016/#sec-Input-Object-type-validation

---

The first three commits are some refactors that I thought may help with clarity. Only the last makes any observable behavior change.

Let me know what you think!