### PR TITLE
Add DisableIntrospection SchemaOpt

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -68,6 +68,7 @@ type Schema struct {
 	validationTracer      trace.ValidationTracer
 	logger                log.Logger
 	useStringDescriptions bool
+	disableIntrospection  bool
 }
 
 // SchemaOpt is an option to pass to ParseSchema or MustParseSchema.
@@ -122,6 +123,13 @@ func ValidationTracer(tracer trace.ValidationTracer) SchemaOpt {
 func Logger(logger log.Logger) SchemaOpt {
 	return func(s *Schema) {
 		s.logger = logger
+	}
+}
+
+// DisableIntrospection disables introspection queries.
+func DisableIntrospection() SchemaOpt {
+	return func(s *Schema) {
+		s.disableIntrospection = true
 	}
 }
 
@@ -184,9 +192,10 @@ func (s *Schema) exec(ctx context.Context, queryString string, operationName str
 
 	r := &exec.Request{
 		Request: selected.Request{
-			Doc:    doc,
-			Vars:   variables,
-			Schema: s.schema,
+			Doc:                  doc,
+			Vars:                 variables,
+			Schema:               s.schema,
+			DisableIntrospection: s.disableIntrospection,
 		},
 		Limiter: make(chan struct{}, s.maxParallelism),
 		Tracer:  s.tracer,

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -1905,6 +1905,164 @@ func TestIntrospection(t *testing.T) {
 	})
 }
 
+var starwarsSchemaNoIntrospection = graphql.MustParseSchema(starwars.Schema, &starwars.Resolver{}, []graphql.SchemaOpt{graphql.DisableIntrospection()}...)
+
+func TestIntrospectionDisableIntrospection(t *testing.T) {
+	gqltesting.RunTests(t, []*gqltesting.Test{
+		{
+			Schema: starwarsSchemaNoIntrospection,
+			Query: `
+				{
+					__schema {
+						types {
+							name
+						}
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+				}
+			`,
+		},
+
+		{
+			Schema: starwarsSchemaNoIntrospection,
+			Query: `
+				{
+					__schema {
+						queryType {
+							name
+						}
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+				}
+			`,
+		},
+
+		{
+			Schema: starwarsSchemaNoIntrospection,
+			Query: `
+				{
+					a: __type(name: "Droid") {
+						name
+						kind
+						interfaces {
+							name
+						}
+						possibleTypes {
+							name
+						}
+					},
+					b: __type(name: "Character") {
+						name
+						kind
+						interfaces {
+							name
+						}
+						possibleTypes {
+							name
+						}
+					}
+					c: __type(name: "SearchResult") {
+						name
+						kind
+						interfaces {
+							name
+						}
+						possibleTypes {
+							name
+						}
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+				}
+			`,
+		},
+
+		{
+			Schema: starwarsSchemaNoIntrospection,
+			Query: `
+				{
+					__type(name: "Droid") {
+						name
+						fields {
+							name
+							args {
+								name
+								type {
+									name
+								}
+								defaultValue
+							}
+							type {
+								name
+								kind
+							}
+						}
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+				}
+			`,
+		},
+
+		{
+			Schema: starwarsSchemaNoIntrospection,
+			Query: `
+				{
+					__type(name: "Episode") {
+						enumValues {
+							name
+						}
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+				}
+			`,
+		},
+
+		{
+			Schema: starwarsSchemaNoIntrospection,
+			Query: `
+				{
+					__schema {
+						directives {
+							name
+							description
+							locations
+							args {
+								name
+								description
+								type {
+									kind
+									ofType {
+										kind
+										name
+									}
+								}
+							}
+						}
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+				}
+			`,
+		},
+	})
+}
+
 func TestMutationOrder(t *testing.T) {
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{


### PR DESCRIPTION
Allows the server to disable schema introspection.

This basically just gates the `__type`, `__typename`, and `__schema` introspection schema behind a `SchemaOpt`. gqlgen recently implemented similar functionality (https://github.com/99designs/gqlgen/pull/447), albeit also on a per-request basis. I think this functionality would be quite desired for running GraphQL servers in production.

Thoughts?