### PR TITLE
Added possibility to propagate subscription error properly

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -40,3 +40,22 @@ func (err *QueryError) Error() string {
 }
 
 var _ error = &QueryError{}
+
+// SubscriptionError can be implemented by top-level resolver object to communicate to
+// the library a terminal subscription error happened while the stream is still active.
+//
+// After a subscription has started, this is the mechanism to inform subscriber about stream
+// failure in a graceful manner.
+//
+// **Note** This works only on the top-level object of the resolver, when implemented
+// by fields selector, this has no effect.
+type SubscriptionError interface {
+	// SubscriptionError is called to determined if a terminal error occurred. If the returned
+	// value is nil, subscription continues normally. If the error is non-nil, the subscription is
+	// assumed to have reached a terminal error, the subscription's channel is closed and the error
+	// is returned to the user.
+	//
+	// If the non-nil error returned is a *QueryError type, it is returned as-is to the user, otherwise,
+	// the non-nill error is wrapped using `Errorf("%s", err)` above.
+	SubscriptionError() error
+}

--- a/gqltesting/subscriptions.go
+++ b/gqltesting/subscriptions.go
@@ -61,6 +61,10 @@ func RunSubscribe(t *testing.T, test *TestSubscription) {
 	}
 
 	for i, expected := range test.ExpectedResults {
+		if i+1 > len(results) {
+			t.Fatalf("missing result: wanted %d results, got only %d, next expected result is %+v", len(test.ExpectedResults), len(results), expected)
+		}
+
 		res := results[i]
 
 		checkErrorStrings(t, expected.Errors, res.Errors)
@@ -88,6 +92,10 @@ func RunSubscribe(t *testing.T, test *TestSubscription) {
 			t.Logf("want: %s", want)
 			t.Fail()
 		}
+	}
+
+	if len(results) > len(test.ExpectedResults) {
+		t.Fatalf("unexpected result: wanted %d results, got %d, first extra result was %+v", len(test.ExpectedResults), len(results), results[len(test.ExpectedResults)])
 	}
 }
 


### PR DESCRIPTION
After a subscription has started and sent some results to the user, from the resolver perspective, it's not right now possible to propagate error correctly to the user using the top-level object.

Since a `chan <type>` type is required for the top-level subscription resolver, it cannot convey any error information. By adding a `SubscriptionError` interface that top-level resolver's object can implement, the library upon reception of the result from the channel can check if it implements the `SubscriptionError` interface, if it's the case and the interface's method returned a non-nil error, the subscription is terminated, the channel is closed and the error is propagated to the user.

Extracted from #317 

#### Design

Right now, our use case as always been "terminal" error, i.e. that once we set `SubscriptionError` to be non-nil, we always terminate the stream. 

While extracting the code to submit the PR, I realized that in some situations, it could be desired that this error is treated as a transient error in which case, it should behaves like if a sub-field resolver would have a second return value of type `error`. Moreover, someone could also want to print the "top-level" error as well as the rest of the resolvable fields of this top-level object.

So I think it would be beneficial  to handle terminal & non-terminal errors here. One suggestion I could make would be to change the interface `SubscriptionError` to become:

```
type SubscriptionError interface {
  SubscriptionError() (err error, terminal bool) // Or inverted with `transient bool` instead
}
```

And in the `subscribe` implementation where we check for the `SubscriptionError` interface, if the `terminal` return value is `true`, the code uses the path implemented in this PR.

Otherwise if it's `false`, then we keep the error, resolve the fields and add the errors to the other ones if any.

Thoughts?