### PR TITLE
Fixed `reflect.Value.Type on zero Value` panic when subscription resolver itself panics

### DIFF
--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -37,7 +37,7 @@ type extensionser interface {
 }
 
 func makePanicError(value interface{}) *errors.QueryError {
-	return errors.Errorf("graphql: panic occurred: %v", value)
+	return errors.Errorf("panic occurred: %v", value)
 }
 
 func (r *Request) Execute(ctx context.Context, s *resolvable.Schema, op *query.Operation) ([]byte, []*errors.QueryError) {
@@ -324,7 +324,7 @@ func (r *Request) execList(ctx context.Context, sels []selected.Selection, typ *
 				r.execSelectionSet(ctx, sels, typ.OfType, &pathSegment{path, i}, s, resolver.Index(i), &entryouts[i])
 			}(i)
 		}
-		for i := 0; i < concurrency;i++ {
+		for i := 0; i < concurrency; i++ {
 			sem <- struct{}{}
 		}
 	} else {

--- a/internal/exec/subscribe.go
+++ b/internal/exec/subscribe.go
@@ -55,6 +55,11 @@ func (r *Request) Subscribe(ctx context.Context, s *resolvable.Schema, op *query
 		}
 	}()
 
+	// Handles the case where the locally executed func above panicked
+	if len(r.Request.Errs) > 0 {
+		return sendAndReturnClosed(&Response{Errors: r.Request.Errs})
+	}
+
 	if f == nil {
 		return sendAndReturnClosed(&Response{Errors: []*errors.QueryError{err}})
 	}


### PR DESCRIPTION
The internal exec Subscribe method had code to deal with subscription resolver panicking when being called. But when such handling happen, the error is attached to the request object and it never checked later on.

This leads to some zero checks to fail when we try to extract the type from the resolver's channel since this variable was never set. Doing this creates a second panic which is not handled and make the application die.

To fix the issue, we now check if there is errors on the request object before continuing with the rest of the check, if there is errors, it's because a panic occurs and we return the response right away.