### PR TITLE
Pass context to type assertion calls

### DIFF
--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -278,7 +278,7 @@ func (r *Request) execSelectionSet(ctx context.Context, sels []selected.Selectio
 		v := resolver.Interface()
 		data, err := json.Marshal(v)
 		if err != nil {
-			panic(errors.Errorf("could not marshal %v", v))
+			panic(errors.Errorf("could not marshal %v: %s", v, err))
 		}
 		out.Write(data)
 


### PR DESCRIPTION
To support cases where we need to access context (such as context logger) when resolving a sub type 