### PR TITLE
More descriptive error when unmarshaling ID/Time

### DIFF
--- a/id.go
+++ b/id.go
@@ -1,7 +1,7 @@
 package graphql
 
 import (
-	"errors"
+	"fmt"
 	"strconv"
 )
 
@@ -20,7 +20,7 @@ func (id *ID) UnmarshalGraphQL(input interface{}) error {
 	case int32:
 		*id = ID(strconv.Itoa(int(input)))
 	default:
-		err = errors.New("wrong type")
+		err = fmt.Errorf("wrong type for ID: %T", input)
 	}
 	return err
 }

--- a/time.go
+++ b/time.go
@@ -41,7 +41,7 @@ func (t *Time) UnmarshalGraphQL(input interface{}) error {
 		t.Time = time.Unix(int64(input), 0)
 		return nil
 	default:
-		return fmt.Errorf("wrong type")
+		return fmt.Errorf("wrong type for Time: %T", input)
 	}
 }
 


### PR DESCRIPTION
This adds a tiny bit more information to the error messages produced when unmarshaling an input value to an ID or Time fails.