### PR TITLE
reverse order of errors vs data in response

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -110,6 +110,7 @@ func Logger(logger log.Logger) SchemaOpt {
 
 // Response represents a typical response of a GraphQL server. It may be encoded to JSON directly or
 // it may be further processed to a custom response type, for example to include custom error data.
+// Errors are intentionally serialized first based on the advice in https://github.com/facebook/graphql/commit/7b40390d48680b15cb93e02d46ac5eb249689876#diff-757cea6edf0288677a9eea4cfc801d87R107
 type Response struct {
 	Errors     []*errors.QueryError   `json:"errors,omitempty"`
 	Data       json.RawMessage        `json:"data,omitempty"`

--- a/graphql.go
+++ b/graphql.go
@@ -111,8 +111,8 @@ func Logger(logger log.Logger) SchemaOpt {
 // Response represents a typical response of a GraphQL server. It may be encoded to JSON directly or
 // it may be further processed to a custom response type, for example to include custom error data.
 type Response struct {
-	Data       json.RawMessage        `json:"data,omitempty"`
 	Errors     []*errors.QueryError   `json:"errors,omitempty"`
+	Data       json.RawMessage        `json:"data,omitempty"`
 	Extensions map[string]interface{} `json:"extensions,omitempty"`
 }
 


### PR DESCRIPTION
In this PR I moved the errors field before the data field in the response object based on the recommendation of the graphql standard merged in this pr: https://github.com/facebook/graphql/pull/384
>Note: When `errors` is present in the response, it may be helpful for it to 
> appear first when serialized to make it more clear when errors are present
> in a response during debugging.