### PR TITLE
Changing error comparision in testing

### DIFF
--- a/gqltesting/testing.go
+++ b/gqltesting/testing.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"reflect"
 	"strconv"
+	"strings"
 	"testing"
 
 	graphql "github.com/graph-gophers/graphql-go"
@@ -85,7 +85,7 @@ func checkErrors(t *testing.T, expected, actual []*errors.QueryError) {
 		for i, want := range expected {
 			got := actual[i]
 
-			if !reflect.DeepEqual(got, want) {
+			if !strings.EqualFold(got.Message, want.Message) {
 				t.Fatalf("unexpected error: got %+v, want %+v", got, want)
 			}
 		}


### PR DESCRIPTION
When running tests, the errors are not equal.
When using []*errors.QueryError{errors.Errorf("%s",msg)}, all things being equal
the errors are returned as unequal. Comparing just the messages will be adequate
for application development environments.

The errors that are returned by the internal package cannot be duplicated (easily) when testing. This will allow the messages to be compared as it is the only required component that will be returned in the QueryError struct.