### PR TITLE
Parse string based descriptions

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -34,7 +34,7 @@ func ParseSchema(schemaString string, resolver interface{}, opts ...SchemaOpt) (
 		opt(s)
 	}
 
-	if err := s.schema.Parse(schemaString); err != nil {
+	if err := s.schema.Parse(schemaString, s.noCommentsAsDescriptions); err != nil {
 		return nil, err
 	}
 
@@ -63,15 +63,23 @@ type Schema struct {
 	schema *schema.Schema
 	res    *resolvable.Schema
 
-	maxDepth         int
-	maxParallelism   int
-	tracer           trace.Tracer
-	validationTracer trace.ValidationTracer
-	logger           log.Logger
+	maxDepth                 int
+	maxParallelism           int
+	tracer                   trace.Tracer
+	validationTracer         trace.ValidationTracer
+	logger                   log.Logger
+	noCommentsAsDescriptions bool
 }
 
 // SchemaOpt is an option to pass to ParseSchema or MustParseSchema.
 type SchemaOpt func(*Schema)
+
+// NoCommentsAsDescriptions disables the parsing of comments as descriptions
+func NoCommentsAsDescriptions() SchemaOpt {
+	return func(s *Schema) {
+		s.noCommentsAsDescriptions = true
+	}
+}
 
 // MaxDepth specifies the maximum field nesting depth in a query. The default is 0 which disables max depth checking.
 func MaxDepth(n int) SchemaOpt {

--- a/graphql.go
+++ b/graphql.go
@@ -34,7 +34,7 @@ func ParseSchema(schemaString string, resolver interface{}, opts ...SchemaOpt) (
 		opt(s)
 	}
 
-	if err := s.schema.Parse(schemaString, s.noCommentsAsDescriptions); err != nil {
+	if err := s.schema.Parse(schemaString, s.useStringDescriptions); err != nil {
 		return nil, err
 	}
 
@@ -63,21 +63,21 @@ type Schema struct {
 	schema *schema.Schema
 	res    *resolvable.Schema
 
-	maxDepth                 int
-	maxParallelism           int
-	tracer                   trace.Tracer
-	validationTracer         trace.ValidationTracer
-	logger                   log.Logger
-	noCommentsAsDescriptions bool
+	maxDepth              int
+	maxParallelism        int
+	tracer                trace.Tracer
+	validationTracer      trace.ValidationTracer
+	logger                log.Logger
+	useStringDescriptions bool
 }
 
 // SchemaOpt is an option to pass to ParseSchema or MustParseSchema.
 type SchemaOpt func(*Schema)
 
-// NoCommentsAsDescriptions disables the parsing of comments as descriptions
-func NoCommentsAsDescriptions() SchemaOpt {
+// UseStringDescriptions disables the parsing of comments as descriptions
+func UseStringDescriptions() SchemaOpt {
 	return func(s *Schema) {
-		s.noCommentsAsDescriptions = true
+		s.useStringDescriptions = true
 	}
 }
 

--- a/graphql.go
+++ b/graphql.go
@@ -74,7 +74,10 @@ type Schema struct {
 // SchemaOpt is an option to pass to ParseSchema or MustParseSchema.
 type SchemaOpt func(*Schema)
 
-// UseStringDescriptions disables the parsing of comments as descriptions
+// UseStringDescriptions enables the usage of double quoted and triple quoted
+// strings as descriptions as per the June 2018 spec
+// https://facebook.github.io/graphql/June2018/. When this is not enabled,
+// comments are parsed as descriptions instead.
 func UseStringDescriptions() SchemaOpt {
 	return func(s *Schema) {
 		s.useStringDescriptions = true

--- a/internal/common/lexer.go
+++ b/internal/common/lexer.go
@@ -171,12 +171,8 @@ func (l *Lexer) consumeTripleQuoteComment() {
 		panic("consumeTripleQuoteComment used in wrong context: no third quote?")
 	}
 
-	if l.descComment != "" {
-		l.descComment += "\n"
-	}
-
-	comment := ""
-	numQuotes := 0
+	var comment string
+	var numQuotes int
 	for {
 		l.next = l.sc.Next()
 		if l.next == '"' {
@@ -193,10 +189,6 @@ func (l *Lexer) consumeTripleQuoteComment() {
 }
 
 func (l *Lexer) consumeStringComment(str string) {
-	if l.descComment != "" {
-		l.descComment += "\n"
-	}
-
 	value, err := strconv.Unquote(str)
 	if err != nil {
 		panic(err)

--- a/internal/common/lexer.go
+++ b/internal/common/lexer.go
@@ -129,7 +129,7 @@ func (l *Lexer) ConsumeKeyword(keyword string) {
 
 func (l *Lexer) ConsumeLiteral() *BasicLit {
 	lit := &BasicLit{Type: l.next, Text: l.sc.TokenText()}
-	l.Consume(true)
+	l.Consume(false)
 	return lit
 }
 

--- a/internal/common/lexer_test.go
+++ b/internal/common/lexer_test.go
@@ -7,11 +7,11 @@ import (
 )
 
 type consumeTestCase struct {
-	description              string
-	definition               string
-	expected                 string // expected description
-	failureExpected          bool
-	noCommentsAsDescriptions bool
+	description           string
+	definition            string
+	expected              string // expected description
+	failureExpected       bool
+	useStringDescriptions bool
 }
 
 // Note that these tests stop as soon as they parse the comments, so even though the rest of the file will fail to parse sometimes, the tests still pass
@@ -26,8 +26,8 @@ var consumeTests = []consumeTestCase{{
 type Hello {
 	world: String!
 }`,
-	expected:                 "Comment line 1\nComment line 2\nCommas are insignificant",
-	noCommentsAsDescriptions: false,
+	expected:              "Comment line 1\nComment line 2\nCommas are insignificant",
+	useStringDescriptions: false,
 }, {
 	description: "simple string descriptions allowed in old mode",
 	definition: `
@@ -39,8 +39,8 @@ type Hello {
 type Hello {
 	world: String!
 }`,
-	expected:                 "New style comments",
-	noCommentsAsDescriptions: true,
+	expected:              "New style comments",
+	useStringDescriptions: true,
 }, {
 	description: "triple quote descriptions allowed in old mode",
 	definition: `
@@ -54,14 +54,14 @@ New style comments
 type Hello {
 	world: String!
 }`,
-	expected:                 "New style comments",
-	noCommentsAsDescriptions: true,
+	expected:              "New style comments",
+	useStringDescriptions: true,
 }}
 
 func TestConsume(t *testing.T) {
 	for _, test := range consumeTests {
 		t.Run(test.description, func(t *testing.T) {
-			lex := common.NewLexer(test.definition, test.noCommentsAsDescriptions)
+			lex := common.NewLexer(test.definition, test.useStringDescriptions)
 
 			err := lex.CatchSyntaxError(func() { lex.ConsumeWhitespace() })
 			if test.failureExpected {

--- a/internal/common/lexer_test.go
+++ b/internal/common/lexer_test.go
@@ -7,9 +7,10 @@ import (
 )
 
 type consumeTestCase struct {
-	description string
-	definition  string
-	expected    string // expected description
+	description              string
+	definition               string
+	expected                 string // expected description
+	noCommentsAsDescriptions bool
 }
 
 var consumeTests = []consumeTestCase{{
@@ -27,13 +28,32 @@ so " many comments
 type Hello {
 	world: String!
 }`,
-	expected: "Comment line 1\nComment line 2\nCommas are insignificant\nNew style comments\n\nso \" many comments",
-}}
+	expected:                 "Comment line 1\nComment line 2\nCommas are insignificant\nNew style comments\n\nso \" many comments",
+	noCommentsAsDescriptions: false,
+},
+	{
+		description: "initial test",
+		definition: `
+
+# Comment line 1
+#Comment line 2
+,,,,,, # Commas are insignificant
+"New style comments"
+""
+"""
+so " many comments
+"""
+type Hello {
+	world: String!
+}`,
+		expected:                 "New style comments\n\nso \" many comments",
+		noCommentsAsDescriptions: true,
+	}}
 
 func TestConsume(t *testing.T) {
 	for _, test := range consumeTests {
 		t.Run(test.description, func(t *testing.T) {
-			lex := common.NewLexer(test.definition)
+			lex := common.NewLexer(test.definition, test.noCommentsAsDescriptions)
 
 			err := lex.CatchSyntaxError(func() { lex.Consume(true) })
 			if err != nil {

--- a/internal/common/lexer_test.go
+++ b/internal/common/lexer_test.go
@@ -17,12 +17,17 @@ var consumeTests = []consumeTestCase{{
 	definition: `
 
 # Comment line 1
-# Comment line 2
+#Comment line 2
 ,,,,,, # Commas are insignificant
+"New style comments"
+""
+"""
+so " many comments
+"""
 type Hello {
 	world: String!
 }`,
-	expected: "Comment line 1\nComment line 2\nCommas are insignificant",
+	expected: "Comment line 1\nComment line 2\nCommas are insignificant\nNew style comments\n\nso \" many comments",
 }}
 
 func TestConsume(t *testing.T) {
@@ -30,7 +35,7 @@ func TestConsume(t *testing.T) {
 		t.Run(test.description, func(t *testing.T) {
 			lex := common.NewLexer(test.definition)
 
-			err := lex.CatchSyntaxError(lex.Consume)
+			err := lex.CatchSyntaxError(func() { lex.Consume(true) })
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/common/lexer_test.go
+++ b/internal/common/lexer_test.go
@@ -29,7 +29,7 @@ type Hello {
 	expected:              "Comment line 1\nComment line 2\nCommas are insignificant",
 	useStringDescriptions: false,
 }, {
-	description: "simple string descriptions allowed in old mode",
+	description: "simple string descriptions allowed in new mode",
 	definition: `
 
 # Comment line 1
@@ -42,7 +42,19 @@ type Hello {
 	expected:              "New style comments",
 	useStringDescriptions: true,
 }, {
-	description: "triple quote descriptions allowed in old mode",
+	description: "comment after description works",
+	definition: `
+
+# Comment line 1
+#Comment line 2
+,,,,,, # Commas are insignificant
+type Hello {
+	world: String!
+}`,
+	expected:              "",
+	useStringDescriptions: true,
+}, {
+	description: "triple quote descriptions allowed in new mode",
 	definition: `
 
 # Comment line 1
@@ -50,11 +62,12 @@ type Hello {
 ,,,,,, # Commas are insignificant
 """
 New style comments
+Another line
 """
 type Hello {
 	world: String!
 }`,
-	expected:              "New style comments",
+	expected:              "New style comments\nAnother line",
 	useStringDescriptions: true,
 }}
 

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -107,7 +107,7 @@ func Parse(queryString string) (*Document, *errors.QueryError) {
 
 func parseDocument(l *common.Lexer) *Document {
 	d := &Document{}
-	l.Consume(true)
+	l.ConsumeWhitespace()
 	for l.Peek() != scanner.EOF {
 		if l.Peek() == '{' {
 			op := &Operation{Type: Query, Loc: l.Location()}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -107,7 +107,7 @@ func Parse(queryString string) (*Document, *errors.QueryError) {
 
 func parseDocument(l *common.Lexer) *Document {
 	d := &Document{}
-	l.Consume()
+	l.Consume(true)
 	for l.Peek() != scanner.EOF {
 		if l.Peek() == '{' {
 			op := &Operation{Type: Query, Loc: l.Location()}

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -94,7 +94,7 @@ func (InlineFragment) isSelection() {}
 func (FragmentSpread) isSelection() {}
 
 func Parse(queryString string) (*Document, *errors.QueryError) {
-	l := common.NewLexer(queryString)
+	l := common.NewLexer(queryString, false)
 
 	var doc *Document
 	err := l.CatchSyntaxError(func() { doc = parseDocument(l) })

--- a/internal/schema/meta.go
+++ b/internal/schema/meta.go
@@ -5,7 +5,7 @@ var Meta *Schema
 func init() {
 	Meta = &Schema{} // bootstrap
 	Meta = New()
-	if err := Meta.Parse(metaSrc); err != nil {
+	if err := Meta.Parse(metaSrc, false); err != nil {
 		panic(err)
 	}
 }
@@ -167,7 +167,7 @@ var metaSrc = `
 		inputFields: [__InputValue!]
 		ofType: __Type
 	}
-	
+
 	# An enum describing what kind of type a given ` + "`" + `__Type` + "`" + ` is.
 	enum __TypeKind {
 		# Indicates this type is a scalar.

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -246,8 +246,8 @@ func New() *Schema {
 }
 
 // Parse the schema string.
-func (s *Schema) Parse(schemaString string) error {
-	l := common.NewLexer(schemaString)
+func (s *Schema) Parse(schemaString string, noCommentsAsDescriptions bool) error {
+	l := common.NewLexer(schemaString, noCommentsAsDescriptions)
 
 	err := l.CatchSyntaxError(func() { parseSchema(s, l) })
 	if err != nil {

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -246,8 +246,8 @@ func New() *Schema {
 }
 
 // Parse the schema string.
-func (s *Schema) Parse(schemaString string, noCommentsAsDescriptions bool) error {
-	l := common.NewLexer(schemaString, noCommentsAsDescriptions)
+func (s *Schema) Parse(schemaString string, useStringDescriptions bool) error {
+	l := common.NewLexer(schemaString, useStringDescriptions)
 
 	err := l.CatchSyntaxError(func() { parseSchema(s, l) })
 	if err != nil {

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -389,7 +389,7 @@ func resolveInputObject(s *Schema, values common.InputValueList) error {
 }
 
 func parseSchema(s *Schema, l *common.Lexer) {
-	l.Consume()
+	l.Consume(true)
 
 	for l.Peek() != scanner.EOF {
 		desc := l.DescComment()

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -389,7 +389,7 @@ func resolveInputObject(s *Schema, values common.InputValueList) error {
 }
 
 func parseSchema(s *Schema, l *common.Lexer) {
-	l.Consume(true)
+	l.ConsumeWhitespace()
 
 	for l.Peek() != scanner.EOF {
 		desc := l.DescComment()

--- a/internal/schema/schema_internal_test.go
+++ b/internal/schema/schema_internal_test.go
@@ -18,7 +18,7 @@ func TestParseInterfaceDef(t *testing.T) {
 	tests := []testCase{{
 		description: "Parses simple interface",
 		definition:  "Greeting { field: String }",
-		expected:    &Interface{Name: "Greeting", Fields: []*Field{&Field{Name: "field"}}},
+		expected:    &Interface{Name: "Greeting", Fields: []*Field{{Name: "field"}}},
 	}}
 
 	for _, test := range tests {
@@ -159,7 +159,7 @@ func setup(t *testing.T, def string) *common.Lexer {
 	t.Helper()
 
 	lex := common.NewLexer(def)
-	lex.Consume()
+	lex.Consume(true)
 
 	return lex
 }

--- a/internal/schema/schema_internal_test.go
+++ b/internal/schema/schema_internal_test.go
@@ -159,7 +159,7 @@ func setup(t *testing.T, def string) *common.Lexer {
 	t.Helper()
 
 	lex := common.NewLexer(def, false)
-	lex.Consume(true)
+	lex.ConsumeWhitespace()
 
 	return lex
 }

--- a/internal/schema/schema_internal_test.go
+++ b/internal/schema/schema_internal_test.go
@@ -158,7 +158,7 @@ func compareObjects(t *testing.T, expected, actual *Object) {
 func setup(t *testing.T, def string) *common.Lexer {
 	t.Helper()
 
-	lex := common.NewLexer(def)
+	lex := common.NewLexer(def, false)
 	lex.Consume(true)
 
 	return lex

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -80,7 +80,7 @@ func TestParse(t *testing.T) {
 			t.Skip("TODO: add support for descriptions")
 			schema := setup(t)
 
-			err := schema.Parse(test.sdl)
+			err := schema.Parse(test.sdl, false)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/internal/validation/validate_max_depth_test.go
+++ b/internal/validation/validate_max_depth_test.go
@@ -105,7 +105,7 @@ func (tc maxDepthTestCase) Run(t *testing.T, s *schema.Schema) {
 func TestMaxDepth(t *testing.T) {
 	s := schema.New()
 
-	err := s.Parse(simpleSchema)
+	err := s.Parse(simpleSchema, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -181,7 +181,7 @@ func TestMaxDepth(t *testing.T) {
 func TestMaxDepthInlineFragments(t *testing.T) {
 	s := schema.New()
 
-	err := s.Parse(interfaceSimple)
+	err := s.Parse(interfaceSimple, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,7 +230,7 @@ func TestMaxDepthInlineFragments(t *testing.T) {
 func TestMaxDepthFragmentSpreads(t *testing.T) {
 	s := schema.New()
 
-	err := s.Parse(interfaceSimple)
+	err := s.Parse(interfaceSimple, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -317,7 +317,7 @@ func TestMaxDepthFragmentSpreads(t *testing.T) {
 func TestMaxDepthUnknownFragmentSpreads(t *testing.T) {
 	s := schema.New()
 
-	err := s.Parse(interfaceSimple)
+	err := s.Parse(interfaceSimple, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -352,7 +352,7 @@ func TestMaxDepthUnknownFragmentSpreads(t *testing.T) {
 func TestMaxDepthValidation(t *testing.T) {
 	s := schema.New()
 
-	err := s.Parse(interfaceSimple)
+	err := s.Parse(interfaceSimple, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -39,7 +39,7 @@ func TestValidate(t *testing.T) {
 	schemas := make([]*schema.Schema, len(testData.Schemas))
 	for i, schemaStr := range testData.Schemas {
 		schemas[i] = schema.New()
-		if err := schemas[i].Parse(schemaStr); err != nil {
+		if err := schemas[i].Parse(schemaStr, false); err != nil {
 			t.Fatal(err)
 		}
 	}


### PR DESCRIPTION
This implementation is probably lax about where string descriptions are allowed. Additional test cases would be needed to verify the accuracy of the implementation. Also, this is backwards compatible with comment based descriptions and there's an option to disable the backwards compatibility.

fix #196 
fix #147