### PR TITLE
help wanted: stop returning null data if error is returned

### DIFF
--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -198,8 +198,6 @@ func execFieldSelection(ctx context.Context, r *Request, f *fieldToExec, path *p
 
 	if err != nil {
 		r.AddError(err)
-		f.out.WriteString("null") // TODO handle non-nil
-		return
 	}
 
 	r.execSelectionSet(traceCtx, f.sels, f.field.Type, path, result, f.out)


### PR DESCRIPTION
The spec clearly allows for the case where both data and errors are returned:
http://facebook.github.io/graphql/October2016/#sec-Response-Format

See this comment for an example from the sample graphql-js implementation:
https://github.com/graphql-go/graphql/issues/103#issuecomment-172276590

The code here:
https://github.com/graph-gophers/graphql-go/blob/1a11622ce658bdf2f7a63c80112d76e4794706ee/internal/exec/exec.go#L199-L203

automatically writes "null" for data if an error is returned.

To replicate, simply take any working schema and return an error in your root resolver, along with the data. If the error is returned, data will be null.


This worked for my use case, but I haven't tested it extensively (or written tests). I am concerned that a bunch of error cases that I'm not encountering will make it impossible to return proper data, and curious how that is handled.
Any advice on how/what to test or change, @tonyghita ?
I haven't looked too extensively at the code, but maybe there is sufficient error handling in `execSelectionSet` to prevent it from blowing up?