### PR TITLE
Validate types are including all fields from implemented interface(s)

### DIFF
--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -291,6 +291,11 @@ func (s *Schema) Parse(schemaString string, useStringDescriptions bool) error {
 			if !ok {
 				return errors.Errorf("type %q is not an interface", intfName)
 			}
+			for _, f := range intf.Fields.Names() {
+				if obj.Fields.Get(f) == nil {
+					return errors.Errorf("interface %q expects field %q but %q does not provide it", intfName, f, obj.Name)
+				}
+			}
 			obj.Interfaces[i] = intf
 			intf.PossibleTypes = append(intf.PossibleTypes, obj)
 		}

--- a/internal/schema/schema_internal_test.go
+++ b/internal/schema/schema_internal_test.go
@@ -50,10 +50,6 @@ func TestParseObjectDef(t *testing.T) {
 		definition:  "Hello implements World { field: String }",
 		expected:    &Object{Name: "Hello", interfaceNames: []string{"World"}},
 	}, {
-		description: "Parses type Welcome that implements interface Greeting without providing required fields",
-		definition:  "Hello implements World { }",
-		err:         errors.Errorf(`interface "World" expects field "field" but "Hello" does not provide it`),
-	}, {
 		description: "Parses type inheriting multiple interfaces",
 		definition:  "Hello implements Wo & rld { field: String }",
 		expected:    &Object{Name: "Hello", interfaceNames: []string{"Wo", "rld"}},

--- a/internal/schema/schema_internal_test.go
+++ b/internal/schema/schema_internal_test.go
@@ -50,6 +50,10 @@ func TestParseObjectDef(t *testing.T) {
 		definition:  "Hello implements World { field: String }",
 		expected:    &Object{Name: "Hello", interfaceNames: []string{"World"}},
 	}, {
+		description: "Parses type Welcome that implements interface Greeting without providing required fields",
+		definition:  "interface Greeting { message: String! } type Welcome implements Greeting {}",
+		err:         errors.Errorf(`interface "Greeting" expects field "message" but "Welcome" does not provide it`),
+	}, {
 		description: "Parses type inheriting multiple interfaces",
 		definition:  "Hello implements Wo & rld { field: String }",
 		expected:    &Object{Name: "Hello", interfaceNames: []string{"Wo", "rld"}},

--- a/internal/schema/schema_internal_test.go
+++ b/internal/schema/schema_internal_test.go
@@ -51,8 +51,8 @@ func TestParseObjectDef(t *testing.T) {
 		expected:    &Object{Name: "Hello", interfaceNames: []string{"World"}},
 	}, {
 		description: "Parses type Welcome that implements interface Greeting without providing required fields",
-		definition:  "interface Greeting { message: String! } type Welcome implements Greeting {}",
-		err:         errors.Errorf(`interface "Greeting" expects field "message" but "Welcome" does not provide it`),
+		definition:  "Hello implements World { }",
+		err:         errors.Errorf(`interface "World" expects field "field" but "Hello" does not provide it`),
 	}, {
 		description: "Parses type inheriting multiple interfaces",
 		definition:  "Hello implements Wo & rld { field: String }",

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -3,6 +3,7 @@ package schema_test
 import (
 	"testing"
 
+	"github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/internal/schema"
 )
 

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -89,3 +89,25 @@ func TestParse(t *testing.T) {
 		})
 	}
 }
+
+func TestInvalidInterfaceImpl(t *testing.T) {
+	var tests = []parseTestCase{{
+		description: "Parses type Welcome that implements interface Greeting without providing required fields",
+		sdl:         "interface Greeting { message: String! } type Welcome implements Greeting {}",
+		err:         errors.Errorf(`interface "Greeting" expects field "message" but "Welcome" does not provide it`),
+	}}
+
+	setup := func(t *testing.T) *schema.Schema {
+		t.Helper()
+		return schema.New()
+	}
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			schema := setup(t)
+			err := schema.Parse(test.sdl, false)
+			if err == nil || err.Error() != test.err.Error() {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Validate types are including all fields from implemented interface(s). I had a case were the type didn't include all fields from the implemented interface and it caused [graphiql](https://github.com/graphql/graphiql) documentation to crash. getting the following error:

> Error: "Interface" expects field "message" but "Type" does not provide it.
    at invariant (https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.10/graphiql.js:25007:11)
    at https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.10/graphiql.js:29985:29
    at Array.forEach (<anonymous>)
    at assertObjectImplementsInterface (https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.10/graphiql.js:29980:30)
    at https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.10/graphiql.js:29862:18
    at Array.forEach (<anonymous>)
    at https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.10/graphiql.js:29861:30
    at Array.forEach (<anonymous>)
    at new GraphQLSchema (https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.10/graphiql.js:29858:32)
    at buildClientSchema (https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.10/graphiql.js:31247:10)
