### PR TITLE
Allow `schema` to be omitted when using default root op names

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,9 +45,6 @@ func (_ *query) Hello() string { return "Hello, world!" }
 
 func main() {
         s := `
-                schema {
-                        query: Query
-                }
                 type Query {
                         hello: String!
                 }

--- a/internal/exec/resolvable/resolvable.go
+++ b/internal/exec/resolvable/resolvable.go
@@ -362,7 +362,8 @@ func (b *execBuilder) makeFieldExec(typeName string, f *schema.Field, m reflect.
 	var out reflect.Type
 	if methodIndex != -1 {
 		out = m.Type.Out(0)
-		if typeName == "Subscription" && out.Kind() == reflect.Chan {
+		sub, ok := b.schema.EntryPoints["subscription"]
+		if ok && typeName == sub.TypeName() && out.Kind() == reflect.Chan {
 			out = m.Type.Out(0).Elem()
 		}
 	} else {

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -286,6 +286,21 @@ func (s *Schema) Parse(schemaString string, useStringDescriptions bool) error {
 		}
 	}
 
+	// https://graphql.github.io/graphql-spec/June2018/#sec-Root-Operation-Types
+	// > While any type can be the root operation type for a GraphQL operation, the type system definition language can
+	// > omit the schema definition when the query, mutation, and subscription root types are named Query, Mutation,
+	// > and Subscription respectively.
+	if len(s.entryPointNames) == 0 {
+		if _, ok := s.Types["Query"]; ok {
+			s.entryPointNames["query"] = "Query"
+		}
+		if _, ok := s.Types["Mutation"]; ok {
+			s.entryPointNames["mutation"] = "Mutation"
+		}
+		if _, ok := s.Types["Subscription"]; ok {
+			s.entryPointNames["subscription"] = "Subscription"
+		}
+	}
 	s.EntryPoints = make(map[string]NamedType)
 	for key, name := range s.entryPointNames {
 		t, ok := s.Types[name]

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -166,6 +166,46 @@ func TestParse(t *testing.T) {
 			},
 		},
 		{
+			name: "Default Root schema",
+			sdl: `
+			type Query {
+				hello: String!
+			}
+			type Mutation {
+				concat(a: String!, b: String!): String!
+			}
+			`,
+			validateSchema: func(s *schema.Schema) error {
+				typq, ok := s.Types["Query"].(*schema.Object)
+				if !ok {
+					return fmt.Errorf("type %q not found", "Query")
+				}
+				helloField := typq.Fields.Get("hello")
+				if helloField == nil {
+					return fmt.Errorf("field %q not found", "hello")
+				}
+				if helloField.Type.String() != "String!" {
+					return fmt.Errorf("field %q has an invalid type: %q", "hello", helloField.Type.String())
+				}
+
+				typm, ok := s.Types["Mutation"].(*schema.Object)
+				if !ok {
+					return fmt.Errorf("type %q not found", "Mutation")
+				}
+				concatField := typm.Fields.Get("concat")
+				if concatField == nil {
+					return fmt.Errorf("field %q not found", "concat")
+				}
+				if concatField.Type.String() != "String!" {
+					return fmt.Errorf("field %q has an invalid type: %q", "concat", concatField.Type.String())
+				}
+				if len(concatField.Args) != 2 || concatField.Args[0] == nil || concatField.Args[1] == nil || concatField.Args[0].Type.String() != "String!" || concatField.Args[1].Type.String() != "String!" {
+					return fmt.Errorf("field %q has an invalid args: %+v", "concat", concatField.Args)
+				}
+				return nil
+			},
+		},
+		{
 			name: "Extend type",
 			sdl: `
 			type Query {

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -24,6 +24,9 @@ func (s *Schema) Subscribe(ctx context.Context, queryString string, operationNam
 	if s.res.Resolver == (reflect.Value{}) {
 		return nil, errors.New("schema created without resolver, can not subscribe")
 	}
+	if _, ok := s.schema.EntryPoints["subscription"]; !ok {
+		return nil, errors.New("no subscriptions are offered by the schema")
+	}
 	return s.subscribe(ctx, queryString, operationName, variables, s.res), nil
 }
 


### PR DESCRIPTION
Fixes #304 