### PR TITLE
Resolve schema parsing data races

### DIFF
--- a/graphql_test.go
+++ b/graphql_test.go
@@ -164,6 +164,8 @@ func (r *discussPlanResolver) DismissVader(ctx context.Context) (string, error) 
 }
 
 func TestHelloWorld(t *testing.T) {
+	t.Parallel()
+
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
 			Schema: graphql.MustParseSchema(`
@@ -212,6 +214,8 @@ func TestHelloWorld(t *testing.T) {
 }
 
 func TestHelloSnake(t *testing.T) {
+	t.Parallel()
+
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
 			Schema: graphql.MustParseSchema(`
@@ -260,6 +264,8 @@ func TestHelloSnake(t *testing.T) {
 }
 
 func TestHelloSnakeArguments(t *testing.T) {
+	t.Parallel()
+
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
 			Schema: graphql.MustParseSchema(`
@@ -360,6 +366,8 @@ func (r *testNilInterfaceResolver) C() (interface{ Z() int32 }, error) {
 }
 
 func TestNilInterface(t *testing.T) {
+	t.Parallel()
+
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
 			Schema: graphql.MustParseSchema(`
@@ -403,6 +411,8 @@ func TestNilInterface(t *testing.T) {
 }
 
 func TestErrorPropagationInLists(t *testing.T) {
+	t.Parallel()
+
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
 			Schema: graphql.MustParseSchema(`
@@ -631,6 +641,8 @@ func TestErrorPropagationInLists(t *testing.T) {
 }
 
 func TestErrorWithExtensions(t *testing.T) {
+	t.Parallel()
+
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
 			Schema: graphql.MustParseSchema(`
@@ -670,6 +682,8 @@ func TestErrorWithExtensions(t *testing.T) {
 }
 
 func TestErrorWithNoExtensions(t *testing.T) {
+	t.Parallel()
+
 	err := errors.New("I find your lack of faith disturbing")
 
 	gqltesting.RunTests(t, []*gqltesting.Test{
@@ -1074,6 +1088,8 @@ func (r *testDeprecatedDirectiveResolver) C() int32 {
 }
 
 func TestDeprecatedDirective(t *testing.T) {
+	t.Parallel()
+
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
 			Schema: graphql.MustParseSchema(`
@@ -2064,6 +2080,8 @@ func TestIntrospectionDisableIntrospection(t *testing.T) {
 }
 
 func TestMutationOrder(t *testing.T) {
+	t.Parallel()
+
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
 			Schema: graphql.MustParseSchema(`
@@ -2111,6 +2129,8 @@ func TestMutationOrder(t *testing.T) {
 }
 
 func TestTime(t *testing.T) {
+	t.Parallel()
+
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
 			Schema: graphql.MustParseSchema(`
@@ -2150,6 +2170,8 @@ func (r *resolverWithUnexportedMethod) changeTheNumber(args struct{ NewNumber in
 }
 
 func TestUnexportedMethod(t *testing.T) {
+	t.Parallel()
+
 	_, err := graphql.ParseSchema(`
 		schema {
 			mutation: Mutation
@@ -2171,6 +2193,8 @@ func (r *resolverWithUnexportedField) ChangeTheNumber(args struct{ newNumber int
 }
 
 func TestUnexportedField(t *testing.T) {
+	t.Parallel()
+
 	_, err := graphql.ParseSchema(`
 		schema {
 			mutation: Mutation
@@ -2323,6 +2347,8 @@ func (r *inputResolver) ID(args struct{ Value graphql.ID }) graphql.ID {
 }
 
 func TestInput(t *testing.T) {
+	t.Parallel()
+
 	coercionSchema := graphql.MustParseSchema(`
 		schema {
 			query: Query
@@ -2511,6 +2537,8 @@ func (r *childResolver) NilChild() *childResolver {
 }
 
 func TestErrorPropagation(t *testing.T) {
+	t.Parallel()
+
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
 			Schema: graphql.MustParseSchema(`

--- a/internal/exec/resolvable/meta.go
+++ b/internal/exec/resolvable/meta.go
@@ -9,21 +9,27 @@ import (
 	"github.com/graph-gophers/graphql-go/introspection"
 )
 
-var MetaSchema *Object
-var MetaType *Object
+// Meta defines the details of the metadata schema for introspection.
+type Meta struct {
+	FieldSchema   Field
+	FieldType     Field
+	FieldTypename Field
+	Schema        *Object
+	Type          *Object
+}
 
-func init() {
+func newMeta(s *schema.Schema) *Meta {
 	var err error
-	b := newBuilder(schema.Meta)
+	b := newBuilder(s)
 
-	metaSchema := schema.Meta.Types["__Schema"].(*schema.Object)
-	MetaSchema, err = b.makeObjectExec(metaSchema.Name, metaSchema.Fields, nil, false, reflect.TypeOf(&introspection.Schema{}))
+	metaSchema := s.Types["__Schema"].(*schema.Object)
+	so, err := b.makeObjectExec(metaSchema.Name, metaSchema.Fields, nil, false, reflect.TypeOf(&introspection.Schema{}))
 	if err != nil {
 		panic(err)
 	}
 
-	metaType := schema.Meta.Types["__Type"].(*schema.Object)
-	MetaType, err = b.makeObjectExec(metaType.Name, metaType.Fields, nil, false, reflect.TypeOf(&introspection.Type{}))
+	metaType := s.Types["__Type"].(*schema.Object)
+	t, err := b.makeObjectExec(metaType.Name, metaType.Fields, nil, false, reflect.TypeOf(&introspection.Type{}))
 	if err != nil {
 		panic(err)
 	}
@@ -31,28 +37,36 @@ func init() {
 	if err := b.finish(); err != nil {
 		panic(err)
 	}
-}
 
-var MetaFieldTypename = Field{
-	Field: schema.Field{
-		Name: "__typename",
-		Type: &common.NonNull{OfType: schema.Meta.Types["String"]},
-	},
-	TraceLabel: fmt.Sprintf("GraphQL field: __typename"),
-}
+	fieldTypename := Field{
+		Field: schema.Field{
+			Name: "__typename",
+			Type: &common.NonNull{OfType: s.Types["String"]},
+		},
+		TraceLabel: fmt.Sprintf("GraphQL field: __typename"),
+	}
 
-var MetaFieldSchema = Field{
-	Field: schema.Field{
-		Name: "__schema",
-		Type: schema.Meta.Types["__Schema"],
-	},
-	TraceLabel: fmt.Sprintf("GraphQL field: __schema"),
-}
+	fieldSchema := Field{
+		Field: schema.Field{
+			Name: "__schema",
+			Type: s.Types["__Schema"],
+		},
+		TraceLabel: fmt.Sprintf("GraphQL field: __schema"),
+	}
 
-var MetaFieldType = Field{
-	Field: schema.Field{
-		Name: "__type",
-		Type: schema.Meta.Types["__Type"],
-	},
-	TraceLabel: fmt.Sprintf("GraphQL field: __type"),
+	fieldType := Field{
+		Field: schema.Field{
+			Name: "__type",
+			Type: s.Types["__Type"],
+		},
+		TraceLabel: fmt.Sprintf("GraphQL field: __type"),
+	}
+
+	return &Meta{
+		FieldSchema:   fieldSchema,
+		FieldTypename: fieldTypename,
+		FieldType:     fieldType,
+		Schema:        so,
+		Type:          t,
+	}
 }

--- a/internal/exec/resolvable/resolvable.go
+++ b/internal/exec/resolvable/resolvable.go
@@ -12,6 +12,7 @@ import (
 )
 
 type Schema struct {
+	*Meta
 	schema.Schema
 	Query        Resolvable
 	Mutation     Resolvable
@@ -88,6 +89,7 @@ func ApplyResolver(s *schema.Schema, resolver interface{}) (*Schema, error) {
 	}
 
 	return &Schema{
+		Meta:         newMeta(s),
 		Schema:       *s,
 		Resolver:     reflect.ValueOf(resolver),
 		Query:        query,

--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -39,7 +39,7 @@ func ApplyOperation(r *Request, s *resolvable.Schema, op *query.Operation) []Sel
 	case query.Subscription:
 		obj = s.Subscription.(*resolvable.Object)
 	}
-	return applySelectionSet(r, obj, op.Selections)
+	return applySelectionSet(r, s, obj, op.Selections)
 }
 
 type Selection interface {
@@ -70,7 +70,7 @@ func (*SchemaField) isSelection()   {}
 func (*TypeAssertion) isSelection() {}
 func (*TypenameField) isSelection() {}
 
-func applySelectionSet(r *Request, e *resolvable.Object, sels []query.Selection) (flattenedSels []Selection) {
+func applySelectionSet(r *Request, s *resolvable.Schema, e *resolvable.Object, sels []query.Selection) (flattenedSels []Selection) {
 	for _, sel := range sels {
 		switch sel := sel.(type) {
 		case *query.Field:
@@ -91,9 +91,9 @@ func applySelectionSet(r *Request, e *resolvable.Object, sels []query.Selection)
 			case "__schema":
 				if !r.DisableIntrospection {
 					flattenedSels = append(flattenedSels, &SchemaField{
-						Field:       resolvable.MetaFieldSchema,
+						Field:       s.Meta.FieldSchema,
 						Alias:       field.Alias.Name,
-						Sels:        applySelectionSet(r, resolvable.MetaSchema, field.Selections),
+						Sels:        applySelectionSet(r, s, s.Meta.Schema, field.Selections),
 						Async:       true,
 						FixedResult: reflect.ValueOf(introspection.WrapSchema(r.Schema)),
 					})
@@ -114,9 +114,9 @@ func applySelectionSet(r *Request, e *resolvable.Object, sels []query.Selection)
 					}
 
 					flattenedSels = append(flattenedSels, &SchemaField{
-						Field:       resolvable.MetaFieldType,
+						Field:       s.Meta.FieldType,
 						Alias:       field.Alias.Name,
-						Sels:        applySelectionSet(r, resolvable.MetaType, field.Selections),
+						Sels:        applySelectionSet(r, s, s.Meta.Type, field.Selections),
 						Async:       true,
 						FixedResult: reflect.ValueOf(introspection.WrapType(t)),
 					})
@@ -140,7 +140,7 @@ func applySelectionSet(r *Request, e *resolvable.Object, sels []query.Selection)
 					}
 				}
 
-				fieldSels := applyField(r, fe.ValueExec, field.Selections)
+				fieldSels := applyField(r, s, fe.ValueExec, field.Selections)
 				flattenedSels = append(flattenedSels, &SchemaField{
 					Field:      *fe,
 					Alias:      field.Alias.Name,
@@ -156,14 +156,14 @@ func applySelectionSet(r *Request, e *resolvable.Object, sels []query.Selection)
 			if skipByDirective(r, frag.Directives) {
 				continue
 			}
-			flattenedSels = append(flattenedSels, applyFragment(r, e, &frag.Fragment)...)
+			flattenedSels = append(flattenedSels, applyFragment(r, s, e, &frag.Fragment)...)
 
 		case *query.FragmentSpread:
 			spread := sel
 			if skipByDirective(r, spread.Directives) {
 				continue
 			}
-			flattenedSels = append(flattenedSels, applyFragment(r, e, &r.Doc.Fragments.Get(spread.Name.Name).Fragment)...)
+			flattenedSels = append(flattenedSels, applyFragment(r, s, e, &r.Doc.Fragments.Get(spread.Name.Name).Fragment)...)
 
 		default:
 			panic("invalid type")
@@ -172,7 +172,7 @@ func applySelectionSet(r *Request, e *resolvable.Object, sels []query.Selection)
 	return
 }
 
-func applyFragment(r *Request, e *resolvable.Object, frag *query.Fragment) []Selection {
+func applyFragment(r *Request, s *resolvable.Schema, e *resolvable.Object, frag *query.Fragment) []Selection {
 	if frag.On.Name != "" && frag.On.Name != e.Name {
 		a, ok := e.TypeAssertions[frag.On.Name]
 		if !ok {
@@ -181,18 +181,18 @@ func applyFragment(r *Request, e *resolvable.Object, frag *query.Fragment) []Sel
 
 		return []Selection{&TypeAssertion{
 			TypeAssertion: *a,
-			Sels:          applySelectionSet(r, a.TypeExec.(*resolvable.Object), frag.Selections),
+			Sels:          applySelectionSet(r, s, a.TypeExec.(*resolvable.Object), frag.Selections),
 		}}
 	}
-	return applySelectionSet(r, e, frag.Selections)
+	return applySelectionSet(r, s, e, frag.Selections)
 }
 
-func applyField(r *Request, e resolvable.Resolvable, sels []query.Selection) []Selection {
+func applyField(r *Request, s *resolvable.Schema, e resolvable.Resolvable, sels []query.Selection) []Selection {
 	switch e := e.(type) {
 	case *resolvable.Object:
-		return applySelectionSet(r, e, sels)
+		return applySelectionSet(r, s, e, sels)
 	case *resolvable.List:
-		return applyField(r, e.Elem, sels)
+		return applyField(r, s, e.Elem, sels)
 	case *resolvable.Scalar:
 		return nil
 	default:

--- a/internal/exec/subscribe.go
+++ b/internal/exec/subscribe.go
@@ -29,7 +29,7 @@ func (r *Request) Subscribe(ctx context.Context, s *resolvable.Schema, op *query
 
 		sels := selected.ApplyOperation(&r.Request, s, op)
 		var fields []*fieldToExec
-		collectFieldsToResolve(sels, s.Resolver, &fields, make(map[string]*fieldToExec))
+		collectFieldsToResolve(sels, s, s.Resolver, &fields, make(map[string]*fieldToExec))
 
 		// TODO: move this check into validation.Validate
 		if len(fields) != 1 {
@@ -120,7 +120,7 @@ func (r *Request) Subscribe(ctx context.Context, s *resolvable.Schema, op *query
 						defer subR.handlePanic(subCtx)
 
 						var buf bytes.Buffer
-						subR.execSelectionSet(subCtx, f.sels, f.field.Type, &pathSegment{nil, f.field.Alias}, resp, &buf)
+						subR.execSelectionSet(subCtx, f.sels, f.field.Type, &pathSegment{nil, f.field.Alias}, s, resp, &buf)
 
 						propagateChildError := false
 						if _, nonNullChild := f.field.Type.(*common.NonNull); nonNullChild && resolvedToNull(&buf) {

--- a/internal/schema/meta.go
+++ b/internal/schema/meta.go
@@ -1,13 +1,20 @@
 package schema
 
-var Meta *Schema
-
 func init() {
-	Meta = &Schema{} // bootstrap
-	Meta = New()
-	if err := Meta.Parse(metaSrc, false); err != nil {
+	_ = newMeta()
+}
+
+// newMeta initializes an instance of the meta Schema.
+func newMeta() *Schema {
+	s := &Schema{
+		entryPointNames: make(map[string]string),
+		Types:           make(map[string]NamedType),
+		Directives:      make(map[string]*DirectiveDecl),
+	}
+	if err := s.Parse(metaSrc, false); err != nil {
 		panic(err)
 	}
+	return s
 }
 
 var metaSrc = `

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -238,10 +238,11 @@ func New() *Schema {
 		Types:           make(map[string]NamedType),
 		Directives:      make(map[string]*DirectiveDecl),
 	}
-	for n, t := range Meta.Types {
+	m := newMeta()
+	for n, t := range m.Types {
 		s.Types[n] = t
 	}
-	for n, d := range Meta.Directives {
+	for n, d := range m.Directives {
 		s.Directives[n] = d
 	}
 	return s


### PR DESCRIPTION
Moving package globals to per-schema objects, resolving data races from parsing multiple schemas in parallel. While this has limited likelihood in production code (since typically just 1 schema would be used), tests are a different story

This change is _not_ well tested. I've verified that the race detection is no longer triggered within this project, or within one of my own that uses the library, while the tests still pass.

The CI build for the project will also need to be updated to execute tests with the race detector enabled going forward.