### PR TITLE
Added possibility to customize subscription resolver timeout value

### DIFF
--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"reflect"
 	"sync"
+	"time"
 
 	"github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/internal/common"
@@ -20,9 +21,10 @@ import (
 
 type Request struct {
 	selected.Request
-	Limiter chan struct{}
-	Tracer  trace.Tracer
-	Logger  log.Logger
+	Limiter                  chan struct{}
+	Tracer                   trace.Tracer
+	Logger                   log.Logger
+	SubscribeResolverTimeout time.Duration
 }
 
 func (r *Request) handlePanic(ctx context.Context) {

--- a/internal/exec/subscribe.go
+++ b/internal/exec/subscribe.go
@@ -115,8 +115,12 @@ func (r *Request) Subscribe(ctx context.Context, s *resolvable.Schema, op *query
 				}
 				var out bytes.Buffer
 				func() {
-					// TODO: configurable timeout
-					subCtx, cancel := context.WithTimeout(ctx, time.Second)
+					timeout := r.SubscribeResolverTimeout
+					if timeout == 0 {
+						timeout = time.Second
+					}
+
+					subCtx, cancel := context.WithTimeout(ctx, timeout)
 					defer cancel()
 
 					// resolve response

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -54,9 +54,10 @@ func (s *Schema) subscribe(ctx context.Context, queryString string, operationNam
 			Vars:   variables,
 			Schema: s.schema,
 		},
-		Limiter: make(chan struct{}, s.maxParallelism),
-		Tracer:  s.tracer,
-		Logger:  s.logger,
+		Limiter:                  make(chan struct{}, s.maxParallelism),
+		Tracer:                   s.tracer,
+		Logger:                   s.logger,
+		SubscribeResolverTimeout: s.subscribeResolverTimeout,
 	}
 	varTypes := make(map[string]*introspection.Type)
 	for _, v := range op.Vars {


### PR DESCRIPTION
The previous value was hard-coded to 1 second. This is problematic for resolver that takes more time than this to return a result.

When parsing the schema, it's not possible to pass a custom value for the subscription resolver timeout.

Extracted from #317