### PR TITLE
Switch to interface{} for Subscribe() return

### DIFF
--- a/gqltesting/subscriptions.go
+++ b/gqltesting/subscriptions.go
@@ -57,7 +57,7 @@ func RunSubscribe(t *testing.T, test *TestSubscription) {
 
 	var results []*graphql.Response
 	for res := range c {
-		results = append(results, res)
+		results = append(results, res.(*graphql.Response))
 	}
 
 	for i, expected := range test.ExpectedResults {


### PR DESCRIPTION
**Breaking change (subscriptions)**

It's a lot easier to build `graph-gophers/graphql-transport-ws` around the `interface{}` type.

This PR is to make the changes in [this other PR](https://github.com/graph-gophers/graphql-transport-ws/pull/2) possible.