### PR TITLE
Fix SIGSEGV when client subs to multiple fields

### DIFF
--- a/internal/exec/subscribe.go
+++ b/internal/exec/subscribe.go
@@ -55,6 +55,10 @@ func (r *Request) Subscribe(ctx context.Context, s *resolvable.Schema, op *query
 		}
 	}()
 
+	if f == nil {
+		return sendAndReturnClosed(&Response{Errors: []*errors.QueryError{err}})
+	}
+
 	if err != nil {
 		if _, nonNullChild := f.field.Type.(*common.NonNull); nonNullChild {
 			return sendAndReturnClosed(&Response{Errors: []*errors.QueryError{err}})


### PR DESCRIPTION
This fixes a SIGSEGV panic which can happen when a client attempts to subscribe to more than one field.