### PR TITLE
Fix #357 - Allow passing integers as arguments to graphql.Time parameters

### DIFF
--- a/time.go
+++ b/time.go
@@ -31,7 +31,7 @@ func (t *Time) UnmarshalGraphQL(input interface{}) error {
 		var err error
 		t.Time, err = time.Parse(time.RFC3339, input)
 		return err
-	case int:
+	case int32, int64:
 		t.Time = time.Unix(int64(input), 0)
 		return nil
 	case float64:

--- a/time.go
+++ b/time.go
@@ -31,8 +31,11 @@ func (t *Time) UnmarshalGraphQL(input interface{}) error {
 		var err error
 		t.Time, err = time.Parse(time.RFC3339, input)
 		return err
-	case int32, int64:
+	case int32:
 		t.Time = time.Unix(int64(input), 0)
+		return nil
+	case int64:
+		t.Time = time.Unix(input, 0)
 		return nil
 	case float64:
 		t.Time = time.Unix(int64(input), 0)


### PR DESCRIPTION
Read this for details: https://github.com/graph-gophers/graphql-go/issues/357

TLDR version: This PR replaces this switch case in `time.go`

```
case int:
	t.Time = time.Unix(int64(input), 0)
	return nil
```

with this

```
case int32:
	t.Time = time.Unix(int64(input), 0)
	return nil
case int64:
	t.Time = time.Unix(input, 0)
	return nil
```

so we can pass integers as `graphql.Time` when the application is compiled for 64-bit architecture.