### PR TITLE
provide build-in graphqli

### DIFF
--- a/relay/relay.go
+++ b/relay/relay.go
@@ -45,9 +45,13 @@ func UnmarshalSpec(id graphql.ID, v interface{}) error {
 
 type Handler struct {
 	Schema *graphql.Schema
+	Graphqli bool
 }
 
 func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if h.wasGraphqliHandled(w, r) {
+		return
+	}
 	var params struct {
 		Query         string                 `json:"query"`
 		OperationName string                 `json:"operationName"`
@@ -68,3 +72,51 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(responseJSON)
 }
+
+func (h *Handler) wasGraphqliHandled(w http.ResponseWriter, r *http.Request) bool {
+	acceptHeader := r.Header.Get("Accept")
+	if !h.Graphqli || !strings.Contains(acceptHeader, "text/html") {
+		return false
+	}
+
+	w.Write(GraphqliPage)
+	return true
+}
+
+var GraphqliPage = []byte(`
+<!DOCTYPE html>
+<html>
+	<head>
+		<link href="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.11/graphiql.min.css" rel="stylesheet" />
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/es6-promise/4.1.1/es6-promise.auto.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/react/16.2.0/umd/react.production.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.2.0/umd/react-dom.production.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.11/graphiql.min.js"></script>
+	</head>
+	<body style="width: 100%; height: 100%; margin: 0; overflow: hidden;">
+		<div id="graphiql" style="height: 100vh;">Loading...</div>
+		<script>	
+			function graphQLFetcher(graphQLParams) {
+				return fetch(window.location.pathname, {
+					method: "post",
+					body: JSON.stringify(graphQLParams),
+					credentials: "include",
+				}).then(function (response) {
+					return response.text();
+				}).then(function (responseBody) {
+					try {
+						return JSON.parse(responseBody);
+					} catch (error) {
+						return responseBody;
+					}
+				});
+			}
+			ReactDOM.render(
+				React.createElement(GraphiQL, {fetcher: graphQLFetcher}),
+				document.getElementById("graphiql")
+			);
+		</script>
+	</body>
+</html>
+`)

--- a/relay/relay_test.go
+++ b/relay/relay_test.go
@@ -34,3 +34,28 @@ func TestServeHTTP(t *testing.T) {
 		t.Fatalf("Invalid response. Expected [%s], but instead got [%s]", expectedResponse, actualResponse)
 	}
 }
+
+func TestServeHTTPWithGraphqli(t *testing.T) {
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/graphql", nil)
+	r.Header.Add("Accept", "text/html")
+	h := relay.Handler{Schema: starwarsSchema, Graphqli: true}
+
+	h.ServeHTTP(w, r)
+
+	if w.Code != 200 {
+		t.Fatalf("Expected status code 200, got %d.", w.Code)
+	}
+
+	actualContentType := w.Header().Get("Content-Type")
+	expectedContentType := "text/html; charset=utf-8"
+	if actualContentType != expectedContentType {
+		t.Fatalf("Invalid content-type. Expected [%s], but instead got [%s]", expectedContentType, actualContentType)
+	}
+
+	actualResponse := w.Body.String()
+	expectedResponse := string(relay.GraphqliPage)
+	if string(relay.GraphqliPage) != actualResponse {
+		t.Fatalf("Invalid response. Expected [%s], but instead got [%s]", expectedResponse, actualResponse)
+	}
+}


### PR DESCRIPTION
Goal: Provide build-in Graphqli

Example:
```golang
func main() {
	s, err := loadSchema("./schema.graphql")
	if err != nil {
		log.Fatal(err)
	}

	schema := graphql.MustParseSchema(s, &Resolver{})

	r := mux.NewRouter()
	r.Handle("/graphql", &relay.Handler{Schema: schema, Graphqli: true})
	log.Fatal(http.ListenAndServe(":8080", r))
}
```