### PR TITLE
Fill in variables with specified defaults

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -154,6 +154,13 @@ func (s *Schema) exec(ctx context.Context, queryString string, operationName str
 		return &Response{Errors: []*errors.QueryError{errors.Errorf("%s", err)}}
 	}
 
+	// Fill in variables with the defaults from the operation
+	for _, v := range op.Vars {
+		if _, ok := variables[v.Name.Name]; !ok && v.Default != nil {
+			variables[v.Name.Name] = v.Default.Value(nil)
+		}
+	}
+
 	r := &exec.Request{
 		Request: selected.Request{
 			Doc:    doc,

--- a/graphql.go
+++ b/graphql.go
@@ -155,6 +155,9 @@ func (s *Schema) exec(ctx context.Context, queryString string, operationName str
 	}
 
 	// Fill in variables with the defaults from the operation
+	if variables == nil {
+		variables = make(map[string]interface{}, len(op.Vars))
+	}
 	for _, v := range op.Vars {
 		if _, ok := variables[v.Name.Name]; !ok && v.Default != nil {
 			variables[v.Name.Name] = v.Default.Value(nil)

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -61,6 +61,12 @@ func (r *timeResolver) AddHour(args struct{ Time graphql.Time }) graphql.Time {
 	return graphql.Time{Time: args.Time.Add(time.Hour)}
 }
 
+type echoResolver struct{}
+
+func (r *echoResolver) Echo(args struct{ Value *string }) *string {
+	return args.Value
+}
+
 var starwarsSchema = graphql.MustParseSchema(starwars.Schema, &starwars.Resolver{})
 
 func TestHelloWorld(t *testing.T) {
@@ -435,6 +441,28 @@ func TestVariables(t *testing.T) {
 					"hero": {
 						"name": "Luke Skywalker"
 					}
+				}
+			`,
+		},
+
+		{
+			Schema: graphql.MustParseSchema(`
+				schema {
+					query: Query
+				}
+
+				type Query {
+					echo(value: String): String
+				}
+			`, &echoResolver{}),
+			Query: `
+				query Echo($value:String = "default"){
+					echo(value:$value)
+				}
+			`,
+			ExpectedResult: `
+				{
+					"echo": "default"
 				}
 			`,
 		},


### PR DESCRIPTION
Fixes #97 

Default values specified in the query are currently ignored. This change fills in the variables map with the default values for variables that aren't already specified.