### PR TITLE
First test for errors, then for content

### DIFF
--- a/gqltesting/testing.go
+++ b/gqltesting/testing.go
@@ -43,6 +43,9 @@ func RunTest(t *testing.T, test *Test) {
 		test.Context = context.Background()
 	}
 	result := test.Schema.Exec(test.Context, test.Query, test.OperationName, test.Variables)
+
+	checkErrors(t, test.ExpectedErrors, result.Errors)
+
 	// Verify JSON to avoid red herring errors.
 	got, err := formatJSON(result.Data)
 	if err != nil {
@@ -52,8 +55,6 @@ func RunTest(t *testing.T, test *Test) {
 	if err != nil {
 		t.Fatalf("want: invalid JSON: %s", err)
 	}
-
-	checkErrors(t, test.ExpectedErrors, result.Errors)
 
 	if !bytes.Equal(got, want) {
 		t.Logf("got:  %s", got)


### PR DESCRIPTION
If there are serious errors the returned `Data` field might be empty, which is a JSON parse error. So we need to check errors first, then the rest.


This is half of #267, which @pavelnikolov requested me to split up.

> Also, you might consider adding some unit tests and asses that you get correct message when you move the error checking first?

I wouldn't mind, but frankly I have no idea how to make unittests for unittests :(
I do want to refer to the comments in #267 which show a before/after example i got from using this in my code.