### PR TITLE
Allow @deprecated directive on field args

### DIFF
--- a/graphql_test.go
+++ b/graphql_test.go
@@ -683,6 +683,24 @@ func TestDeprecatedDirective(t *testing.T) {
 	})
 }
 
+type testDeprecatedArgsResolver struct{}
+
+func (r *testDeprecatedArgsResolver) A(ctx context.Context, args struct{ B *string }) int32 {
+	return 0
+}
+
+func TestDeprecatedArgs(t *testing.T) {
+	graphql.MustParseSchema(`
+		schema {
+			query: Query
+		}
+
+		type Query {
+			a(b: String @deprecated): Int!
+		}
+	`, &testDeprecatedArgsResolver{})
+}
+
 func TestInlineFragments(t *testing.T) {
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{

--- a/internal/common/values.go
+++ b/internal/common/values.go
@@ -6,12 +6,13 @@ import (
 
 // http://facebook.github.io/graphql/draft/#InputValueDefinition
 type InputValue struct {
-	Name    Ident
-	Type    Type
-	Default Literal
-	Desc    string
-	Loc     errors.Location
-	TypeLoc errors.Location
+	Name       Ident
+	Type       Type
+	Default    Literal
+	Desc       string
+	Loc        errors.Location
+	TypeLoc    errors.Location
+	Directives DirectiveList
 }
 
 type InputValueList []*InputValue
@@ -37,6 +38,7 @@ func ParseInputValue(l *Lexer) *InputValue {
 		l.ConsumeToken('=')
 		p.Default = ParseLiteral(l, true)
 	}
+	p.Directives = ParseDirectives(l)
 	return p
 }
 


### PR DESCRIPTION
Fixes https://github.com/graph-gophers/graphql-go/issues/204