### PR TITLE
Implement error propagation

### DIFF
--- a/gqltesting/subscriptions.go
+++ b/gqltesting/subscriptions.go
@@ -80,7 +80,7 @@ func RunSubscribe(t *testing.T, test *TestSubscription) {
 		}
 		want, err := formatJSON(expectedData)
 		if err != nil {
-			t.Fatalf("got: invalid JSON: %s", err)
+			t.Fatalf("got: invalid JSON: %s; raw: %s", err, expectedData)
 		}
 
 		if !bytes.Equal(got, want) {

--- a/gqltesting/subscriptions.go
+++ b/gqltesting/subscriptions.go
@@ -71,7 +71,7 @@ func RunSubscribe(t *testing.T, test *TestSubscription) {
 		}
 		got, err := formatJSON(resData)
 		if err != nil {
-			t.Fatalf("got: invalid JSON: %s", err)
+			t.Fatalf("got: invalid JSON: %s; raw: %s", err, resData)
 		}
 
 		expectedData, err := expected.Data.MarshalJSON()

--- a/gqltesting/testing.go
+++ b/gqltesting/testing.go
@@ -4,7 +4,9 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"reflect"
+	"sort"
 	"strconv"
 	"testing"
 
@@ -76,7 +78,19 @@ func formatJSON(data []byte) ([]byte, error) {
 }
 
 func checkErrors(t *testing.T, want, got []*errors.QueryError) {
+	sortErrors(want)
+	sortErrors(got)
+
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("unexpected error: got %+v, want %+v", got, want)
 	}
+}
+
+func sortErrors(errors []*errors.QueryError) {
+	if len(errors) <= 1 {
+		return
+	}
+	sort.Slice(errors, func(i, j int) bool {
+		return fmt.Sprintf("%s", errors[i].Path) < fmt.Sprintf("%s", errors[j].Path)
+	})
 }

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -2131,7 +2131,7 @@ var (
 	exampleErrorString = "This is an error"
 	exampleError       = fmt.Errorf(exampleErrorString)
 
-	nilChildErrorString = `got nil for non-null "Child"`
+	nilChildErrorString = `graphql: got nil for non-null "Child"`
 )
 
 type erroringResolver1 struct{}

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -102,6 +102,26 @@ func (r *findDroidResolver) FindDroid(ctx context.Context) (string, error) {
 	}
 }
 
