### PR TITLE
Add option for custom panic handler

### DIFF
--- a/errors/panic_handler.go
+++ b/errors/panic_handler.go
@@ -1,0 +1,18 @@
+package errors
+
+import (
+	"context"
+)
+
+// PanicHandler is the interface used to create custom panic errors that occur during query execution
+type PanicHandler interface {
+	MakePanicError(ctx context.Context, value interface{}) *QueryError
+}
+
+// DefaultPanicHandler is the default PanicHandler
+type DefaultPanicHandler struct{}
+
+// MakePanicError creates a new QueryError from a panic that occurred during execution
+func (h *DefaultPanicHandler) MakePanicError(ctx context.Context, value interface{}) *QueryError {
+	return Errorf("graphql: panic occurred: %v", value)
+}


### PR DESCRIPTION
This PR adds an option to provide a custom error handler for panics.

By giving more control over the panic error creation, it's possible for the consumer of this library to capture the panics and format the message, add extenstions and send to 3rd party error reporting services.

I opted for keeping existing `log.LogPanic` functionality to not make breaking changes. But you can write your own panic handler that implements both interfaces. Here's an example of how I'm using a custom panic handler. 

```go
// main.go
...
panicHandler := &myerrorlib.PanicHandler{}
rootSchema := graphql.MustParseSchema(
	schema.GetRootSchema(),
	resolvers.NewRootResolver(),
	graphql.Logger(panicHandler),
	graphql.PanicHandler(panicHandler),
)
...
```
and then in my case I'll provide a custom PanicHandler like so:
```go
package myerrorlib

import (
	"context"
	"github.com/graph-gophers/graphql-go/errors"
)

type PanicHandler struct{}

// LogPanic is a no-op to silence the default panic logging.
// Implements the Logger interface from `graph-gophers/graphql-go/log` 
func (p *PanicHandler) LogPanic(ctx context.Context, value interface{}) {
	return
}

// MakePanicError logs and reports the error using the common error library.
// Implements the PanicHandler interface from `graph-gophers/graphql-go/errors` 
func (p *PanicHandler) MakePanicError(
	ctx context.Context,
	value interface{},
) *errors.QueryError {
	// create and report custom error for 3rd party logging
	err := createAndReportErrorf(ctx, "panic: %s", value)
	return &errors.QueryError{
		Message:    err.Error(),
		// Decorate error with status code, trace id etc...
		Extensions: err.Extensions(),
	}
}
```