### PR TITLE
Handle large Float value that come without decimal point

### DIFF
--- a/internal/common/literals.go
+++ b/internal/common/literals.go
@@ -24,10 +24,19 @@ func (lit *BasicLit) Value(vars map[string]interface{}) interface{} {
 	switch lit.Type {
 	case scanner.Int:
 		value, err := strconv.ParseInt(lit.Text, 10, 32)
-		if err != nil {
-			panic(err)
+		if err == nil {
+			return int32(value)
 		}
-		return int32(value)
+		if numError, ok := err.(*strconv.NumError); ok {
+			if numError.Err == strconv.ErrRange {
+				val, e := strconv.ParseFloat(lit.Text, 64)
+				if e != nil {
+					panic(e)
+				}
+				return val
+			}
+		}
+		panic(err)
 
 	case scanner.Float:
 		value, err := strconv.ParseFloat(lit.Text, 64)


### PR DESCRIPTION
This change is to make the library more tolerant to the large Float value number that is greater than `2^32-1` but doesn't come with decimal point `.`
Currently, when a Float input takes a number that is greater than 32 bit, the library crashes.  E.g.
```
"graphql: panic occurred: strconv.ParseInt: parsing \"1554745767989\": value out of range"`. 
```