### PR TITLE
Properly handle nil interface resolvers

### DIFF
--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -210,7 +210,7 @@ func (r *Request) execSelectionSet(ctx context.Context, sels []selected.Selectio
 	switch t := t.(type) {
 	case *schema.Object, *schema.Interface, *schema.Union:
 		// a reflect.Value of a nil interface will show up as an Invalid value
-		if resolver.Kind() == reflect.Invalid || (resolver.Kind() == reflect.Ptr && resolver.IsNil()) {
+		if resolver.Kind() == reflect.Invalid || ((resolver.Kind() == reflect.Ptr || resolver.Kind() == reflect.Interface) && resolver.IsNil()) {
 			if nonNull {
 				panic(errors.Errorf("got nil for non-null %q", t))
 			}

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -209,7 +209,8 @@ func (r *Request) execSelectionSet(ctx context.Context, sels []selected.Selectio
 	t, nonNull := unwrapNonNull(typ)
 	switch t := t.(type) {
 	case *schema.Object, *schema.Interface, *schema.Union:
-		if resolver.Kind() == reflect.Ptr && resolver.IsNil() {
+		// a reflect.Value of a nil interface will show up as an Invalid value
+		if resolver.Kind() == reflect.Invalid || (resolver.Kind() == reflect.Ptr && resolver.IsNil()) {
 			if nonNull {
 				panic(errors.Errorf("got nil for non-null %q", t))
 			}


### PR DESCRIPTION
fixes #233 

Calling `reflect.ValueOf(nil)` returns the zero `Value`, which has type `Invalid`.
Calling `reflect.ValueOf` an interface typed nil returns a `Value` with type `Interface`.

Both of these cases skipped the null checks and fail later on when trying to resolve fields.