+type findDroidOrHumanResolver struct{}
+
+func (r *findDroidOrHumanResolver) FindHuman(ctx context.Context) (*string, error) {
+	human := "human"
+	return &human, nil
+}
+
+func (r *findDroidOrHumanResolver) FindDroid(ctx context.Context) (*droidResolver, error) {
+	return &droidResolver{}, resolverNotFoundError{
+		Code:    "NotFound",
+		Message: "This is not the droid you are looking for",
+	}
+}
+
+type droidResolver struct{}
+
+func (d *droidResolver) Name() string {
+	return "R2D2"
+}
+
 type discussPlanResolver struct{}
 
 func (r *discussPlanResolver) DismissVader(ctx context.Context) (string, error) {
@@ -361,12 +381,19 @@ func TestErrorWithExtensions(t *testing.T) {
 				}
 
 				type Query {
-					FindDroid: String!
+					FindDroid: Droid!
+					FindHuman: String
 				}
-			`, &findDroidResolver{}),
+				type Droid {
+					Name: String!
+				}
+			`, &findDroidOrHumanResolver{}),
 			Query: `
 				{
-					FindDroid
+					FindDroid {
+						Name
+					}
+					FindHuman
 				}
 			`,
 			ExpectedResult: `

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -251,7 +251,7 @@ func (r *Request) execSelectionSet(ctx context.Context, sels []selected.Selectio
 		if resolver.Kind() == reflect.Invalid || ((resolver.Kind() == reflect.Ptr || resolver.Kind() == reflect.Interface) && resolver.IsNil()) {
 			// If a field of a non-null type resolves to nil, add an error and propagate it
 			if nonNull {
-				err := errors.Errorf("got nil for non-null %q", t)
+				err := errors.Errorf("graphql: got nil for non-null %q", t)
 				err.Path = path.toSlice()
 				r.AddError(err)
 			}

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -249,8 +249,11 @@ func (r *Request) execSelectionSet(ctx context.Context, sels []selected.Selectio
 	case *schema.Object, *schema.Interface, *schema.Union:
 		// a reflect.Value of a nil interface will show up as an Invalid value
 		if resolver.Kind() == reflect.Invalid || ((resolver.Kind() == reflect.Ptr || resolver.Kind() == reflect.Interface) && resolver.IsNil()) {
+			// If a field of a non-null type resolves to nil, add an error and propagate it
 			if nonNull {
-				panic(errors.Errorf("got nil for non-null %q", t))
+				err := errors.Errorf("got nil for non-null %q", t)
+				err.Path = path.toSlice()
+				r.AddError(err)
 			}
 			out.WriteString("null")
 			return

--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -28,31 +28,6 @@ func (r *Request) AddError(err *errors.QueryError) {
 	r.Mu.Unlock()
 }
 
-// pathPrefixMatch checks if `path` starts with `prefix`
-func pathPrefixMatch(path []interface{}, prefix []interface{}) bool {
-	if len(prefix) > len(path) {
-		return false
-	}
-	for i, component := range prefix {
-		if path[i] != component {
-			return false
-		}
-	}
-	return true
-}
-
-// SubPathHasError returns true if any path that is a subpath of the given path has added errors to the response
-func (r *Request) SubPathHasError(path []interface{}) bool {
-	r.Mu.Lock()
-	defer r.Mu.Unlock()
-	for _, err := range r.Errs {
-		if pathPrefixMatch(err.Path, path) {
-			return true
-		}
-	}
-	return false
-}
-
 func ApplyOperation(r *Request, s *resolvable.Schema, op *query.Operation) []Selection {
 	var obj *resolvable.Object
 	switch op.Type {

--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -28,6 +28,31 @@ func (r *Request) AddError(err *errors.QueryError) {
 	r.Mu.Unlock()
 }
 
+// pathPrefixMatch checks if `path` starts with `prefix`
+func pathPrefixMatch(path []interface{}, prefix []interface{}) bool {
+	if len(prefix) > len(path) {
+		return false
+	}
+	for i, component := range prefix {
+		if path[i] != component {
+			return false
+		}
+	}
+	return true
+}
+
+// SubPathHasError returns true if any path that is a subpath of the given path has added errors to the response
+func (r *Request) SubPathHasError(path []interface{}) bool {
+	r.Mu.Lock()
+	defer r.Mu.Unlock()
+	for _, err := range r.Errs {
+		if pathPrefixMatch(err.Path, path) {
+			return true
+		}
+	}
+	return false
+}
+
 func ApplyOperation(r *Request, s *resolvable.Schema, op *query.Operation) []Selection {
 	var obj *resolvable.Object
 	switch op.Type {

--- a/internal/exec/subscribe.go
+++ b/internal/exec/subscribe.go
@@ -115,9 +115,13 @@ func (r *Request) Subscribe(ctx context.Context, s *resolvable.Schema, op *query
 					func() {
 						defer subR.handlePanic(subCtx)
 
-						out.WriteString(fmt.Sprintf(`{"%s":`, f.field.Alias))
-						subR.execSelectionSet(subCtx, f.sels, f.field.Type, &pathSegment{nil, f.field.Alias}, resp, &out)
-						out.WriteString(`}`)
+						var buf bytes.Buffer
+						subR.execSelectionSet(subCtx, f.sels, f.field.Type, &pathSegment{nil, f.field.Alias}, resp, &buf)
+						if len(subR.Errs) == 0 {
+							out.WriteString(fmt.Sprintf(`{"%s":`, f.field.Alias))
+							out.Write(buf.Bytes())
+							out.WriteString(`}`)
+						}
 					}()
 
 					if err := subCtx.Err(); err != nil {

--- a/internal/exec/subscribe.go
+++ b/internal/exec/subscribe.go
@@ -123,7 +123,7 @@ func (r *Request) Subscribe(ctx context.Context, s *resolvable.Schema, op *query
 						subR.execSelectionSet(subCtx, f.sels, f.field.Type, &pathSegment{nil, f.field.Alias}, resp, &buf)
 
 						propagateChildError := false
-						if _, nonNullChild := f.field.Type.(*common.NonNull); nonNullChild && subR.SubPathHasError((&pathSegment{nil, f.field.Alias}).toSlice()) {
+						if _, nonNullChild := f.field.Type.(*common.NonNull); nonNullChild && resolvedToNull(&buf) {
 							propagateChildError = true
 						}
 

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -100,11 +100,7 @@ func TestSchemaSubscribe(t *testing.T) {
 				},
 				{
 					Data: json.RawMessage(`
-						{
-							"helloSaid": {
-								"msg":null
-							}
-						}
+						null
 					`),
 					Errors: []*qerrors.QueryError{qerrors.Errorf("%s", resolverErr)},
 				},


### PR DESCRIPTION
This is based on https://github.com/graph-gophers/graphql-go/pull/229, with some additions/changes to handle the following:
- non-nullable fields that resolve to `null`
- non-nullable lists of nullable elements (`[]!`)
- nullable lists of nullable elements (`[]`)

Additionally, to determine if a parent field resolves to `null`, check if any immediate child resolved to `null` instead of checking if any descendant returned an error.