### PR TITLE
improve gqltesting

### DIFF
--- a/gqltesting/testing.go
+++ b/gqltesting/testing.go
@@ -43,6 +43,9 @@ func RunTest(t *testing.T, test *Test) {
 		test.Context = context.Background()
 	}
 	result := test.Schema.Exec(test.Context, test.Query, test.OperationName, test.Variables)
+
+	checkErrors(t, test.ExpectedErrors, result.Errors)
+
 	// Verify JSON to avoid red herring errors.
 	got, err := formatJSON(result.Data)
 	if err != nil {
@@ -52,8 +55,6 @@ func RunTest(t *testing.T, test *Test) {
 	if err != nil {
 		t.Fatalf("want: invalid JSON: %s", err)
 	}
-
-	checkErrors(t, test.ExpectedErrors, result.Errors)
 
 	if !bytes.Equal(got, want) {
 		t.Logf("got:  %s", got)

--- a/gqltesting/testing.go
+++ b/gqltesting/testing.go
@@ -75,27 +75,8 @@ func formatJSON(data []byte) ([]byte, error) {
 	return formatted, nil
 }
 
-func checkErrors(t *testing.T, expected, actual []*errors.QueryError) {
-	expectedCount, actualCount := len(expected), len(actual)
-
-	if expectedCount != actualCount {
-		t.Fatalf("unexpected number of errors: got %d, want %d", actualCount, expectedCount)
-	}
-
-	if expectedCount > 0 {
-		for i, want := range expected {
-			got := actual[i]
-
-			if !reflect.DeepEqual(got, want) {
-				t.Fatalf("unexpected error: got %+v, want %+v", got, want)
-			}
-		}
-
-		// Return because we're done checking.
-		return
-	}
-
-	for _, err := range actual {
-		t.Errorf("unexpected error: '%s'", err)
+func checkErrors(t *testing.T, want, got []*errors.QueryError) {
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected error: got %+v, want %+v", got, want)
 	}
 }


### PR DESCRIPTION
Hi,

gqltesting is very helpful for testing graphql endpoints, but there are two small problems which this PR fixes:

- If you send an invalid graphql query (for example you ask for a field which doesn't exists) you get:
```
    testing.go:49: got: invalid JSON: unexpected end of JSON input ("")
```
That's because the `Result` field is empty. But there is an error object, so the first commit first checks the errors, and if they are as expected then it'll do the body of the result.

- the error check gave a rather uninformative error:
```
    testing.go:82: unexpected number of errors: got 1, want 0
```

The second commit makes that:
```
    testing.go:80: unexpected error: got [graphql: Cannot query field "timestamp" on type "SMSList". (line 1, column 40)], want []
```
and as a bonus the code is now trivial.