### PR TITLE
Allowed Subscription resolver to return `*QueryError` directly

### DIFF
--- a/internal/exec/subscribe.go
+++ b/internal/exec/subscribe.go
@@ -49,9 +49,15 @@ func (r *Request) Subscribe(ctx context.Context, s *resolvable.Schema, op *query
 		result = callOut[0]
 
 		if f.field.HasError && !callOut[1].IsNil() {
-			resolverErr := callOut[1].Interface().(error)
-			err = errors.Errorf("%s", resolverErr)
-			err.ResolverError = resolverErr
+			switch resolverErr := callOut[1].Interface().(type) {
+			case *errors.QueryError:
+				err = resolverErr
+			case error:
+				err = errors.Errorf("%s", resolverErr)
+				err.ResolverError = resolverErr
+			default:
+				panic(fmt.Errorf("can only deal with *QueryError and error types, got %T", resolverErr))
+			}
 		}
 	}()
 


### PR DESCRIPTION
Previously, any error returned by the Subscription resolver was immediately wrapped inside its own `*QueryError` value even if the returned error was already a `*QueryError`.

Now, when receiving such types, we use it as-is without wrapping again.

Extracted from #317