### PR TITLE
adding fuzz tests 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,10 @@
+on: [push, pull_request]
+jobs:
+  test:
+    runs-on: ubuntu-16.04
+    steps:
+    - uses: actions/checkout@v1
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '^1.13'
+    - run: go test ./...

--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,9 @@
 module github.com/graph-gophers/graphql-go
 
-require github.com/opentracing/opentracing-go v1.1.0
+require (
+	github.com/google/gofuzz v1.1.0
+	github.com/opentracing/opentracing-go v1.1.0
+	github.com/stretchr/testify v1.3.0
+)
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/gofuzz v1.1.0 h1:Hsa8mG0dQ46ij8Sl2AYJDUv1oA9/d6Vk+3LG99Oe02g=
+github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0 h1:4G4v2dO3VZwixGIRoQ5Lfboy6nUhCyYzaqnIAPPhYs4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.3.0 h1:TivCn/peBQ7UY8ooIcPgZFpTNSz0Q2U6UrFlUfqbe0Q=
+github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -1,0 +1,63 @@
+package query
+
+import (
+	"log"
+	"testing"
+	"unicode"
+
+	fuzz "github.com/google/gofuzz"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFuzzQueryNonASCII(t *testing.T) {
+	t.Parallel()
+	f := fuzz.New()
+	var query string
+	for i := 0; i < 100000; {
+		f.Fuzz(&query)
+		if !isASCII([]byte(query)) {
+			continue
+		}
+		require.NotPanics(t, func() {
+			Parse(query)
+		}, "panicked with input %s", string(query))
+		i++
+	}
+}
+
+func TestFuzzQueryASCII(t *testing.T) {
+	t.Parallel()
+	f := fuzz.New()
+	var query []byte
+	for i := 0; i < 100000; {
+		f.Fuzz(&query)
+		if isASCII(query) {
+			continue
+		}
+		require.NotPanics(t, func() {
+			Parse(string(query))
+		}, "panicked with input %s", string(query))
+		i++
+	}
+}
+
+func TestFuzzRegressions(t *testing.T) {
+	crashers := []string{`query($~\344\334\234\344\334\344\234�d44\201"`}
+	for _, crash := range crashers {
+		require.NotPanics(t, func() {
+			_, err := Parse(crash)
+			if err == nil {
+				log.Fatalf("found a regression with %s", crash)
+			}
+		}, "panicked for query: %s", crash)
+	}
+}
+
+func isASCII(b []byte) bool {
+	for i := range b {
+		if b[i] > unicode.MaxASCII {
+			return false
+		}
+	}
+	return true
+}


### PR DESCRIPTION
referencing #386 
I added github actions to test them in CI but can remove them since the project uses semaphore.

Will see about fixing the `query($~\344\334\234\344\334\344\234�d44\201"` input