### PR TITLE
Filter interface fragment fields based on concrete type

### DIFF
--- a/graphql_test.go
+++ b/graphql_test.go
@@ -1176,6 +1176,38 @@ func TestFragments(t *testing.T) {
 				}
 			`,
 		},
+		{
+			Schema:         starwarsSchema,
+			Query:          `
+				query {
+					human(id: "1000") {
+						id
+						mass
+						...characterInfo
+					}
+				}
+
+				fragment characterInfo on Character {
+					name
+					...on Droid {
+						primaryFunction
+					}
+					...on Human {
+						height
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+					"human": {
+						"id": "1000",
+						"mass": 77,
+						"name": "Luke Skywalker",
+						"height": 1.72
+					}
+				}
+			`,
+		},
 	})
 }
 

--- a/internal/exec/resolvable/meta.go
+++ b/internal/exec/resolvable/meta.go
@@ -23,13 +23,13 @@ func newMeta(s *schema.Schema) *Meta {
 	b := newBuilder(s)
 
 	metaSchema := s.Types["__Schema"].(*schema.Object)
-	so, err := b.makeObjectExec(metaSchema.Name, metaSchema.Fields, nil, false, reflect.TypeOf(&introspection.Schema{}))
+	so, err := b.makeObjectExec(metaSchema.Name, metaSchema.Fields, nil, nil, false, reflect.TypeOf(&introspection.Schema{}))
 	if err != nil {
 		panic(err)
 	}
 
 	metaType := s.Types["__Type"].(*schema.Object)
-	t, err := b.makeObjectExec(metaType.Name, metaType.Fields, nil, false, reflect.TypeOf(&introspection.Type{}))
+	t, err := b.makeObjectExec(metaType.Name, metaType.Fields, nil, nil, false, reflect.TypeOf(&introspection.Type{}))
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
Fixes #113.

Allows using a fragment for an interface on a field of a concrete object type. Currently this panics because the interface does not implement the concrete type, so this adds support for going the other direction when applying selections.

The approach is different than how type assertions are handled, because those need to be dynamic and figure out at runtime which concrete type is present. In this case, we know the concrete type ahead of time, so we can eagerly drop any child fragments that are on types that aren't compatible with the concrete type the original fragment was spread onto.