### PR TITLE
Fix bug: make Schema.Validate accept arguments

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -142,13 +142,13 @@ type Response struct {
 }
 
 // Validate validates the given query with the schema.
-func (s *Schema) Validate(queryString string) []*errors.QueryError {
+func (s *Schema) Validate(queryString string, args map[string]interface{}) []*errors.QueryError {
 	doc, qErr := query.Parse(queryString)
 	if qErr != nil {
 		return []*errors.QueryError{qErr}
 	}
 
-	return validation.Validate(s.schema, doc, nil, s.maxDepth)
+	return validation.Validate(s.schema, doc, args, s.maxDepth)
 }
 
 // Exec executes the given query with the schema's resolver. It panics if the schema was created


### PR DESCRIPTION
Make `Schema.Validate` accept arguments and pass them over to `validation.Validate`
to allow parameterized queries to be validated correctly.

----

I'm having a problem with [`func (s *Schema) Validate(queryString string) []*errors.QueryError`](https://github.com/graph-gophers/graphql-go/blob/8f92f34fc59823d34fc08bfdc9fd266b854e2b50/graphql.go#L145). It doesn't take the _arguments_ as a parameter and thus fails to validate a parameterized query like this one:
```graphql
query($uid: ID!) {
  customer(id: $uid) {
    id
    firstName
    lastName
  }
}
```
```
graphql: Variable "uid" has invalid value null.
Expected type "ID!", found null. (line 1, column 8);
```

Without parameterization it validates just fine:
```graphql
query {
  customer(id: "foo") {
    id
    firstName
    lastName
  }
}
```

Now I'm wondering why [`func (s *Schema) Validate`](https://github.com/graph-gophers/graphql-go/blob/8f92f34fc59823d34fc08bfdc9fd266b854e2b50/graphql.go#L145) won't actually take `(queryString string, args map[string]interface{})` instead since [`func Validate`](https://github.com/graph-gophers/graphql-go/blob/8f92f34fc59823d34fc08bfdc9fd266b854e2b50/internal/validation/validation.go#L66) takes `nil` arguments right there: [`validation.Validate(s.schema, doc, nil, s.maxDepth)`](https://github.com/graph-gophers/graphql-go/blob/8f92f34fc59823d34fc08bfdc9fd266b854e2b50/graphql.go#L151).

I just tried passing the argument through and parameterized queries are validated correctly now. Is _not taking the args as parameter_ to [`func (s *Schema) Validate`](https://github.com/graph-gophers/graphql-go/blob/8f92f34fc59823d34fc08bfdc9fd266b854e2b50/graphql.go#L145) a deliberate design decision or just a misunderstanding that's fixed by this PR?