### PR TITLE
Properly handle nil interface resolvers

### DIFF
--- a/graphql_test.go
+++ b/graphql_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
-	graphqlerrors "github.com/graph-gophers/graphql-go/errors"
+	gqlerrors "github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/example/starwars"
 	"github.com/graph-gophers/graphql-go/gqltesting"
 )
@@ -293,8 +293,8 @@ func TestNilInterface(t *testing.T) {
 					"c": null
 				}
 			`,
-			ExpectedErrors: []*graphqlerrors.QueryError{
-				&graphqlerrors.QueryError{
+			ExpectedErrors: []*gqlerrors.QueryError{
+				&gqlerrors.QueryError{
 					Message:       "x",
 					Path:          []interface{}{"b"},
 					ResolverError: errors.New("x"),

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -2,10 +2,12 @@ package graphql_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/graph-gophers/graphql-go"
+	graphqlerrors "github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/example/starwars"
 	"github.com/graph-gophers/graphql-go/gqltesting"
 )
@@ -241,6 +243,63 @@ func TestBasic(t *testing.T) {
 					}
 				}
 			`,
+		},
+	})
+}
+
+type testNilInterfaceResolver struct{}
+
+func (r *testNilInterfaceResolver) A() interface{ Z() int32 } {
+	return nil
+}
+
+func (r *testNilInterfaceResolver) B() (interface{ Z() int32 }, error) {
+	return nil, errors.New("x")
+}
+
+func (r *testNilInterfaceResolver) C() (interface{ Z() int32 }, error) {
+	return nil, nil
+}
+
+func TestNilInterface(t *testing.T) {
+	gqltesting.RunTests(t, []*gqltesting.Test{
+		{
+			Schema: graphql.MustParseSchema(`
+				schema {
+					query: Query
+				}
+
+				type Query {
+					a: T
+					b: T
+					c: T
+				}
+
+				type T {
+					z: Int!
+				}
+			`, &testNilInterfaceResolver{}),
+			Query: `
+				{
+					a { z }
+					b { z }
+					c { z }
+				}
+			`,
+			ExpectedResult: `
+				{
+					"a": null,
+					"b": null,
+					"c": null
+				}
+			`,
+			ExpectedErrors: []*graphqlerrors.QueryError{
+				&graphqlerrors.QueryError{
+					Message:       "x",
+					Path:          []interface{}{"b"},
+					ResolverError: errors.New("x"),
+				},
+			},
 		},
 	})
 }

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -210,7 +210,7 @@ func (r *Request) execSelectionSet(ctx context.Context, sels []selected.Selectio
 	switch t := t.(type) {
 	case *schema.Object, *schema.Interface, *schema.Union:
 		// a reflect.Value of a nil interface will show up as an Invalid value
-		if resolver.Kind() == reflect.Invalid || (resolver.Kind() == reflect.Ptr && resolver.IsNil()) {
+		if resolver.Kind() == reflect.Invalid || ((resolver.Kind() == reflect.Ptr || resolver.Kind() == reflect.Interface) && resolver.IsNil()) {
 			if nonNull {
 				panic(errors.Errorf("got nil for non-null %q", t))
 			}

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -209,7 +209,8 @@ func (r *Request) execSelectionSet(ctx context.Context, sels []selected.Selectio
 	t, nonNull := unwrapNonNull(typ)
 	switch t := t.(type) {
 	case *schema.Object, *schema.Interface, *schema.Union:
-		if resolver.Kind() == reflect.Ptr && resolver.IsNil() {
+		// a reflect.Value of a nil interface will show up as an Invalid value
+		if resolver.Kind() == reflect.Invalid || (resolver.Kind() == reflect.Ptr && resolver.IsNil()) {
 			if nonNull {
 				panic(errors.Errorf("got nil for non-null %q", t))
 			}


### PR DESCRIPTION
fixes #233 

Calling `reflect.ValueOf(nil)` returns the zero `Value`, which has type `Invalid`.
Calling `reflect.ValueOf` an interface typed nil returns a `Value` with type `Interface`.

Both of these cases skipped the null checks and fail later on when trying to resolve fields.