### PR TITLE
Fixed union inline fragments

### DIFF
--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -187,18 +187,23 @@ func applyFragment(r *Request, s *resolvable.Schema, e *resolvable.Object, frag 
 		}}
 	}
 	if ok && len(face.PossibleTypes) > 0 {
+		sels := []Selection{}
 		for _, t := range face.PossibleTypes {
 			if t.Name == e.Name {
 				return applySelectionSet(r, s, e, frag.Selections)
 			}
+
 			if a, ok := e.TypeAssertions[t.Name]; ok {
-				return []Selection{&TypeAssertion{
+				sels = append(sels, &TypeAssertion{
 					TypeAssertion: *a,
 					Sels:          applySelectionSet(r, s, a.TypeExec.(*resolvable.Object), frag.Selections),
-				}}
+				})
 			}
 		}
-		panic(fmt.Errorf("%q does not implement %q", e.Name, frag.On)) // TODO proper error handling
+		if len(sels) == 0 {
+			panic(fmt.Errorf("%q does not implement %q", e.Name, frag.On)) // TODO proper error handling
+		}
+		return sels
 	}
 	return applySelectionSet(r, s, e, frag.Selections)
 }

--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -191,10 +191,8 @@ func applyFragment(r *Request, s *resolvable.Schema, e *resolvable.Object, frag 
 			if t.Name == e.Name {
 				return applySelectionSet(r, s, e, frag.Selections)
 			}
-			for assertedName, assertedObject := range e.TypeAssertions {
-				if t.Name == assertedName {
-					return applySelectionSet(r, s, assertedObject.TypeExec.(*resolvable.Object), frag.Selections)
-				}
+			if assertion, ok := e.TypeAssertions[t.Name]; ok {
+				return applySelectionSet(r, s, assertion.TypeExec.(*resolvable.Object), frag.Selections)
 			}
 		}
 		panic(fmt.Errorf("%q does not implement %q", e.Name, frag.On)) // TODO proper error handling

--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -191,8 +191,11 @@ func applyFragment(r *Request, s *resolvable.Schema, e *resolvable.Object, frag 
 			if t.Name == e.Name {
 				return applySelectionSet(r, s, e, frag.Selections)
 			}
-			if assertion, ok := e.TypeAssertions[t.Name]; ok {
-				return applySelectionSet(r, s, assertion.TypeExec.(*resolvable.Object), frag.Selections)
+			if a, ok := e.TypeAssertions[t.Name]; ok {
+				return []Selection{&TypeAssertion{
+					TypeAssertion: *a,
+					Sels:          applySelectionSet(r, s, a.TypeExec.(*resolvable.Object), frag.Selections),
+				}}
 			}
 		}
 		panic(fmt.Errorf("%q does not implement %q", e.Name, frag.On)) // TODO proper error handling


### PR DESCRIPTION
This fixes #241. I haven't fully understood the problem yet, so no tests are present. I adopted code from https://github.com/graph-gophers/graphql-go/issues/241#issuecomment-406877915, modifying it to support the scenario in that issue. I did not remove the original comparsion added by @marksauter, I don't know what was the scenario that broke his code.

I'm casting the "fragment type" as an interface, if it works then I look into its possible types and check if there's a TypeAssertion for that interface. I think that's OK? I'll write tests for this patch if you think this is fine.