### PR TITLE
WIP: add parallel breath-first execution

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -39,4 +39,4 @@ func (err *QueryError) Error() string {
 	return str
 }
 
-var _ error = &QueryError{}
+var _ error = (*QueryError)(nil)

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -3,10 +3,8 @@ package exec
 import (
 	"bytes"
 	"context"
-	"encoding/json"
 	"fmt"
 	"reflect"
-	"sync"
 
 	"github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/internal/common"
@@ -40,12 +38,55 @@ func makePanicError(value interface{}) *errors.QueryError {
 	return errors.Errorf("graphql: panic occurred: %v", value)
 }
 
+func (r *Request) process(ctx context.Context, w *objWriter, nodes []*execNode, s *resolvable.Schema) {
+	queue := nodes
+	for len(queue) > 0 {
+		batch := queue
+		queue = nil
+
+		// run the whole batch (everything from the current level) concurrently.
+		result := make(chan *execNode, len(batch))
+		for _, n := range batch {
+			go func(n *execNode) {
+				if n.field != nil {
+					r.resolveNode(ctx, n, true)
+					expandNode(n, s)
+				}
+				result <- n
+			}(n)
+		}
+
+		// wait for the batch to complete and refill the queue.
+		for range batch {
+			n := <-result
+			queue = append(queue, n.children...)
+		}
+	}
+
+	for _, n := range nodes {
+		w.Write(r, n)
+	}
+}
+
 func (r *Request) Execute(ctx context.Context, s *resolvable.Schema, op *query.Operation) ([]byte, []*errors.QueryError) {
-	var out bytes.Buffer
+	out := &bytes.Buffer{}
+
 	func() {
 		defer r.handlePanic(ctx)
 		sels := selected.ApplyOperation(&r.Request, s, op)
-		r.execSelections(ctx, sels, nil, s, s.Resolver, &out, op.Type == query.Mutation)
+		nodes := collectNodes(sels, s, s.Resolver, nil, make(map[string]*execNode))
+
+		w := newObjWriter(out)
+		defer w.Flush()
+
+		if op.Type == query.Mutation {
+			// process mutations sequentially.
+			for _, n := range nodes {
+				r.process(ctx, w, []*execNode{n}, s)
+			}
+		} else {
+			r.process(ctx, w, nodes, s)
+		}
 	}()
 
 	if err := ctx.Err(); err != nil {
@@ -55,76 +96,51 @@ func (r *Request) Execute(ctx context.Context, s *resolvable.Schema, op *query.O
 	return out.Bytes(), r.Errs
 }
 
-type fieldToExec struct {
-	field    *selected.SchemaField
-	sels     []selected.Selection
-	resolver reflect.Value
-	out      *bytes.Buffer
+// execNode is used to build a tree structure that closely assembles the returned data. This in-memory representation
+// allows nodes to be resolved in a different order (e.g. concurrently or breath-first) than they are printed (which
+// is always depth-first).
+type execNode struct {
+	label    interface{}           // label for the full path (used in errors and debug output)
+	parent   *execNode             // parent node
+	children []*execNode           // child nodes
+	typ      common.Type           // GraphQL type of the node
+	field    *selected.SchemaField // field information (might be nil within lists)
+	sels     []selected.Selection  // selected fields
+	resolver reflect.Value         // resolver for resolving the selected fields
+	value    reflect.Value         // resolved value
+	err      *errors.QueryError    // error while resolving the value
 }
 
-func resolvedToNull(b *bytes.Buffer) bool {
-	return bytes.Equal(b.Bytes(), []byte("null"))
-}
-
-func (r *Request) execSelections(ctx context.Context, sels []selected.Selection, path *pathSegment, s *resolvable.Schema, resolver reflect.Value, out *bytes.Buffer, serially bool) {
-	async := !serially && selected.HasAsyncSel(sels)
-
-	var fields []*fieldToExec
-	collectFieldsToResolve(sels, s, resolver, &fields, make(map[string]*fieldToExec))
-
-	if async {
-		var wg sync.WaitGroup
-		wg.Add(len(fields))
-		for _, f := range fields {
-			go func(f *fieldToExec) {
-				defer wg.Done()
-				defer r.handlePanic(ctx)
-				f.out = new(bytes.Buffer)
-				execFieldSelection(ctx, r, s, f, &pathSegment{path, f.field.Alias}, true)
-			}(f)
-		}
-		wg.Wait()
-	} else {
-		for _, f := range fields {
-			f.out = new(bytes.Buffer)
-			execFieldSelection(ctx, r, s, f, &pathSegment{path, f.field.Alias}, true)
-		}
+// fullPath returns the full path of the node. This path is included in all graphQL error messages.
+func (n *execNode) fullPath() []interface{} {
+	if n == nil {
+		return nil
 	}
-
-	out.WriteByte('{')
-	for i, f := range fields {
-		// If a non-nullable child resolved to null, an error was added to the
-		// "errors" list in the response, so this field resolves to null.
-		// If this field is non-nullable, the error is propagated to its parent.
-		if _, ok := f.field.Type.(*common.NonNull); ok && resolvedToNull(f.out) {
-			out.Reset()
-			out.Write([]byte("null"))
-			return
-		}
-
-		if i > 0 {
-			out.WriteByte(',')
-		}
-		out.WriteByte('"')
-		out.WriteString(f.field.Alias)
-		out.WriteByte('"')
-		out.WriteByte(':')
-		out.Write(f.out.Bytes())
-	}
-	out.WriteByte('}')
+	return append(n.parent.fullPath(), n.label)
 }
 
-func collectFieldsToResolve(sels []selected.Selection, s *resolvable.Schema, resolver reflect.Value, fields *[]*fieldToExec, fieldByAlias map[string]*fieldToExec) {
+// add appends additional children to this node.
+func (n *execNode) add(cs []*execNode) {
+	for i := range cs {
+		cs[i].parent = n
+	}
+	n.children = append(n.children, cs...)
+}
+
+// collectNodes transforms a selection into a set of nodes. Typename fields are resolved by adding a
+// appropriate SchemaField to the selection and type assertions are resolved by adding additional fields to the
+// targeted selections.
+func collectNodes(sels []selected.Selection, s *resolvable.Schema, resolver reflect.Value, nodes []*execNode, nodeByAlias map[string]*execNode) []*execNode {
 	for _, sel := range sels {
 		switch sel := sel.(type) {
 		case *selected.SchemaField:
-			field, ok := fieldByAlias[sel.Alias]
+			node, ok := nodeByAlias[sel.Alias]
 			if !ok { // validation already checked for conflict (TODO)
-				field = &fieldToExec{field: sel, resolver: resolver}
-				fieldByAlias[sel.Alias] = field
-				*fields = append(*fields, field)
+				node = &execNode{label: sel.Alias, field: sel, resolver: resolver, typ: sel.Type}
+				nodeByAlias[sel.Alias] = node
+				nodes = append(nodes, node)
 			}
-			field.sels = append(field.sels, sel.Sels...)
+			node.sels = append(node.sels, sel.Sels...)
 
 		case *selected.TypenameField:
 			sf := &selected.SchemaField{
@@ -132,19 +148,20 @@ func collectFieldsToResolve(sels []selected.Selection, s *resolvable.Schema, res
 				Alias:       sel.Alias,
 				FixedResult: reflect.ValueOf(typeOf(sel, resolver)),
 			}
-			*fields = append(*fields, &fieldToExec{field: sf, resolver: resolver})
+			nodes = append(nodes, &execNode{label: sel.Alias, field: sf, resolver: resolver, typ: sf.Type})
 
 		case *selected.TypeAssertion:
 			out := resolver.Method(sel.MethodIndex).Call(nil)
 			if !out[1].Bool() {
 				continue
 			}
-			collectFieldsToResolve(sel.Sels, s, out[0], fields, fieldByAlias)
+			nodes = collectNodes(sel.Sels, s, out[0], nodes, nodeByAlias)
 
 		default:
 			panic("unreachable")
 		}
 	}
+	return nodes
 }
 
 func typeOf(tf *selected.TypenameField, resolver reflect.Value) string {
@@ -160,195 +177,102 @@ func typeOf(tf *selected.TypenameField, resolver reflect.Value) string {
 	return ""
 }
 
-func execFieldSelection(ctx context.Context, r *Request, s *resolvable.Schema, f *fieldToExec, path *pathSegment, applyLimiter bool) {
+func (r *Request) resolveNode(ctx context.Context, n *execNode, applyLimiter bool) {
 	if applyLimiter {
 		r.Limiter <- struct{}{}
+		defer func() {
+			<-r.Limiter
+		}()
 	}
 
-	var result reflect.Value
-	var err *errors.QueryError
+	n.value, n.err = func() (result reflect.Value, err *errors.QueryError) {
+		traceCtx, finish := r.Tracer.TraceField(ctx, n.field.TraceLabel, n.field.TypeName, n.field.Name, !n.field.Async, n.field.Args)
+		defer func() {
+			finish(err)
+		}()
 
-	traceCtx, finish := r.Tracer.TraceField(ctx, f.field.TraceLabel, f.field.TypeName, f.field.Name, !f.field.Async, f.field.Args)
-	defer func() {
-		finish(err)
-	}()
-
-	err = func() (err *errors.QueryError) {
 		defer func() {
 			if panicValue := recover(); panicValue != nil {
 				r.Logger.LogPanic(ctx, panicValue)
 				err = makePanicError(panicValue)
-				err.Path = path.toSlice()
+				err.Path = n.fullPath()
 			}
 		}()
 
-		if f.field.FixedResult.IsValid() {
-			result = f.field.FixedResult
-			return nil
+		if n.field.FixedResult.IsValid() {
+			return n.field.FixedResult, nil
 		}
 
 		if err := traceCtx.Err(); err != nil {
-			return errors.Errorf("%s", err) // don't execute any more resolvers if context got cancelled
+			return reflect.Value{}, errors.Errorf("%s", err) // don't execute any more resolvers if context got cancelled
 		}
 
-		res := f.resolver
-		if f.field.UseMethodResolver() {
+		res := n.resolver
+		if n.field.UseMethodResolver() {
 			var in []reflect.Value
-			if f.field.HasContext {
+			if n.field.HasContext {
 				in = append(in, reflect.ValueOf(traceCtx))
 			}
-			if f.field.ArgsPacker != nil {
-				in = append(in, f.field.PackedArgs)
+			if n.field.ArgsPacker != nil {
+				in = append(in, n.field.PackedArgs)
 			}
-			callOut := res.Method(f.field.MethodIndex).Call(in)
+			callOut := res.Method(n.field.MethodIndex).Call(in)
 			result = callOut[0]
-			if f.field.HasError && !callOut[1].IsNil() {
+			if n.field.HasError && !callOut[1].IsNil() {
 				resolverErr := callOut[1].Interface().(error)
 				err := errors.Errorf("%s", resolverErr)
-				err.Path = path.toSlice()
 				err.ResolverError = resolverErr
-				if ex, ok := callOut[1].Interface().(extensionser); ok {
+				err.Path = n.fullPath()
+				if ex, ok := resolverErr.(extensionser); ok {
 					err.Extensions = ex.Extensions()
 				}
-				return err
+				return reflect.Value{}, err
 			}
-		} else {
-			// TODO extract out unwrapping ptr logic to a common place
-			if res.Kind() == reflect.Ptr {
-				res = res.Elem()
-			}
-			result = res.FieldByIndex(f.field.FieldIndex)
+			return result, nil
 		}
-		return nil
+		// TODO extract out unwrapping ptr logic to a common place
+		if res.Kind() == reflect.Ptr {
+			res = res.Elem()
+		}
+		return res.FieldByIndex(n.field.FieldIndex), nil
 	}()
-
-	if applyLimiter {
-		<-r.Limiter
-	}
-
-	if err != nil {
-		// If an error occurred while resolving a field, it should be treated as though the field
-		// returned null, and an error must be added to the "errors" list in the response.
-		r.AddError(err)
-		f.out.WriteString("null")
-		return
-	}
-
-	r.execSelectionSet(traceCtx, f.sels, f.field.Type, path, s, result, f.out)
 }
 
-func (r *Request) execSelectionSet(ctx context.Context, sels []selected.Selection, typ common.Type, path *pathSegment, s *resolvable.Schema, resolver reflect.Value, out *bytes.Buffer) {
-	t, nonNull := unwrapNonNull(typ)
+// expandNode adds the next level of unresolved children to a node n. This function must be called after
+// n itself has been resolved.
+func expandNode(n *execNode, s *resolvable.Schema) {
+	t, _ := unwrapNonNull(n.typ)
 	switch t := t.(type) {
+	case *schema.Scalar, *schema.Enum:
+		// nothing to do.
 	case *schema.Object, *schema.Interface, *schema.Union:
-		// a reflect.Value of a nil interface will show up as an Invalid value
-		if resolver.Kind() == reflect.Invalid || ((resolver.Kind() == reflect.Ptr || resolver.Kind() == reflect.Interface) && resolver.IsNil()) {
-			// If a field of a non-null type resolves to null (either because the
-			// function to resolve the field returned null or because an error occurred),
-			// add an error to the "errors" list in the response.
-			if nonNull {
-				err := errors.Errorf("graphql: got nil for non-null %q", t)
-				err.Path = path.toSlice()
-				r.AddError(err)
-			}
-			out.WriteString("null")
+		if isNull(n.value) {
 			return
 		}
-
-		r.execSelections(ctx, sels, path, s, resolver, out, false)
-		return
-	}
-
-	if !nonNull {
-		if resolver.IsNil() {
-			out.WriteString("null")
-			return
-		}
-		resolver = resolver.Elem()
-	}
-
-	switch t := t.(type) {
+		children := collectNodes(n.sels, s, n.value, nil, make(map[string]*execNode))
+		n.add(children)
 	case *common.List:
-		r.execList(ctx, sels, t, path, s, resolver, out)
-
-	case *schema.Scalar:
-		v := resolver.Interface()
-		data, err := json.Marshal(v)
-		if err != nil {
-			panic(errors.Errorf("could not marshal %v: %s", v, err))
-		}
-		out.Write(data)
-
-	case *schema.Enum:
-		var stringer fmt.Stringer = resolver
-		if s, ok := resolver.Interface().(fmt.Stringer); ok {
-			stringer = s
-		}
-		name := stringer.String()
-		var valid bool
-		for _, v := range t.Values {
-			if v.Name == name {
-				valid = true
-				break
-			}
-		}
-		if !valid {
-			err := errors.Errorf("Invalid value %s.\nExpected type %s, found %s.", name, t.Name, name)
-			err.Path = path.toSlice()
-			r.AddError(err)
-			out.WriteString("null")
+		if isNull(n.value) {
 			return
 		}
-		out.WriteByte('"')
-		out.WriteString(name)
-		out.WriteByte('"')
-
+		value := n.value
+		if value.Kind() == reflect.Ptr {
+			value = value.Elem()
+		}
+		children := make([]*execNode, value.Len())
+		for i := range children {
+			children[i] = &execNode{label: i, value: value.Index(i), typ:   t.OfType}
+			grandChildren := collectNodes(n.sels, s, children[i].value, nil, make(map[string]*execNode))
+			children[i].add(grandChildren)
+		}
+		n.add(children)
 	default:
-		panic("unreachable")
+		panic(fmt.Sprintf("unknown schema type %T", t))
 	}
 }
 
-func (r *Request) execList(ctx context.Context, sels []selected.Selection, typ *common.List, path *pathSegment, s *resolvable.Schema, resolver reflect.Value, out *bytes.Buffer) {
-	l := resolver.Len()
-	entryouts := make([]bytes.Buffer, l)
-
-	if selected.HasAsyncSel(sels) {
-		var wg sync.WaitGroup
-		wg.Add(l)
-		for i := 0; i < l; i++ {
-			go func(i int) {
-				defer wg.Done()
-				defer r.handlePanic(ctx)
-				r.execSelectionSet(ctx, sels, typ.OfType, &pathSegment{path, i}, s, resolver.Index(i), &entryouts[i])
-			}(i)
-		}
-		wg.Wait()
-	} else {
-		for i := 0; i < l; i++ {
-			r.execSelectionSet(ctx, sels, typ.OfType, &pathSegment{path, i}, s, resolver.Index(i), &entryouts[i])
-		}
-	}
-
-	_, listOfNonNull := typ.OfType.(*common.NonNull)
-
-	out.WriteByte('[')
-	for i, entryout := range entryouts {
-		// If the list wraps a non-null type and one of the list elements
-		// resolves to null, then the entire list resolves to null.
-		if listOfNonNull && resolvedToNull(&entryout) {
-			out.Reset()
-			out.WriteString("null")
-			return
-		}
-
-		if i > 0 {
-			out.WriteByte(',')
-		}
-		out.Write(entryout.Bytes())
-	}
-	out.WriteByte(']')
-}
-
+// unwrapNonNull removes the not-null type annotation of a type and returns the original type. The second return
+// value is true if a not-null annotation has been removed.
 func unwrapNonNull(t common.Type) (common.Type, bool) {
 	if nn, ok := t.(*common.NonNull); ok {
 		return nn.OfType, true
@@ -356,14 +280,8 @@ func unwrapNonNull(t common.Type) (common.Type, bool) {
 	return t, false
 }
 
-type pathSegment struct {
-	parent *pathSegment
-	value  interface{}
-}
-
-func (p *pathSegment) toSlice() []interface{} {
-	if p == nil {
-		return nil
-	}
-	return append(p.parent.toSlice(), p.value)
+// isNull checks whatever a reflect.Value is invalid or nil.
+func isNull(v reflect.Value) bool {
+	k := v.Kind()
+	return k == reflect.Invalid || ((k == reflect.Ptr || k == reflect.Interface) && v.IsNil())
 }

--- a/internal/exec/subscribe.go
+++ b/internal/exec/subscribe.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
-	"sync"
 	"time"
 
 	"github.com/graph-gophers/graphql-go/errors"
@@ -14,7 +13,6 @@ import (
 	"github.com/graph-gophers/graphql-go/internal/exec/resolvable"
 	"github.com/graph-gophers/graphql-go/internal/exec/selected"
 	"github.com/graph-gophers/graphql-go/internal/query"
-	"github.com/graph-gophers/graphql-go/internal/schema"
 )
 
 type Response struct {
@@ -24,33 +22,31 @@ type Response struct {
 
 func (r *Request) Subscribe(ctx context.Context, s *resolvable.Schema, op *query.Operation) <-chan *Response {
 	var result reflect.Value
-	var f *fieldToExec
+	var n *execNode
 	var err *errors.QueryError
 	func() {
 		defer r.handlePanic(ctx)
 
 		sels := selected.ApplyOperation(&r.Request, s, op)
-		var fields []*fieldToExec
-		collectFieldsToResolve(sels, s, s.Resolver, &fields, make(map[string]*fieldToExec))
-
+		nodes := collectNodes(sels, s, s.Resolver, nil, make(map[string]*execNode))
 		// TODO: move this check into validation.Validate
-		if len(fields) != 1 {
+		if len(nodes) != 1 {
 			err = errors.Errorf("%s", "can subscribe to at most one subscription at a time")
 			return
 		}
-		f = fields[0]
+		n = nodes[0]
 
 		var in []reflect.Value
-		if f.field.HasContext {
+		if n.field.HasContext {
 			in = append(in, reflect.ValueOf(ctx))
 		}
-		if f.field.ArgsPacker != nil {
-			in = append(in, f.field.PackedArgs)
+		if n.field.ArgsPacker != nil {
+			in = append(in, n.field.PackedArgs)
 		}
-		callOut := f.resolver.Method(f.field.MethodIndex).Call(in)
+		callOut := n.resolver.Method(n.field.MethodIndex).Call(in)
 		result = callOut[0]
 
-		if f.field.HasError && !callOut[1].IsNil() {
+		if n.field.HasError && !callOut[1].IsNil() {
 			resolverErr := callOut[1].Interface().(error)
 			err = errors.Errorf("%s", resolverErr)
 			err.ResolverError = resolverErr
@@ -58,10 +54,10 @@ func (r *Request) Subscribe(ctx context.Context, s *resolvable.Schema, op *query
 	}()
 
 	if err != nil {
-		if _, nonNullChild := f.field.Type.(*common.NonNull); nonNullChild {
+		if _, nonNullChild := n.field.Type.(*common.NonNull); nonNullChild {
 			return sendAndReturnClosed(&Response{Errors: []*errors.QueryError{err}})
 		}
-		return sendAndReturnClosed(&Response{Data: []byte(fmt.Sprintf(`{"%s":null}`, f.field.Alias)), Errors: []*errors.QueryError{err}})
+		return sendAndReturnClosed(&Response{Data: []byte(fmt.Sprintf(`{"%s":null}`, n.field.Alias)), Errors: []*errors.QueryError{err}})
 	}
 
 	if ctxErr := ctx.Err(); ctxErr != nil {
@@ -121,19 +117,17 @@ func (r *Request) Subscribe(ctx context.Context, s *resolvable.Schema, op *query
 					func() {
 						defer subR.handlePanic(subCtx)
 
-						var buf bytes.Buffer
-						subR.execSelectionSet(subCtx, f.sels, f.field.Type, &pathSegment{nil, f.field.Alias}, s, resp, &buf)
-
-						propagateChildError := false
-						if _, nonNullChild := f.field.Type.(*common.NonNull); nonNullChild && resolvedToNull(&buf) {
-							propagateChildError = true
+						n.value = resp
+						nodes := collectNodes(n.sels, s, resp, nil, make(map[string]*execNode))
+						n.children = nodes
+						for _, c := range nodes {
+							c.parent = n
 						}
+						subR.process(subCtx, nodes, s)
 
-						if !propagateChildError {
-							out.WriteString(fmt.Sprintf(`{"%s":`, f.field.Alias))
-							out.Write(buf.Bytes())
-							out.WriteString(`}`)
-						}
+						w := newObjWriter(&out)
+						defer w.Flush()
+						w.Write(subR, n)
 					}()
 
 					if err := subCtx.Err(); err != nil {
@@ -160,299 +154,4 @@ func sendAndReturnClosed(resp *Response) chan *Response {
 	c <- resp
 	close(c)
 	return c
-}
-
-type fieldToExec struct {
-	field    *selected.SchemaField
-	sels     []selected.Selection
-	resolver reflect.Value
-	out      *bytes.Buffer
-}
-
-func resolvedToNull(b *bytes.Buffer) bool {
-	return bytes.Equal(b.Bytes(), []byte("null"))
-}
-
-
-type pathSegment struct {
-	parent *pathSegment
-	value  interface{}
-}
-
-func (p *pathSegment) toSlice() []interface{} {
-	if p == nil {
-		return nil
-	}
-	return append(p.parent.toSlice(), p.value)
-}
-
-
-func (r *Request) execSelections(ctx context.Context, sels []selected.Selection, path *pathSegment, s *resolvable.Schema, resolver reflect.Value, out *bytes.Buffer, serially bool) {
-	async := !serially && selected.HasAsyncSel(sels)
-
-	var fields []*fieldToExec
-	collectFieldsToResolve(sels, s, resolver, &fields, make(map[string]*fieldToExec))
-
-	if async {
-		var wg sync.WaitGroup
-		wg.Add(len(fields))
-		for _, f := range fields {
-			go func(f *fieldToExec) {
-				defer wg.Done()
-				defer r.handlePanic(ctx)
-				f.out = new(bytes.Buffer)
-				execNodeSelection(ctx, r, s, f, &pathSegment{path, f.field.Alias}, true)
-			}(f)
-		}
-		wg.Wait()
-	} else {
-		for _, f := range fields {
-			f.out = new(bytes.Buffer)
-			execNodeSelection(ctx, r, s, f, &pathSegment{path, f.field.Alias}, true)
-		}
-	}
-
-	out.WriteByte('{')
-	for i, f := range fields {
-		// If a non-nullable child resolved to null, an error was added to the
-		// "errors" list in the response, so this field resolves to null.
-		// If this field is non-nullable, the error is propagated to its parent.
-		if _, ok := f.field.Type.(*common.NonNull); ok && resolvedToNull(f.out) {
-			out.Reset()
-			out.Write([]byte("null"))
-			return
-		}
-
-		if i > 0 {
-			out.WriteByte(',')
-		}
-		out.WriteByte('"')
-		out.WriteString(f.field.Alias)
-		out.WriteByte('"')
-		out.WriteByte(':')
-		out.Write(f.out.Bytes())
-	}
-	out.WriteByte('}')
-}
-
-func collectFieldsToResolve(sels []selected.Selection, s *resolvable.Schema, resolver reflect.Value, fields *[]*fieldToExec, fieldByAlias map[string]*fieldToExec) {
-	for _, sel := range sels {
-		switch sel := sel.(type) {
-		case *selected.SchemaField:
-			field, ok := fieldByAlias[sel.Alias]
-			if !ok { // validation already checked for conflict (TODO)
-				field = &fieldToExec{field: sel, resolver: resolver}
-				fieldByAlias[sel.Alias] = field
-				*fields = append(*fields, field)
-			}
-			field.sels = append(field.sels, sel.Sels...)
-
-		case *selected.TypenameField:
-			sf := &selected.SchemaField{
-				Field:       s.Meta.FieldTypename,
-				Alias:       sel.Alias,
-				FixedResult: reflect.ValueOf(typeOf(sel, resolver)),
-			}
-			*fields = append(*fields, &fieldToExec{field: sf, resolver: resolver})
-
-		case *selected.TypeAssertion:
-			out := resolver.Method(sel.MethodIndex).Call(nil)
-			if !out[1].Bool() {
-				continue
-			}
-			collectFieldsToResolve(sel.Sels, s, out[0], fields, fieldByAlias)
-
-		default:
-			panic("unreachable")
-		}
-	}
-}
-
-func execNodeSelection(ctx context.Context, r *Request, s *resolvable.Schema, f *fieldToExec, path *pathSegment, applyLimiter bool) {
-	if applyLimiter {
-		r.Limiter <- struct{}{}
-	}
-
-	var result reflect.Value
-	var err *errors.QueryError
-
-	traceCtx, finish := r.Tracer.TraceField(ctx, f.field.TraceLabel, f.field.TypeName, f.field.Name, !f.field.Async, f.field.Args)
-	defer func() {
-		finish(err)
-	}()
-
-	err = func() (err *errors.QueryError) {
-		defer func() {
-			if panicValue := recover(); panicValue != nil {
-				r.Logger.LogPanic(ctx, panicValue)
-				err = makePanicError(panicValue)
-				err.Path = path.toSlice()
-			}
-		}()
-
-		if f.field.FixedResult.IsValid() {
-			result = f.field.FixedResult
-			return nil
-		}
-
-		if err := traceCtx.Err(); err != nil {
-			return errors.Errorf("%s", err) // don't execute any more resolvers if context got cancelled
-		}
-
-		res := f.resolver
-		if f.field.UseMethodResolver() {
-			var in []reflect.Value
-			if f.field.HasContext {
-				in = append(in, reflect.ValueOf(traceCtx))
-			}
-			if f.field.ArgsPacker != nil {
-				in = append(in, f.field.PackedArgs)
-			}
-			callOut := res.Method(f.field.MethodIndex).Call(in)
-			result = callOut[0]
-			if f.field.HasError && !callOut[1].IsNil() {
-				resolverErr := callOut[1].Interface().(error)
-				err := errors.Errorf("%s", resolverErr)
-				err.Path = path.toSlice()
-				err.ResolverError = resolverErr
-				if ex, ok := callOut[1].Interface().(extensionser); ok {
-					err.Extensions = ex.Extensions()
-				}
-				return err
-			}
-		} else {
-			// TODO extract out unwrapping ptr logic to a common place
-			if res.Kind() == reflect.Ptr {
-				res = res.Elem()
-			}
-			result = res.FieldByIndex(f.field.FieldIndex)
-		}
-		return nil
-	}()
-
-	if applyLimiter {
-		<-r.Limiter
-	}
-
-	if err != nil {
-		// If an error occurred while resolving a field, it should be treated as though the field
-		// returned null, and an error must be added to the "errors" list in the response.
-		r.AddError(err)
-		f.out.WriteString("null")
-		return
-	}
-
-	r.execSelectionSet(traceCtx, f.sels, f.field.Type, path, s, result, f.out)
-}
-
-func (r *Request) execSelectionSet(ctx context.Context, sels []selected.Selection, typ common.Type, path *pathSegment, s *resolvable.Schema, resolver reflect.Value, out *bytes.Buffer) {
-	t, nonNull := unwrapNonNull(typ)
-	switch t := t.(type) {
-	case *schema.Object, *schema.Interface, *schema.Union:
-		// a reflect.Value of a nil interface will show up as an Invalid value
-		if resolver.Kind() == reflect.Invalid || ((resolver.Kind() == reflect.Ptr || resolver.Kind() == reflect.Interface) && resolver.IsNil()) {
-			// If a field of a non-null type resolves to null (either because the
-			// function to resolve the field returned null or because an error occurred),
-			// add an error to the "errors" list in the response.
-			if nonNull {
-				err := errors.Errorf("graphql: got nil for non-null %q", t)
-				err.Path = path.toSlice()
-				r.AddError(err)
-			}
-			out.WriteString("null")
-			return
-		}
-
-		r.execSelections(ctx, sels, path, s, resolver, out, false)
-		return
-	}
-
-	if !nonNull {
-		if resolver.IsNil() {
-			out.WriteString("null")
-			return
-		}
-		resolver = resolver.Elem()
-	}
-
-	switch t := t.(type) {
-	case *common.List:
-		r.execList(ctx, sels, t, path, s, resolver, out)
-
-	case *schema.Scalar:
-		v := resolver.Interface()
-		data, err := json.Marshal(v)
-		if err != nil {
-			panic(errors.Errorf("could not marshal %v: %s", v, err))
-		}
-		out.Write(data)
-
-	case *schema.Enum:
-		var stringer fmt.Stringer = resolver
-		if s, ok := resolver.Interface().(fmt.Stringer); ok {
-			stringer = s
-		}
-		name := stringer.String()
-		var valid bool
-		for _, v := range t.Values {
-			if v.Name == name {
-				valid = true
-				break
-			}
-		}
-		if !valid {
-			err := errors.Errorf("Invalid value %s.\nExpected type %s, found %s.", name, t.Name, name)
-			err.Path = path.toSlice()
-			r.AddError(err)
-			out.WriteString("null")
-			return
-		}
-		out.WriteByte('"')
-		out.WriteString(name)
-		out.WriteByte('"')
-
-	default:
-		panic("unreachable")
-	}
-}
-
-func (r *Request) execList(ctx context.Context, sels []selected.Selection, typ *common.List, path *pathSegment, s *resolvable.Schema, resolver reflect.Value, out *bytes.Buffer) {
-	l := resolver.Len()
-	entryouts := make([]bytes.Buffer, l)
-
-	if selected.HasAsyncSel(sels) {
-		var wg sync.WaitGroup
-		wg.Add(l)
-		for i := 0; i < l; i++ {
-			go func(i int) {
-				defer wg.Done()
-				defer r.handlePanic(ctx)
-				r.execSelectionSet(ctx, sels, typ.OfType, &pathSegment{path, i}, s, resolver.Index(i), &entryouts[i])
-			}(i)
-		}
-		wg.Wait()
-	} else {
-		for i := 0; i < l; i++ {
-			r.execSelectionSet(ctx, sels, typ.OfType, &pathSegment{path, i}, s, resolver.Index(i), &entryouts[i])
-		}
-	}
-
-	_, listOfNonNull := typ.OfType.(*common.NonNull)
-
-	out.WriteByte('[')
-	for i, entryout := range entryouts {
-		// If the list wraps a non-null type and one of the list elements
-		// resolves to null, then the entire list resolves to null.
-		if listOfNonNull && resolvedToNull(&entryout) {
-			out.Reset()
-			out.WriteString("null")
-			return
-		}
-
-		if i > 0 {
-			out.WriteByte(',')
-		}
-		out.Write(entryout.Bytes())
-	}
-	out.WriteByte(']')
 }

--- a/internal/exec/subscribe.go
+++ b/internal/exec/subscribe.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"reflect"
+	"sync"
 	"time"
 
 	"github.com/graph-gophers/graphql-go/errors"
@@ -13,6 +14,7 @@ import (
 	"github.com/graph-gophers/graphql-go/internal/exec/resolvable"
 	"github.com/graph-gophers/graphql-go/internal/exec/selected"
 	"github.com/graph-gophers/graphql-go/internal/query"
+	"github.com/graph-gophers/graphql-go/internal/schema"
 )
 
 type Response struct {
@@ -158,4 +160,299 @@ func sendAndReturnClosed(resp *Response) chan *Response {
 	c <- resp
 	close(c)
 	return c
+}
+
+type fieldToExec struct {
+	field    *selected.SchemaField
+	sels     []selected.Selection
+	resolver reflect.Value
+	out      *bytes.Buffer
+}
+
+func resolvedToNull(b *bytes.Buffer) bool {
+	return bytes.Equal(b.Bytes(), []byte("null"))
+}
+
+
+type pathSegment struct {
+	parent *pathSegment
+	value  interface{}
+}
+
+func (p *pathSegment) toSlice() []interface{} {
+	if p == nil {
+		return nil
+	}
+	return append(p.parent.toSlice(), p.value)
+}
+
+
+func (r *Request) execSelections(ctx context.Context, sels []selected.Selection, path *pathSegment, s *resolvable.Schema, resolver reflect.Value, out *bytes.Buffer, serially bool) {
+	async := !serially && selected.HasAsyncSel(sels)
+
+	var fields []*fieldToExec
+	collectFieldsToResolve(sels, s, resolver, &fields, make(map[string]*fieldToExec))
+
+	if async {
+		var wg sync.WaitGroup
+		wg.Add(len(fields))
+		for _, f := range fields {
+			go func(f *fieldToExec) {
+				defer wg.Done()
+				defer r.handlePanic(ctx)
+				f.out = new(bytes.Buffer)
+				execNodeSelection(ctx, r, s, f, &pathSegment{path, f.field.Alias}, true)
+			}(f)
+		}
+		wg.Wait()
+	} else {
+		for _, f := range fields {
+			f.out = new(bytes.Buffer)
+			execNodeSelection(ctx, r, s, f, &pathSegment{path, f.field.Alias}, true)
+		}
+	}
+
+	out.WriteByte('{')
+	for i, f := range fields {
+		// If a non-nullable child resolved to null, an error was added to the
+		// "errors" list in the response, so this field resolves to null.
+		// If this field is non-nullable, the error is propagated to its parent.
+		if _, ok := f.field.Type.(*common.NonNull); ok && resolvedToNull(f.out) {
+			out.Reset()
+			out.Write([]byte("null"))
+			return
+		}
+
+		if i > 0 {
+			out.WriteByte(',')
+		}
+		out.WriteByte('"')
+		out.WriteString(f.field.Alias)
+		out.WriteByte('"')
+		out.WriteByte(':')
+		out.Write(f.out.Bytes())
+	}
+	out.WriteByte('}')
+}
+
+func collectFieldsToResolve(sels []selected.Selection, s *resolvable.Schema, resolver reflect.Value, fields *[]*fieldToExec, fieldByAlias map[string]*fieldToExec) {
+	for _, sel := range sels {
+		switch sel := sel.(type) {
+		case *selected.SchemaField:
+			field, ok := fieldByAlias[sel.Alias]
+			if !ok { // validation already checked for conflict (TODO)
+				field = &fieldToExec{field: sel, resolver: resolver}
+				fieldByAlias[sel.Alias] = field
+				*fields = append(*fields, field)
+			}
+			field.sels = append(field.sels, sel.Sels...)
+
+		case *selected.TypenameField:
+			sf := &selected.SchemaField{
+				Field:       s.Meta.FieldTypename,
+				Alias:       sel.Alias,
+				FixedResult: reflect.ValueOf(typeOf(sel, resolver)),
+			}
+			*fields = append(*fields, &fieldToExec{field: sf, resolver: resolver})
+
+		case *selected.TypeAssertion:
+			out := resolver.Method(sel.MethodIndex).Call(nil)
+			if !out[1].Bool() {
+				continue
+			}
+			collectFieldsToResolve(sel.Sels, s, out[0], fields, fieldByAlias)
+
+		default:
+			panic("unreachable")
+		}
+	}
+}
+
+func execNodeSelection(ctx context.Context, r *Request, s *resolvable.Schema, f *fieldToExec, path *pathSegment, applyLimiter bool) {
+	if applyLimiter {
+		r.Limiter <- struct{}{}
+	}
+
+	var result reflect.Value
+	var err *errors.QueryError
+
+	traceCtx, finish := r.Tracer.TraceField(ctx, f.field.TraceLabel, f.field.TypeName, f.field.Name, !f.field.Async, f.field.Args)
+	defer func() {
+		finish(err)
+	}()
+
+	err = func() (err *errors.QueryError) {
+		defer func() {
+			if panicValue := recover(); panicValue != nil {
+				r.Logger.LogPanic(ctx, panicValue)
+				err = makePanicError(panicValue)
+				err.Path = path.toSlice()
+			}
+		}()
+
+		if f.field.FixedResult.IsValid() {
+			result = f.field.FixedResult
+			return nil
+		}
+
+		if err := traceCtx.Err(); err != nil {
+			return errors.Errorf("%s", err) // don't execute any more resolvers if context got cancelled
+		}
+
+		res := f.resolver
+		if f.field.UseMethodResolver() {
+			var in []reflect.Value
+			if f.field.HasContext {
+				in = append(in, reflect.ValueOf(traceCtx))
+			}
+			if f.field.ArgsPacker != nil {
+				in = append(in, f.field.PackedArgs)
+			}
+			callOut := res.Method(f.field.MethodIndex).Call(in)
+			result = callOut[0]
+			if f.field.HasError && !callOut[1].IsNil() {
+				resolverErr := callOut[1].Interface().(error)
+				err := errors.Errorf("%s", resolverErr)
+				err.Path = path.toSlice()
+				err.ResolverError = resolverErr
+				if ex, ok := callOut[1].Interface().(extensionser); ok {
+					err.Extensions = ex.Extensions()
+				}
+				return err
+			}
+		} else {
+			// TODO extract out unwrapping ptr logic to a common place
+			if res.Kind() == reflect.Ptr {
+				res = res.Elem()
+			}
+			result = res.FieldByIndex(f.field.FieldIndex)
+		}
+		return nil
+	}()
+
+	if applyLimiter {
+		<-r.Limiter
+	}
+
+	if err != nil {
+		// If an error occurred while resolving a field, it should be treated as though the field
+		// returned null, and an error must be added to the "errors" list in the response.
+		r.AddError(err)
+		f.out.WriteString("null")
+		return
+	}
+
+	r.execSelectionSet(traceCtx, f.sels, f.field.Type, path, s, result, f.out)
+}
+
+func (r *Request) execSelectionSet(ctx context.Context, sels []selected.Selection, typ common.Type, path *pathSegment, s *resolvable.Schema, resolver reflect.Value, out *bytes.Buffer) {
+	t, nonNull := unwrapNonNull(typ)
+	switch t := t.(type) {
+	case *schema.Object, *schema.Interface, *schema.Union:
+		// a reflect.Value of a nil interface will show up as an Invalid value
+		if resolver.Kind() == reflect.Invalid || ((resolver.Kind() == reflect.Ptr || resolver.Kind() == reflect.Interface) && resolver.IsNil()) {
+			// If a field of a non-null type resolves to null (either because the
+			// function to resolve the field returned null or because an error occurred),
+			// add an error to the "errors" list in the response.
+			if nonNull {
+				err := errors.Errorf("graphql: got nil for non-null %q", t)
+				err.Path = path.toSlice()
+				r.AddError(err)
+			}
+			out.WriteString("null")
+			return
+		}
+
+		r.execSelections(ctx, sels, path, s, resolver, out, false)
+		return
+	}
+
+	if !nonNull {
+		if resolver.IsNil() {
+			out.WriteString("null")
+			return
+		}
+		resolver = resolver.Elem()
+	}
+
+	switch t := t.(type) {
+	case *common.List:
+		r.execList(ctx, sels, t, path, s, resolver, out)
+
+	case *schema.Scalar:
+		v := resolver.Interface()
+		data, err := json.Marshal(v)
+		if err != nil {
+			panic(errors.Errorf("could not marshal %v: %s", v, err))
+		}
+		out.Write(data)
+
+	case *schema.Enum:
+		var stringer fmt.Stringer = resolver
+		if s, ok := resolver.Interface().(fmt.Stringer); ok {
+			stringer = s
+		}
+		name := stringer.String()
+		var valid bool
+		for _, v := range t.Values {
+			if v.Name == name {
+				valid = true
+				break
+			}
+		}
+		if !valid {
+			err := errors.Errorf("Invalid value %s.\nExpected type %s, found %s.", name, t.Name, name)
+			err.Path = path.toSlice()
+			r.AddError(err)
+			out.WriteString("null")
+			return
+		}
+		out.WriteByte('"')
+		out.WriteString(name)
+		out.WriteByte('"')
+
+	default:
+		panic("unreachable")
+	}
+}
+
+func (r *Request) execList(ctx context.Context, sels []selected.Selection, typ *common.List, path *pathSegment, s *resolvable.Schema, resolver reflect.Value, out *bytes.Buffer) {
+	l := resolver.Len()
+	entryouts := make([]bytes.Buffer, l)
+
+	if selected.HasAsyncSel(sels) {
+		var wg sync.WaitGroup
+		wg.Add(l)
+		for i := 0; i < l; i++ {
+			go func(i int) {
+				defer wg.Done()
+				defer r.handlePanic(ctx)
+				r.execSelectionSet(ctx, sels, typ.OfType, &pathSegment{path, i}, s, resolver.Index(i), &entryouts[i])
+			}(i)
+		}
+		wg.Wait()
+	} else {
+		for i := 0; i < l; i++ {
+			r.execSelectionSet(ctx, sels, typ.OfType, &pathSegment{path, i}, s, resolver.Index(i), &entryouts[i])
+		}
+	}
+
+	_, listOfNonNull := typ.OfType.(*common.NonNull)
+
+	out.WriteByte('[')
+	for i, entryout := range entryouts {
+		// If the list wraps a non-null type and one of the list elements
+		// resolves to null, then the entire list resolves to null.
+		if listOfNonNull && resolvedToNull(&entryout) {
+			out.Reset()
+			out.WriteString("null")
+			return
+		}
+
+		if i > 0 {
+			out.WriteByte(',')
+		}
+		out.Write(entryout.Bytes())
+	}
+	out.WriteByte(']')
 }

--- a/internal/exec/writer.go
+++ b/internal/exec/writer.go
@@ -1,0 +1,211 @@
+package exec
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"reflect"
+
+	"github.com/graph-gophers/graphql-go/errors"
+	"github.com/graph-gophers/graphql-go/internal/common"
+	"github.com/graph-gophers/graphql-go/internal/schema"
+)
+
+// writeNode writes an execNode to the output buffer. It reports any errors encountered and returns true if
+// the parent must become NULL too (error propagation).
+func writeNode(r *Request, out *bytes.Buffer, n *execNode) bool {
+	typ, nonNull := unwrapNonNull(n.typ)
+	if n.err != nil {
+		r.AddError(n.err)
+		out.WriteString("null")
+		return nonNull
+	}
+	if isNull(n.value) {
+		out.WriteString("null")
+		if nonNull {
+			err := errors.Errorf("graphql: got nil for non-null %q", typ)
+			err.Path = n.fullPath()
+			r.AddError(err)
+			return true
+		}
+		return false
+	}
+	switch typ := typ.(type) {
+	case *schema.Scalar:
+		return writeScalar(r, out, n)
+	case *common.List:
+		return writeList(r, out, n)
+	case *schema.Object, *schema.Interface, *schema.Union:
+		return writeObj(r, out, n)
+	case *schema.Enum:
+		return writeEnum(r, out, n, typ)
+	default:
+		panic(fmt.Sprintf("unknown schema type %T", typ))
+	}
+}
+
+// writeScalar writes a graphQL scalar to the output buffer. It follows the writeNode semantic.
+func writeScalar(r *Request, out *bytes.Buffer, n *execNode) bool {
+	_, nonNull := unwrapNonNull(n.typ)
+	w := newResetWriter(out)
+	if err := json.NewEncoder(w).Encode(n.value.Interface()); err != nil {
+		writeErr := errors.Errorf("json.Encode: %v", err)
+		writeErr.Path = n.fullPath()
+		r.AddError(writeErr)
+		w.PropagateNull()
+		return nonNull
+	}
+	if nonNull && w.IsNull() {
+		err := errors.Errorf("graphql: got nil for non-null %q", n.typ)
+		err.Path = n.fullPath()
+		r.AddError(err)
+		return true
+	}
+	return false
+}
+
+// writeList writes a GraphQL list to the output buffer. It follows the writeNode semantic.
+func writeList(r *Request, out *bytes.Buffer, n *execNode) bool {
+	w := newResetWriter(out)
+	propNull := false
+	w.WriteByte('[')
+	for i, c := range n.children {
+		if i > 0 {
+			w.WriteByte(',')
+		}
+		if writeNode(r, w.Buffer, c) {
+			propNull = true
+		}
+	}
+	w.WriteByte(']')
+	if propNull {
+		w.PropagateNull()
+		_, nonNull := unwrapNonNull(n.typ)
+		return nonNull
+	}
+	return false
+}
+
+// writeObj writes a GraphQL object. It reports any error it encounters and follows the writeNode semantic.
+func writeObj(r *Request, out *bytes.Buffer, n *execNode) bool {
+	w := newResetWriter(out)
+	propNull := false
+	w.WriteByte('{')
+	for i, c := range n.children {
+		if i > 0 {
+			w.WriteByte(',')
+		}
+		w.WriteByte('"')
+		w.WriteString(c.field.Alias)
+		w.WriteByte('"')
+		w.WriteByte(':')
+		if writeNode(r, w.Buffer, c) {
+			propNull = true
+		}
+	}
+	w.WriteByte('}')
+	if propNull {
+		w.PropagateNull()
+		_, nonNull := unwrapNonNull(n.typ)
+		return nonNull
+	}
+	return false
+}
+
+// writeEnum writes a graphQL enum to the output buffer. It follows the writeNode semantic.
+func writeEnum(r *Request, out *bytes.Buffer, n *execNode, t *schema.Enum) bool {
+	value := n.value
+	if value.Kind() == reflect.Ptr {
+		value = value.Elem()
+	}
+	var stringer fmt.Stringer = value
+	if s, ok := value.Interface().(fmt.Stringer); ok {
+		stringer = s
+	}
+	name := stringer.String()
+	var valid bool
+	for _, v := range t.Values {
+		if v.Name == name {
+			valid = true
+			break
+		}
+	}
+	if !valid {
+		err := errors.Errorf("Invalid value %s.\nExpected type %s, found %s.", name, t.Name, name)
+		err.Path = n.fullPath()
+		r.AddError(err)
+		out.WriteString("null")
+		_, nonNull := unwrapNonNull(n.typ)
+		return nonNull
+	}
+	out.WriteByte('"')
+	out.WriteString(name)
+	out.WriteByte('"')
+	return false
+}
+
+// resetWriter is a writer that appends data to an existing bytes.Buffer. The PropagateNull method can
+// be used to change the written data afterwards.
+type resetWriter struct {
+	*bytes.Buffer
+	start int
+}
+
+// newResetWriter initializes a new reset-able writer.
+func newResetWriter(out *bytes.Buffer) *resetWriter {
+	return &resetWriter{Buffer: out, start: out.Len()}
+}
+
+// PropagateNull changes the data appended by this writer to "null", the JSON null value. Data that has
+// been written to the buffer before is unaffected.
+func (w *resetWriter) PropagateNull() {
+	w.Truncate(w.start)
+	w.WriteString("null")
+}
+
+// IsNull checks whatever the data written by this writer is the null value in JSON.
+func (w *resetWriter) IsNull() bool {
+	return bytes.Equal(w.Bytes()[w.start:], []byte("null"))
+}
+
+// objWriter is a streaming-able API for writing GraphQL objects similar to writeObj.
+type objWriter struct {
+	rw *resetWriter
+	propNull bool
+}
+
+// newObjWriter initializes a new object writer.
+func newObjWriter(out *bytes.Buffer) *objWriter {
+	return &objWriter{rw: newResetWriter(out)}
+}
+
+// Write writes a single node (key/value pair) within the object.
+func (w *objWriter) Write(r *Request, n *execNode) {
+	if w.rw.Len() == w.rw.start {
+		w.rw.WriteByte('{')
+	} else {
+		w.rw.WriteByte(',')
+	}
+	w.rw.WriteByte('"')
+	w.rw.WriteString(n.field.Alias)
+	w.rw.WriteByte('"')
+	w.rw.WriteByte(':')
+
+	if writeNode(r, w.rw.Buffer, n) {
+		w.propNull = true
+	}
+}
+
+// Flush finishes the object and propagates the NULL value if necessary.
+func (w *objWriter) Flush() {
+	if w.propNull {
+		w.rw.PropagateNull()
+		return
+	}
+	if w.rw.Len() == w.rw.start {
+		w.rw.WriteByte('{')
+	}
+	w.rw.WriteByte('}')
+}
+
+


### PR DESCRIPTION
This change is still WIP and is not yet ready to merge. But it passes all test already and I would like to coordinate the merge. Are you interested in a change like this or should I consider starting a fork?

**Problem Description**

Currently, ``graph-gophers/graphql-go`` resolves nodes in depth-first order. This is bad for data-loaders, because a common query like `posts { author; comments { author }}` is resolved like ``posts`` -> ``author of post 1`` -> ``comments of post 1`` -> ``authors of comment ...`` -> ``author of post 2`` -> ``comments of post 2``, etc...

This gives data-loaders no clear dispatch point, therefore dataloaders have to use some time based heuristics (e.g. wait for 100ms before dispatching) which leads to increased query latency. The depth-first traversal is also the worst case scenario for such time based heuristics.

Another problem with time based heuristics is that they degrade horribly during load. When the system load is low, the resolvers will be batched into a single database query. But once the load increases, the time limit might be to tight and a lot of database queries will be generated, adding even more load to an already overloaded system.

The official reference implementation does not have this problem. The JavaScript VM ensures that all resolvers are executed during the same _tick_ within the event loop (unless they do a system call or anything else which triggers a new event), and dataloaders are registered to run at the next tick. Unfortunately, no such solution is possible in Go.

**Proposed Solution**

To avoid this problem, GraphQL libraries for Java and .Net are resolving nodes in breath-first order by default. This will load all posts at level 1, then all authors (of posts) and all comments at level 2 and then all authors (of comments) at level 3. Dataloaders can be configured to dispatch the queries after each level.

**Status of this PR**

This change implements breath-first traversal and already passes all test cases.

The subscription code still uses the old exec code. This should be refactored too before merging this.

The previous exec code did a ``wg.Wait()`` after resolving each node's children. Therefore, if there was a resolver that took a considerable amount of time (e.g. 1s), The response took ``1s * number_of_nodes``. The new code does only one ``wg.Wait()`` per level. This seems to be ideal, because proceeding earlier might have negative effects on data loaders anyway.

I have split the code for resolving and generating the JSON output into separate functions, making the whole code much easier to read.

The previous code used one ``bytes.Buffer`` per node. The new code only uses one for the whole request, but requires an in-memory tree of all resolved ``reflect.Value``s during the request.

The intention of the internal ``async`` flag was not clear to me. It looks like that goroutines are only used when there is a resolver with a context field. But once there is at least one resolver that takes a context as argument, all resolvers will be executed within goroutines. This behavior seems strange. I have not ported it yet.

This change does not change or add any APIs. We might want to consider exposing configurable execution strategies in the future (the Java GraphQL implementation offers this feature). More important, having a subscribe-able event for data-loaders to know when a level has been fully scheduled to be resolved is important. We might require an API that can return ``Thunks`` or something similar to fully support this feature. 