### PR TITLE
testing: Verify JSON first to avoid red herring errors

### DIFF
--- a/gqltesting/testing.go
+++ b/gqltesting/testing.go
@@ -43,11 +43,17 @@ func RunTest(t *testing.T, test *Test) {
 		test.Context = context.Background()
 	}
 	result := test.Schema.Exec(test.Context, test.Query, test.OperationName, test.Variables)
+	// Verify JSON to avoid red herring errors.
+	got, err := formatJSON(result.Data)
+	if err != nil {
+		t.Fatalf("got: invalid JSON: %s", err)
+	}
+	want, err := formatJSON([]byte(test.ExpectedResult))
+	if err != nil {
+		t.Fatalf("want: invalid JSON: %s", err)
+	}
+
 	checkErrors(t, test.ExpectedErrors, result.Errors)
-
-	got := formatJSON(t, result.Data)
-
-	want := formatJSON(t, []byte(test.ExpectedResult))
 
 	if !bytes.Equal(got, want) {
 		t.Logf("got:  %s", got)
@@ -56,16 +62,16 @@ func RunTest(t *testing.T, test *Test) {
 	}
 }
 
-func formatJSON(t *testing.T, data []byte) []byte {
+func formatJSON(data []byte) ([]byte, error) {
 	var v interface{}
 	if err := json.Unmarshal(data, &v); err != nil {
-		t.Fatalf("invalid JSON: %s", err)
+		return nil, err
 	}
 	formatted, err := json.Marshal(v)
 	if err != nil {
-		t.Fatal(err)
+		return nil, err
 	}
-	return formatted
+	return formatted, nil
 }
 
 func checkErrors(t *testing.T, expected, actual []*errors.QueryError) {


### PR DESCRIPTION
A confusing error saying got/want are equal is shown before the
actual error if the result data or expected result has invalid
JSON. This change checks both before any expectations requiring
them to ease test debugging.

Before:
```
got: graphql: Unauthorized
&{%!t(string=Unauthorized) [] [%!t(string=createRedacted)] %!t(string=) %!t(*graphql_api.AuthError=&{})}
want: graphql: Unauthorized
&{%!t(string=Unauthorized) [] [%!t(string=createRedacted)] %!t(string=) %!t(*graphql_api.AuthError=&{})}
--- FAIL: TestCreateRedacted (0.00s)
	/redacted/go/src/github.com/redacted/redacted/graphql_api/testing.go:63: invalid JSON: invalid character 'U' looking for beginning of value
FAIL
FAIL	github.com/redacted/redacted/graphql_api	0.009s
Error: Tests failed.
```

After:
```
--- FAIL: TestCreateRedacted (0.00s)
	/redacted/go/src/github.com/redacted/redacted/graphql_api/testing.go:54: want: invalid JSON: invalid character 'U' looking for beginning of value
FAIL
FAIL	github.com/redacted/redacted/graphql_api	0.004s
Error: Tests failed.
```