### PR TITLE
fix error message

### DIFF
--- a/gqltesting/testing.go
+++ b/gqltesting/testing.go
@@ -72,7 +72,7 @@ func checkErrors(t *testing.T, expected, actual []*errors.QueryError) {
 	expectedCount, actualCount := len(expected), len(actual)
 
 	if expectedCount != actualCount {
-		t.Fatalf("unexpected number of errors: got %d, want %d", expectedCount, actualCount)
+		t.Fatalf("unexpected number of errors: got %d, want %d", actualCount, expectedCount)
 	}
 
 	if expectedCount > 0 {


### PR DESCRIPTION
When errors counts don't match, error prints inverted 'got' and 'want' values