### PR TITLE
Improve test failure output

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/graph-gophers/graphql-go
 
-require github.com/opentracing/opentracing-go v1.1.0
+require (
+	github.com/nsf/jsondiff v0.0.0-20190712045011-8443391ee9b6
+	github.com/opentracing/opentracing-go v1.1.0
+)
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,4 @@
+github.com/nsf/jsondiff v0.0.0-20190712045011-8443391ee9b6 h1:qsqscDgSJy+HqgMTR+3NwjYJBbp1+honwDsszLoS+pA=
+github.com/nsf/jsondiff v0.0.0-20190712045011-8443391ee9b6/go.mod h1:uFMI8w+ref4v2r9jz+c9i1IfIttS/OkmLfrk1jne5hs=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=

--- a/gqltesting/testing.go
+++ b/gqltesting/testing.go
@@ -93,8 +93,38 @@ func checkErrors(t *testing.T, want, got []*errors.QueryError) {
 	sortErrors(got)
 
 	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("unexpected error: got %+v, want %+v", got, want)
+		t.Log("unexpected error:")
+		t.Log("  Got: \n", formatErrors(got))
+		t.Log("  Want: \n", formatErrors(want))
+		t.Fatal()
 	}
+}
+
+func formatErrors(errs []*errors.QueryError) string {
+	var errorStr string
+	for _, err := range errs {
+		if err == nil {
+			errorStr = errorStr + "(nil)\n"
+		} else {
+			errorStr = errorStr + formatError(*err)
+		}
+	}
+	return errorStr
+}
+
+func formatError(err errors.QueryError) string {
+	return fmt.Sprintf(
+		`%s
+Path: %v
+Rule: %s
+Resolver: %s
+Extensions: %+v
+`,
+		err.Error(),
+		err.Path,
+		err.Rule,
+		err.ResolverError,
+		err.Extensions)
 }
 
 func sortErrors(errors []*errors.QueryError) {

--- a/gqltesting/testing.go
+++ b/gqltesting/testing.go
@@ -96,7 +96,7 @@ func checkErrors(t *testing.T, want, got []*errors.QueryError) {
 		t.Log("unexpected error:")
 		t.Log("  Got: \n", formatErrors(got))
 		t.Log("  Want: \n", formatErrors(want))
-		t.Fatal()
+		t.FailNow()
 	}
 }
 


### PR DESCRIPTION
This PR improves the way that the RunTests function presents test failures to the developer in three ways:

1. I added t.Helper() calls to the helper functions so that the file/line number for failures is in calling code instead of the test helpers every time

```
BEFORE:
--- FAIL: TestGqlInvestigationSuite/TestInvestigationNotFound (0.02s)
testing.go:93: unexpected error: got [...SNIP}
```
testing.go:93 is the line number where you call t.Fail() in graphql-go, not the location where I called RunTests in my library
```
AFTER: 
--- FAIL: TestGqlInvestigationSuite/TestInvestigationNotFound (0.02s)
investigation_test.go:123: unexpected error: got [...SNIP}
```
investigation_test.go is the calling code and takes me to which test I wrote that failed.

2. I added an import of `github.com/nsf/jsondiff` to print out a diff between the actual and expected responses to a tested query
EXAMPLE:
```
--- FAIL: TestGqlCasesSuite (0.03s)
    --- FAIL: TestGqlCasesSuite/TestValidCasefileRequest (0.03s)
        /Users/macrae/ccode/saber/saber-api/gql/casefile_test.go:238: Did not get expected result:
             {
                "filed": {
                    "closedAt": null,
                    "id": "a688c5c5-0f8c-4f5a-a179-6d29caef924f",
                    "initiatedAt": "2020-02-19T18:55:36Z",
                    "number": "510322",
                    ---"status": "INVESTIGATION"---
                }
            }
        /Users/macrae/ccode/saber/saber-api/gql/casefile_test.go:238: Got: {"casefile":{"id":"a688c5c5-0f8c-4f5a-a179-6d29caef924f","number":"510322","flagCount":10,"initiatedAt":"2020-02-19T18:55:36Z","closedAt":null}}
```
the `---` indicates that the status field was missing.

3. I added a formatting step to printing out errors when the expected errors are not returned. I'm not entirely sure why `Sprintf("+v"` was printing out `error.Error()` instead of the struct and its members but I made a format string that does that explicitly. This caught me because I was being told that two errors were different even though their .Error() appeared the same. They had different paths.
EXAMPLE:
```
--- FAIL: TestGqlInvestigationSuite/TestInvestigationNotFound (0.02s)
        /Users/macrae/ccode/saber/saber-api/gql/investigation_test.go:123: unexpected error:
        /Users/macrae/ccode/saber/saber-api/gql/investigation_test.go:123:   Got: 
            graphql: error [NotFound]: Could not match an investigation with that ID
            Path: [casefile investigation]
            Rule: 
            Resolver: error [NotFound]: Could not match an investigation with that ID
            Extensions: map[code:NotFound message:Could not match an investigation with that ID]
            
        /Users/macrae/ccode/saber/saber-api/gql/investigation_test.go:123:   Want: 
            graphql: error [NotFound]: Could not match an investigation with that ID
            Path: [casefile]
            Rule: 
            Resolver: error [NotFound]: Could not match an investigation with that ID
            Extensions: map[code:NotFound message:Could not match an investigation with that ID]
```


### Notes for reviewer
I used jsondiff because I'd used it before. It should be pretty easy to get rid of that dependency and use the system diff instead but I wanted to get the ball rolling on this PR. 

I didn't make any changes to the streaming tests because I'm not using them. If you'd like me to at least add the .Helper() stuff to this PR I can do that. I also noticed that they are not deep comparing errors so they are potentially missing some things. 