### PR TITLE
Add context to validation tracing

### DIFF
--- a/subscriptions.go
+++ b/subscriptions.go
@@ -36,7 +36,7 @@ func (s *Schema) subscribe(ctx context.Context, queryString string, operationNam
 		return sendAndReturnClosed(&Response{Errors: []*qerrors.QueryError{qErr}})
 	}
 
-	validationFinish := s.validationTracer.TraceValidation()
+	validationFinish := s.validationTracer.TraceValidation(ctx)
 	errs := validation.Validate(s.schema, doc, variables, s.maxDepth)
 	validationFinish(errs)
 	if len(errs) != 0 {

--- a/trace/trace.go
+++ b/trace/trace.go
@@ -67,6 +67,22 @@ func (OpenTracingTracer) TraceField(ctx context.Context, label, typeName, fieldN
 	}
 }
 
+func (OpenTracingTracer) TraceValidation(ctx context.Context) TraceValidationFinishFunc {
+	span, _ := opentracing.StartSpanFromContext(ctx, "Validate Query")
+
+	return func(errs []*errors.QueryError) {
+		if len(errs) > 0 {
+			msg := errs[0].Error()
+			if len(errs) > 1 {
+				msg += fmt.Sprintf(" (and %d more errors)", len(errs)-1)
+			}
+			ext.Error.Set(span, true)
+			span.SetTag("graphql.error", msg)
+		}
+		span.Finish()
+	}
+}
+
 func noop(*errors.QueryError) {}
 
 type NoopTracer struct{}

--- a/trace/validation_trace.go
+++ b/trace/validation_trace.go
@@ -1,17 +1,25 @@
 package trace
 
 import (
+	"context"
+
 	"github.com/graph-gophers/graphql-go/errors"
 )
 
 type TraceValidationFinishFunc = TraceQueryFinishFunc
 
+// Deprecated: use ValidationTracerContext.
 type ValidationTracer interface {
 	TraceValidation() TraceValidationFinishFunc
 }
 
+type ValidationTracerContext interface {
+	TraceValidation(ctx context.Context) TraceValidationFinishFunc
+}
+
 type NoopValidationTracer struct{}
 
+// Deprecated: use a Tracer which implements ValidationTracerContext.
 func (NoopValidationTracer) TraceValidation() TraceValidationFinishFunc {
 	return func(errs []*errors.QueryError) {}
 }


### PR DESCRIPTION
Context is needed for tracing to access the current span, in order to
 add tags to it, or create child spans. As presently defined (without a
 context), this cannot be done: new spans could be created, but they
 would not be associated with the existing request trace.

OpenTracingTracer implements the new interface (it never implemented the
 old one). Via this 'extension interface', the tracer configured (or the
 default tracer) will be used as the validation tracer if:

 * The tracer implements the (optional) interface; and
 * A validation tracer isn't provided using the deprecated option

What this means is that the deprecated option is _preferred_ as an
 override. This allows users to migrate in a non-breaking, non-behaviour
 changing way, until such time as they intentionally remove the use of
 the deprecated option. For those who are currently using the default
 tracer, and not supplying a validation tracer, validation will be traced
 immediately with no change required to configuration options.