### PR TITLE
Add support for directives in schema parser

### DIFF
--- a/internal/common/values.go
+++ b/internal/common/values.go
@@ -6,12 +6,13 @@ import (
 
 // http://facebook.github.io/graphql/draft/#InputValueDefinition
 type InputValue struct {
-	Name    Ident
-	Type    Type
-	Default Literal
-	Desc    string
-	Loc     errors.Location
-	TypeLoc errors.Location
+	Name       Ident
+	Type       Type
+	Default    Literal
+	Desc       string
+	Directives DirectiveList
+	Loc        errors.Location
+	TypeLoc    errors.Location
 }
 
 type InputValueList []*InputValue
@@ -37,6 +38,7 @@ func ParseInputValue(l *Lexer) *InputValue {
 		l.ConsumeToken('=')
 		p.Default = ParseLiteral(l, true)
 	}
+	p.Directives = ParseDirectives(l)
 	return p
 }
 


### PR DESCRIPTION
This adds support for parsing directives in the schema.

It's probably of limited use for now but it's mostly so it stops crashing on schemas with directives, and it's a first step towards a better directive support.