### PR TITLE
Validation for subscriptions in schema.Exec

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -181,7 +181,7 @@ func (s *Schema) exec(ctx context.Context, queryString string, operationName str
 
 	// Subscriptions are not valid in Exec. Use schema.Subscribe() instead.
 	if op.Type == query.Subscription {
-		return &Response{Errors: []*errors.QueryError{errors.Errorf("graphql-ws protocol header is missing")}}
+		return &Response{Errors: []*errors.QueryError{&errors.QueryError{ Message: "graphql-ws protocol header is missing" }}}
 	}
 
 	// Fill in variables with the defaults from the operation

--- a/graphql.go
+++ b/graphql.go
@@ -179,6 +179,11 @@ func (s *Schema) exec(ctx context.Context, queryString string, operationName str
 		return &Response{Errors: []*errors.QueryError{errors.Errorf("%s", err)}}
 	}
 
+	// Subscriptions are not valid in Exec. Use schema.Subscribe() instead.
+	if op.Type == query.Subscription {
+		return &Response{Errors: []*errors.QueryError{errors.Errorf("graphql-ws protocol header is missing")}}
+	}
+
 	// Fill in variables with the defaults from the operation
 	if variables == nil {
 		variables = make(map[string]interface{}, len(op.Vars))

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -3072,3 +3072,33 @@ func TestSchema_Exec_without_resolver(t *testing.T) {
 		})
 	}
 }
+
+type subscriptionsInExecResolver struct{}
+
+func (r *subscriptionsInExecResolver) AppUpdated() <-chan string {
+	return make(chan string)
+}
+
+func TestSubscriptions_In_Exec(t *testing.T) {
+	gqltesting.RunTest(t, &gqltesting.Test{
+		Schema: graphql.MustParseSchema(`
+			schema {
+				subscription: Subscription
+			}
+
+			type Subscription {
+				appUpdated : String!
+			}
+	`, &subscriptionsInExecResolver{}),
+		Query: `
+			subscription {
+				appUpdated
+		  	}
+		`,
+		ExpectedErrors: []*gqlerrors.QueryError{
+			{
+				Message: "graphql-ws protocol header is missing",
+			},
+		},
+	})
+}


### PR DESCRIPTION
I've added validation for subscriptions in `scheme.Exec` which is invalid. I also added unit test for it.

PR for https://github.com/graph-gophers/graphql-go/issues/348.