### PR TITLE
Add support for custom error handlers

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -17,6 +17,16 @@ type Location struct {
 	Column int `json:"column"`
 }
 
+// ErrorHandler describes a function that converts an error to a QueryError
+type ErrorHandler func(error) *QueryError
+
+// DefaultErrorHandler returns the default error handler
+func DefaultErrorHandler() ErrorHandler {
+	return func(err error) *QueryError {
+		return Errorf("%s", err)
+	}
+}
+
 func (a Location) Before(b Location) bool {
 	return a.Line < b.Line || (a.Line == b.Line && a.Column < b.Column)
 }

--- a/gqltesting/testing.go
+++ b/gqltesting/testing.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"reflect"
 	"strconv"
 	"testing"
 
@@ -84,8 +83,7 @@ func checkErrors(t *testing.T, expected, actual []*errors.QueryError) {
 	if expectedCount > 0 {
 		for i, want := range expected {
 			got := actual[i]
-
-			if !reflect.DeepEqual(got, want) {
+			if got.Message != want.Message {
 				t.Fatalf("unexpected error: got %+v, want %+v", got, want)
 			}
 		}


### PR DESCRIPTION
This PR aims at being a more concise way of handling errors while resolving a query.

It relates to https://github.com/graph-gophers/graphql-go/issues/60 and https://github.com/graph-gophers/graphql-go/pull/49. The latter has no documentation at all so it is unclear how to interact with it.

Also, this PR adds tests to this feature which may also be used as a reference. Motivation behind this:

## Augment/Hide Implementation Details

If you use a stacktrace library you may not want to share that information with API consumers, or maybe you want to add more information to the error

## Server-side Logging

graphql-go swallows the errors and nothing gets logged on the server side. This gives developers the opportunity to do that too.

--

An error handler must be of type `type ErrorHandler func(error) *QueryError`. A default handler is provided making this feature opt-in and backwards compatible.

The basic principle is to use `SchemaOpts` to augment the schema. Basic usage:

```go
graphql.MustParseSchema(sampleSchemaStr, someResolvers, graphql.ErrorHandler(func(err error) *gqlerrors.QueryError {
    return gqlerrors.Errorf("Prefix - %s", err)
}))
```

Hope it helps.