### PR TITLE
Validate Max Depth

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -24,10 +24,11 @@ import (
 // resolver, then the schema can not be executed, but it may be inspected (e.g. with ToJSON).
 func ParseSchema(schemaString string, resolver interface{}, opts ...SchemaOpt) (*Schema, error) {
 	s := &Schema{
-		schema:         schema.New(),
-		maxParallelism: 10,
-		tracer:         trace.OpenTracingTracer{},
-		logger:         &log.DefaultLogger{},
+		schema:           schema.New(),
+		maxParallelism:   10,
+		tracer:           trace.OpenTracingTracer{},
+		validationTracer: trace.NoopValidationTracer{},
+		logger:           &log.DefaultLogger{},
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -62,13 +63,22 @@ type Schema struct {
 	schema *schema.Schema
 	res    *resolvable.Schema
 
-	maxParallelism int
-	tracer         trace.Tracer
-	logger         log.Logger
+	maxDepth         int
+	maxParallelism   int
+	tracer           trace.Tracer
+	validationTracer trace.ValidationTracer
+	logger           log.Logger
 }
 
 // SchemaOpt is an option to pass to ParseSchema or MustParseSchema.
 type SchemaOpt func(*Schema)
+
+// MaxDepth specifies the maximum field nesting depth in a query. The default is 0 which disables max depth checking.
+func MaxDepth(n int) SchemaOpt {
+	return func(s *Schema) {
+		s.maxDepth = n
+	}
+}
 
 // MaxParallelism specifies the maximum number of resolvers per request allowed to run in parallel. The default is 10.
 func MaxParallelism(n int) SchemaOpt {
@@ -81,6 +91,13 @@ func MaxParallelism(n int) SchemaOpt {
 func Tracer(tracer trace.Tracer) SchemaOpt {
 	return func(s *Schema) {
 		s.tracer = tracer
+	}
+}
+
+// ValidationTracer is used to trace validation errors. It defaults to trace.NoopValidationTracer.
+func ValidationTracer(tracer trace.ValidationTracer) SchemaOpt {
+	return func(s *Schema) {
+		s.validationTracer = tracer
 	}
 }
 
@@ -106,7 +123,7 @@ func (s *Schema) Validate(queryString string) []*errors.QueryError {
 		return []*errors.QueryError{qErr}
 	}
 
-	return validation.Validate(s.schema, doc)
+	return validation.Validate(s.schema, doc, s.maxDepth)
 }
 
 // Exec executes the given query with the schema's resolver. It panics if the schema was created
@@ -125,7 +142,9 @@ func (s *Schema) exec(ctx context.Context, queryString string, operationName str
 		return &Response{Errors: []*errors.QueryError{qErr}}
 	}
 
-	errs := validation.Validate(s.schema, doc)
+	validationFinish := s.validationTracer.TraceValidation()
+	errs := validation.Validate(s.schema, doc, s.maxDepth)
+	validationFinish(errs)
 	if len(errs) != 0 {
 		return &Response{Errors: errs}
 	}

--- a/internal/validation/validate_max_depth_test.go
+++ b/internal/validation/validate_max_depth_test.go
@@ -1,0 +1,395 @@
+package validation
+
+import (
+	"testing"
+
+	"github.com/graph-gophers/graphql-go/internal/query"
+	"github.com/graph-gophers/graphql-go/internal/schema"
+)
+
+const (
+	simpleSchema = `schema {
+		query: Query
+	}
+
+	type Query {
+		characters: [Character]!
+	}
+
+	type Character {
+		id: ID!
+		name: String!
+		friends: [Character]!
+	}`
+	interfaceSimple = `schema {
+		query: Query
+	}
+
+	type Query {
+		characters: [Character]
+	}
+
+	interface Character {
+		id: ID!
+		name: String!
+		friends: [Character]
+		appearsIn: [Episode]!
+	}
+
+	enum Episode {
+		NEWHOPE
+		EMPIRE
+		JEDI
+	}
+
+	type Starship {}
+
+	type Human implements Character {
+		id: ID!
+		name: String!
+		friends: [Character]
+		appearsIn: [Episode]!
+		starships: [Starship]
+		totalCredits: Int
+	}
+
+	type Droid implements Character {
+		id: ID!
+		name: String!
+		friends: [Character]
+		appearsIn: [Episode]!
+		primaryFunction: String
+	}`
+)
+
+type maxDepthTestCase struct {
+	name    string
+	query   string
+	depth   int
+	failure bool
+}
+
+func (tc maxDepthTestCase) Run(t *testing.T, s *schema.Schema) {
+	t.Run(tc.name, func(t *testing.T) {
+		doc, qErr := query.Parse(tc.query)
+		if qErr != nil {
+			t.Fatal(qErr)
+		}
+
+		errs := Validate(s, doc, tc.depth)
+		if (len(errs) > 0) != tc.failure {
+			t.Errorf("expected failure: %t, actual errors (%d): %v", tc.failure, len(errs), errs)
+		}
+	})
+}
+
+func TestMaxDepth(t *testing.T) {
+	s := schema.New()
+
+	err := s.Parse(simpleSchema)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []maxDepthTestCase{
+		{
+			name: "off",
+			query: `query Okay {        # depth 0
+			characters {         # depth 1
+			  id                 # depth 2
+			  name               # depth 2
+			  friends {          # depth 2
+					friends {    # depth 3
+					  friends {  # depth 4
+						  id       # depth 5
+						  name     # depth 5
+					  }
+				  }
+			  }
+			}
+		}`,
+			depth: 0,
+		}, {
+			name: "maxDepth-1",
+			query: `query Fine {        # depth 0
+				characters {         # depth 1
+				  id                 # depth 2
+				  name               # depth 2
+				  friends {          # depth 2
+					  id               # depth 3
+					  name             # depth 3
+				  }
+				}
+			}`,
+			depth: 4,
+		}, {
+			name: "maxDepth",
+			query: `query Deep {        # depth 0
+				characters {         # depth 1
+				  id                 # depth 2
+				  name               # depth 2
+				  friends {          # depth 2
+					  id               # depth 3
+					  name             # depth 3
+				  }
+				}
+			}`,
+			depth: 3,
+		}, {
+			name: "maxDepth+1",
+			query: `query TooDeep {        # depth 0
+				characters {         # depth 1
+				  id                 # depth 2
+				  name               # depth 2
+				  friends {          # depth 2
+						friends {    # depth 3
+						  friends {  # depth 4
+							id       # depth 5
+							name     # depth 5
+						  }
+						}
+					}
+				}
+			}`,
+			depth:   4,
+			failure: true,
+		},
+	} {
+		tc.Run(t, s)
+	}
+}
+
+func TestMaxDepthInlineFragments(t *testing.T) {
+	s := schema.New()
+
+	err := s.Parse(interfaceSimple)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []maxDepthTestCase{
+		{
+			name: "maxDepth-1",
+			query: `query { # depth 0
+				characters { # depth 1
+				  name # depth 2
+				  ... on Human { # depth 2
+					totalCredits # depth 2
+				  }
+				}
+			  }`,
+			depth: 3,
+		},
+		{
+			name: "maxDepth",
+			query: `query { # depth 0
+				characters { # depth 1
+				  ... on Droid { # depth 2
+					primaryFunction # depth 2
+				  }
+				}
+			  }`,
+			depth: 2,
+		},
+		{
+			name: "maxDepth+1",
+			query: `query { # depth 0
+				characters { # depth 1
+				  ... on Droid { # depth 2
+					primaryFunction # depth 2
+				  }
+				}
+			  }`,
+			depth:   1,
+			failure: true,
+		},
+	} {
+		tc.Run(t, s)
+	}
+}
+
+func TestMaxDepthFragmentSpreads(t *testing.T) {
+	s := schema.New()
+
+	err := s.Parse(interfaceSimple)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []maxDepthTestCase{
+		{
+			name: "maxDepth-1",
+			query: `fragment friend on Character {
+				id  # depth 5
+				name
+				friends {
+					name  # depth 6
+				}
+			}
+
+			query {        # depth 0
+				characters {         # depth 1
+				  id                 # depth 2
+				  name               # depth 2
+				  friends {          # depth 2
+					friends {        # depth 3
+						friends {    # depth 4
+							...friend # depth 5
+						}
+					}
+				  }
+				}
+			}`,
+			depth: 7,
+		},
+		{
+			name: "maxDepth",
+			query: `fragment friend on Character {
+				id # depth 5
+				name
+			}
+			query {        # depth 0
+				characters {         # depth 1
+				  id                 # depth 2
+				  name               # depth 2
+				  friends {          # depth 2
+					friends {        # depth 3
+						friends {    # depth 4
+							...friend # depth 5
+						}
+					}
+				  }
+				}
+			}`,
+			depth: 5,
+		},
+		{
+			name: "maxDepth+1",
+			query: `fragment friend on Character {
+				id # depth 6
+				name
+				friends {
+					name # depth 7
+				}
+			}
+			query {        # depth 0
+				characters {         # depth 1
+				  id                 # depth 2
+				  name               # depth 2
+				  friends {          # depth 2
+					friends {        # depth 3
+						friends {    # depth 4
+						  friends {  # depth 5
+							...friend # depth 6
+						  }
+						}
+					}
+				  }
+				}
+			}`,
+			depth:   6,
+			failure: true,
+		},
+	} {
+		tc.Run(t, s)
+	}
+}
+
+func TestMaxDepthValidation(t *testing.T) {
+	s := schema.New()
+
+	err := s.Parse(interfaceSimple)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name     string
+		query    string
+		maxDepth int
+		expected bool
+	}{
+		{
+			name: "off",
+			query: `query Fine {        # depth 0
+				characters {         # depth 1
+				  id                 # depth 2
+				  name               # depth 2
+				  friends {          # depth 2
+					  id               # depth 3
+					  name             # depth 3
+				  }
+				}
+			}`,
+			maxDepth: 0,
+		}, {
+			name: "fields",
+			query: `query Fine {        # depth 0
+				characters {         # depth 1
+				  id                 # depth 2
+				  name               # depth 2
+				  friends {          # depth 2
+					  id               # depth 3
+					  name             # depth 3
+				  }
+				}
+			}`,
+			maxDepth: 2,
+			expected: true,
+		}, {
+			name: "fragment",
+			query: `fragment friend on Character {
+				id # depth 6
+				name
+				friends {
+					name # depth 7
+				}
+			}
+			query {        # depth 0
+				characters {         # depth 1
+				  id                 # depth 2
+				  name               # depth 2
+				  friends {          # depth 2
+					friends {        # depth 3
+						friends {    # depth 4
+						  friends {  # depth 5
+							...friend # depth 6
+						  }
+						}
+					}
+				  }
+				}
+			}`,
+			maxDepth: 5,
+			expected: true,
+		}, {
+			name: "inlinefragment",
+			query: `query { # depth 0
+				characters { # depth 1
+				  ... on Droid { # depth 2
+					primaryFunction # depth 2
+				  }
+				}
+			  }`,
+			maxDepth: 1,
+			expected: true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			doc, err := query.Parse(tc.query)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			context := newContext(s, doc, tc.maxDepth)
+			op := doc.Operations[0]
+
+			opc := &opContext{context: context, ops: doc.Operations}
+
+			actual := validateMaxDepth(opc, op.Selections, 1)
+			if actual != tc.expected {
+				t.Errorf("expected %t, actual %t", tc.expected, actual)
+			}
+		})
+	}
+}

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -31,6 +31,7 @@ type context struct {
 	usedVars         map[*query.Operation]varSet
 	fieldMap         map[*query.Field]fieldInfo
 	overlapValidated map[selectionPair]struct{}
+	maxDepth         int
 }
 
 func (c *context) addErr(loc errors.Location, rule string, format string, a ...interface{}) {
@@ -50,21 +51,32 @@ type opContext struct {
 	ops []*query.Operation
 }
 
-func Validate(s *schema.Schema, doc *query.Document) []*errors.QueryError {
-	c := &context{
+func newContext(s *schema.Schema, doc *query.Document, maxDepth int) *context {
+	return &context{
 		schema:           s,
 		doc:              doc,
 		opErrs:           make(map[*query.Operation][]*errors.QueryError),
 		usedVars:         make(map[*query.Operation]varSet),
 		fieldMap:         make(map[*query.Field]fieldInfo),
 		overlapValidated: make(map[selectionPair]struct{}),
+		maxDepth:         maxDepth,
 	}
+}
+
+func Validate(s *schema.Schema, doc *query.Document, maxDepth int) []*errors.QueryError {
+	c := newContext(s, doc, maxDepth)
 
 	opNames := make(nameSet)
 	fragUsedBy := make(map[*query.FragmentDecl][]*query.Operation)
 	for _, op := range doc.Operations {
 		c.usedVars[op] = make(varSet)
 		opc := &opContext{c, []*query.Operation{op}}
+
+		// Check if max depth is exceeded, if it's set. If max depth is exceeded,
+		// don't continue to validate the document and exit early.
+		if validateMaxDepth(opc, op.Selections, 1) {
+			return c.errs
+		}
 
 		if op.Name.Name == "" && len(doc.Operations) != 1 {
 			c.addErr(op.Loc, "LoneAnonymousOperation", "This anonymous operation must be the only defined operation.")
@@ -164,6 +176,40 @@ func Validate(s *schema.Schema, doc *query.Document) []*errors.QueryError {
 	}
 
 	return c.errs
+}
+
+// validates the query doesn't go deeper than maxDepth (if set). Returns whether
+// or not query validated max depth to avoid excessive recursion.
+func validateMaxDepth(c *opContext, sels []query.Selection, depth int) bool {
+	// maxDepth checking is turned off when maxDepth is 0
+	if c.maxDepth == 0 {
+		return false
+	}
+
+	exceededMaxDepth := false
+
+	for _, sel := range sels {
+		switch sel := sel.(type) {
+		case *query.Field:
+			if depth > c.maxDepth {
+				exceededMaxDepth = true
+				c.addErr(sel.Alias.Loc, "MaxDepthExceeded", "Field %q has depth %d that exceeds max depth %d", sel.Name.Name, depth, c.maxDepth)
+				continue
+			}
+			exceededMaxDepth = exceededMaxDepth || validateMaxDepth(c, sel.Selections, depth+1)
+		case *query.InlineFragment:
+			// Depth is not checked because inline fragments resolve to other fields which are checked.
+			// Depth is not incremented because inline fragments have the same depth as neighboring fields
+			exceededMaxDepth = exceededMaxDepth || validateMaxDepth(c, sel.Selections, depth)
+		case *query.FragmentSpread:
+			// Depth is not checked because fragments resolve to other fields which are checked.
+			frag := c.doc.Fragments.Get(sel.Name.Name)
+			// Depth is not incremented because fragments have the same depth as surrounding fields
+			exceededMaxDepth = exceededMaxDepth || validateMaxDepth(c, frag.Selections, depth)
+		}
+	}
+
+	return exceededMaxDepth
 }
 
 func validateSelectionSet(c *opContext, sels []query.Selection, t schema.NamedType) {

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -50,7 +50,7 @@ func TestValidate(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			errs := validation.Validate(schemas[test.Schema], d)
+			errs := validation.Validate(schemas[test.Schema], d, 0)
 			got := []*errors.QueryError{}
 			for _, err := range errs {
 				if err.Rule == test.Rule {

--- a/trace/validation_trace.go
+++ b/trace/validation_trace.go
@@ -1,0 +1,17 @@
+package trace
+
+import (
+	"github.com/graph-gophers/graphql-go/errors"
+)
+
+type TraceValidationFinishFunc = TraceQueryFinishFunc
+
+type ValidationTracer interface {
+	TraceValidation() TraceValidationFinishFunc
+}
+
+type NoopValidationTracer struct{}
+
+func (NoopValidationTracer) TraceValidation() TraceValidationFinishFunc {
+	return func(errs []*errors.QueryError) {}
+}


### PR DESCRIPTION
This change validates that queries don't exceed a configurable max depth. This is opt-in by setting a max depth using `graphql.MaxDepth`. A `ValidatorTracer` is added, similar to `Tracer`, to track validation errors.