### PR TITLE
bugfix: correctly determine fragment usage

### DIFF
--- a/internal/validation/testdata/tests.json
+++ b/internal/validation/testdata/tests.json
@@ -1465,6 +1465,13 @@
       "errors": []
     },
     {
+      "name": "Validate: fragments are used even when they are nested",
+      "rule": "NoUnusedFragments",
+      "schema": 1,
+      "query": "\n        query Foo() {\n ...StringFragment\n stringBox {\n ...StringFragment\n ...StringFragmentPrime\n}\n}\n\n\n fragment StringFragment on StringBox {\n scalar\n}\n\n fragment StringFragmentPrime on StringBox {\n unrelatedField\n}\n",
+      "errors": []
+    },
+    {
       "name": "Validate: No unused variables/uses all variables in fragments",
       "rule": "NoUnusedVariables",
       "schema": 0,

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -418,8 +418,9 @@ func markUsedFragments(c *context, sels []query.Selection, fragUsed map[*query.F
 			}
 
 			if _, ok := fragUsed[frag]; ok {
-				return
+				continue
 			}
+
 			fragUsed[frag] = struct{}{}
 			markUsedFragments(c, frag.Selections, fragUsed)
 


### PR DESCRIPTION
In previous versions of this code, this validation would exit when it
encountered a fragment legitimately used twice. This bugfix skips the recursion
but does not stop progress altogether allowing other fragments to be marked as
used.