### PR TITLE
simpler error comparisons

### DIFF
--- a/gqltesting/testing.go
+++ b/gqltesting/testing.go
@@ -74,27 +74,8 @@ func formatJSON(data []byte) ([]byte, error) {
 	return formatted, nil
 }
 
-func checkErrors(t *testing.T, expected, actual []*errors.QueryError) {
-	expectedCount, actualCount := len(expected), len(actual)
-
-	if expectedCount != actualCount {
-		t.Fatalf("unexpected number of errors: got %d, want %d", actualCount, expectedCount)
-	}
-
-	if expectedCount > 0 {
-		for i, want := range expected {
-			got := actual[i]
-
-			if !reflect.DeepEqual(got, want) {
-				t.Fatalf("unexpected error: got %+v, want %+v", got, want)
-			}
-		}
-
-		// Return because we're done checking.
-		return
-	}
-
-	for _, err := range actual {
-		t.Errorf("unexpected error: '%s'", err)
+func checkErrors(t *testing.T, want, got []*errors.QueryError) {
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("unexpected error: got %+v, want %+v", got, want)
 	}
 }


### PR DESCRIPTION
Before you would get the unhelpful message:

    testing.go:82: unexpected number of errors: got 1, want 0

but now you get:

    testing.go:80: unexpected error: got [graphql: Cannot query field "timestamp" on type "SMSList". (line 1, column 40)], want []


This is half of #267, which @pavelnikolov asked me to split up.