### PR TITLE
Add location and path information to errors from custom type validation

### DIFF
--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -135,12 +135,28 @@ func applySelectionSet(r *Request, s *resolvable.Schema, e *resolvable.Object, s
 					var err error
 					packedArgs, err = fe.ArgsPacker.Pack(args)
 					if err != nil {
-						r.AddError(errors.Errorf("%s", err))
+						curErr := errors.Errorf("%s", err)
+						// the error location will always be the first argument
+						// because the Pack interface provided ArgsPacker does
+						// not support detailed error information tracing
+						curErr.Locations = append(curErr.Locations, sel.Arguments[0].Value.Location())
+						// record error path, full path will be constructed recursively
+						curErr.Path = append(curErr.Path, field.Name.Name)
+						curErr.Path = append(curErr.Path, sel.Arguments[0].Name.Name)
+						r.AddError(curErr)
 						return
 					}
 				}
 
 				fieldSels := applyField(r, s, fe.ValueExec, field.Selections)
+				r.Mu.Lock()
+				if len(r.Errs) > 0 {
+					// recursively prepend error path
+					r.Errs[0].Path = append([]interface{}{field.Name.Name}, r.Errs[0].Path...)
+					// it is ok to use index 0 becasue selection process will
+					// panick and return with exactly one error
+				}
+				r.Mu.Unlock()
 				flattenedSels = append(flattenedSels, &SchemaField{
 					Field:      *fe,
 					Alias:      field.Alias.Name,


### PR DESCRIPTION
## Description
use the errors interface provided by the graphql library to add location and path for query argument errors for custom types

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
follow [GraphQL spec](https://graphql.github.io/graphql-spec/June2018/#sec-Errors)
<!--- If it fixes an open issue, please link to the issue here. -->
fix #352 
fix ethereum/go-ethereum#20042


## How Has This Been Tested?
tested in the setup of ethereum/go-ethereum with the following queries:
```graphql
{
  block(hash: 99) {
    hash
}
```
```graphql
{
  block(hash: "99") {
    hash
}
```
```graphql
{
  block(hash: "0xff") {
    hash
}
```
```graphql
{
  block {
    tooShort: account(address:"0xffff") {
      balance
    }
    notHexadecimal: account(address: "foobarbaz") {
      balance
    }
  }
}
```

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Improvement/refactoring (non-breaking change that doesn't add any features but makes things better)
