### PR TITLE
print the actual errors in checkErrors when it's appropriate

### DIFF
--- a/gqltesting/testing.go
+++ b/gqltesting/testing.go
@@ -75,12 +75,7 @@ func formatJSON(data []byte) ([]byte, error) {
 }
 
 func checkErrors(t *testing.T, expected, actual []*errors.QueryError) {
-	expectedCount, actualCount := len(expected), len(actual)
-
-	if expectedCount != actualCount {
-		t.Fatalf("unexpected number of errors: got %d, want %d", actualCount, expectedCount)
-	}
-
+	expectedCount := len(expected)
 	if expectedCount > 0 {
 		for i, want := range expected {
 			got := actual[i]


### PR DESCRIPTION
Current implementation doesn't print any errors when there's no expected errors, it just print two numbers which makes it difficult to debug.

![image](https://user-images.githubusercontent.com/4319104/39590162-b3ae0fc8-4f32-11e8-9871-93b7d4fd15eb.png)

Using this PR, errors will be printed, which looks like this:

![image](https://user-images.githubusercontent.com/4319104/39590429-719f6dc4-4f33-11e8-9249-665e426d6498.png)
