### PR TITLE
Added Verbose Logger for logging query info during panic

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -128,6 +128,13 @@ func Logger(logger log.Logger) SchemaOpt {
 	}
 }
 
+// VerboseLogger is used to log panics with query info during query execution. It defaults to exec.VerboseLogger.
+func VerboseLogger(logger log.VerboseLogger) SchemaOpt {
+	return func(s *Schema) {
+		s.logger = logger
+	}
+}
+
 // DisableIntrospection disables introspection queries.
 func DisableIntrospection() SchemaOpt {
 	return func(s *Schema) {
@@ -218,6 +225,7 @@ func (s *Schema) exec(ctx context.Context, queryString string, operationName str
 		Limiter: make(chan struct{}, s.maxParallelism),
 		Tracer:  s.tracer,
 		Logger:  s.logger,
+		LoggerInfo: fmt.Sprintf("Query: %v\nOperationName: %v\nVariables: %+v", queryString, operationName, variables),
 	}
 	varTypes := make(map[string]*introspection.Type)
 	for _, v := range op.Vars {

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -23,11 +23,12 @@ type Request struct {
 	Limiter chan struct{}
 	Tracer  trace.Tracer
 	Logger  log.Logger
+	LoggerInfo interface{}
 }
 
 func (r *Request) handlePanic(ctx context.Context) {
 	if value := recover(); value != nil {
-		r.Logger.LogPanic(ctx, value)
+		r.Logger.LogPanic(ctx, value, r.LoggerInfo)
 		r.AddError(makePanicError(value))
 	}
 }
@@ -176,7 +177,7 @@ func execFieldSelection(ctx context.Context, r *Request, s *resolvable.Schema, f
 	err = func() (err *errors.QueryError) {
 		defer func() {
 			if panicValue := recover(); panicValue != nil {
-				r.Logger.LogPanic(ctx, panicValue)
+				r.Logger.LogPanic(ctx, panicValue, r.LoggerInfo)
 				err = makePanicError(panicValue)
 				err.Path = path.toSlice()
 			}

--- a/log/log.go
+++ b/log/log.go
@@ -8,16 +8,27 @@ import (
 
 // Logger is the interface used to log panics that occur during query execution. It is settable via graphql.ParseSchema
 type Logger interface {
-	LogPanic(ctx context.Context, value interface{})
+	LogPanic(ctx context.Context, value interface{}, info interface{})
 }
 
 // DefaultLogger is the default logger used to log panics that occur during query execution
 type DefaultLogger struct{}
 
 // LogPanic is used to log recovered panic values that occur during query execution
-func (l *DefaultLogger) LogPanic(ctx context.Context, value interface{}) {
+func (l *DefaultLogger) LogPanic(ctx context.Context, value interface{}, _ interface{}) {
 	const size = 64 << 10
 	buf := make([]byte, size)
 	buf = buf[:runtime.Stack(buf, false)]
 	log.Printf("graphql: panic occurred: %v\n%s\ncontext: %v", value, buf, ctx)
+}
+
+// VerboseLogger is the verbose logger used to log panics that occur during query execution along with some info
+type VerboseLogger struct{}
+
+// LogPanic is used to log recovered panic values that occur during query execution
+func (l VerboseLogger) LogPanic(ctx context.Context, value interface{}, info interface{}) {
+	const size = 64 << 10
+	buf := make([]byte, size)
+	buf = buf[:runtime.Stack(buf, false)]
+	log.Printf("graphql: panic occurred: %v\n%s\ncontext: %v\ninfo: %v", value, buf, ctx, info)
 }


### PR DESCRIPTION
Changes:
1. Added type `VerboseLogger` implements log.Logger. LogPanic method on VerboseLogger and logs the info passed on.
2. Modified the LogPanic method definition by adding field `info` to be logged.
3. Added LoggerInfo field on type `Request`. This loggerinfo will be used for verbose logging. Adding loggerinfo to each request.
4. Exposed function `VerboseLogger` type `SchemaOpt` to be used from outside graphql-go to change logging to verbose.

User can therefore pass-in the `VerboseLogger` `SchemaOpt` during parsing phase to set the logging to verbose effectively logging all the query info which led to panic. This can be really helpful to debug which query is causing problem in production systems by avoiding manually going through the stack trace or employing some hack.