### PR TITLE
Added possibility to explore the actual field selection tree

### DIFF
--- a/context.go
+++ b/context.go
@@ -1,0 +1,26 @@
+package graphql
+
+import (
+	"context"
+
+	gcontext "github.com/graph-gophers/graphql-go/internal/context"
+	"github.com/graph-gophers/graphql-go/selected"
+)
+
+type Context struct {
+	Field selected.Field
+}
+
+// GraphQLContext is used to retrieved the graphql from the context. If no graphql
+// is present in the context, the `fallbackGraphql` received in parameter
+// is returned instead.
+func GraphQLContext(ctx context.Context) *Context {
+	field, found := gcontext.GraphQL(ctx)
+	if !found {
+		return nil
+	}
+
+	return &Context{
+		Field: field.ToSelection().(selected.Field),
+	}
+}

--- a/example/starwars/starwars.go
+++ b/example/starwars/starwars.go
@@ -4,12 +4,14 @@
 package starwars
 
 import (
+	"context"
 	"encoding/base64"
 	"fmt"
 	"strconv"
 	"strings"
 
 	graphql "github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/selected"
 )
 
 var Schema = `
@@ -93,6 +95,8 @@ var Schema = `
 		appearsIn: [Episode!]!
 		# This droid's primary function
 		primaryFunction: String
+
+
 	}
 	# A connection object for a character's friends
 	type FriendsConnection {
@@ -301,7 +305,10 @@ func (r *Resolver) Reviews(args struct{ Episode string }) []*reviewResolver {
 	return l
 }
 
-func (r *Resolver) Search(args struct{ Text string }) []*searchResultResolver {
+func (r *Resolver) Search(ctx context.Context, args struct{ Text string }) []*searchResultResolver {
+	graphqlContext := graphql.GraphQLContext(ctx)
+	selected.Dump(graphqlContext.Field)
+
 	var l []*searchResultResolver
 	for _, h := range humans {
 		if strings.Contains(h.Name, args.Text) {
@@ -338,7 +345,10 @@ func (r *Resolver) Human(args struct{ ID graphql.ID }) *humanResolver {
 	return nil
 }
 
-func (r *Resolver) Droid(args struct{ ID graphql.ID }) *droidResolver {
+func (r *Resolver) Droid(ctx context.Context, args struct{ ID graphql.ID }) *droidResolver {
+	graphqlContext := graphql.GraphQLContext(ctx)
+	selected.Dump(graphqlContext.Field)
+
 	if d := droidData[args.ID]; d != nil {
 		return &droidResolver{d}
 	}

--- a/internal/context/context.go
+++ b/internal/context/context.go
@@ -1,0 +1,32 @@
+package context
+
+import (
+	"context"
+
+	"github.com/graph-gophers/graphql-go/internal/exec/selected"
+)
+
+type graphqlKeyType int
+
+const graphqlFieldKey graphqlKeyType = iota
+
+// WithGraphQLContext is used to create a new context with a graphql added to it
+// so it can be later retrieved using `Graphql`.
+func WithGraphQLContext(ctx context.Context, field *selected.SchemaField) context.Context {
+	return context.WithValue(ctx, graphqlFieldKey, field)
+}
+
+// GraphQL is used to retrieved the graphql from the context. If no graphql
+// is present in the context, the `fallbackGraphql` received in parameter
+// is returned instead.
+func GraphQL(ctx context.Context) (field *selected.SchemaField, found bool) {
+	if ctx == nil {
+		return
+	}
+
+	if v, ok := ctx.Value(graphqlFieldKey).(*selected.SchemaField); ok {
+		return v, true
+	}
+
+	return
+}

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/internal/common"
+	gcontext "github.com/graph-gophers/graphql-go/internal/context"
 	"github.com/graph-gophers/graphql-go/internal/exec/resolvable"
 	"github.com/graph-gophers/graphql-go/internal/exec/selected"
 	"github.com/graph-gophers/graphql-go/internal/query"
@@ -197,7 +198,7 @@ func execFieldSelection(ctx context.Context, r *Request, s *resolvable.Schema, f
 		if f.field.UseMethodResolver() {
 			var in []reflect.Value
 			if f.field.HasContext {
-				in = append(in, reflect.ValueOf(traceCtx))
+				in = append(in, reflect.ValueOf(gcontext.WithGraphQLContext(traceCtx, f.field)))
 			}
 			if f.field.ArgsPacker != nil {
 				in = append(in, f.field.PackedArgs)

--- a/internal/exec/subscribe.go
+++ b/internal/exec/subscribe.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/internal/common"
+	gcontext "github.com/graph-gophers/graphql-go/internal/context"
 	"github.com/graph-gophers/graphql-go/internal/exec/resolvable"
 	"github.com/graph-gophers/graphql-go/internal/exec/selected"
 	"github.com/graph-gophers/graphql-go/internal/query"
@@ -40,7 +41,7 @@ func (r *Request) Subscribe(ctx context.Context, s *resolvable.Schema, op *query
 
 		var in []reflect.Value
 		if f.field.HasContext {
-			in = append(in, reflect.ValueOf(ctx))
+			in = append(in, reflect.ValueOf(gcontext.WithGraphQLContext(ctx, f.field)))
 		}
 		if f.field.ArgsPacker != nil {
 			in = append(in, f.field.PackedArgs)

--- a/selected/interface.go
+++ b/selected/interface.go
@@ -1,0 +1,78 @@
+package selected
+
+import (
+	"fmt"
+)
+
+type Kind int
+
+func (k Kind) String() string {
+	switch k {
+	case FieldKind:
+		return "field"
+	case TypeAssertionKind:
+		return "type_assertion"
+	case TypenameFieldKind:
+		return "typename_field"
+	default:
+		panic(fmt.Errorf("invalid kind %d received", k))
+	}
+}
+
+const (
+	FieldKind Kind = iota
+	TypeAssertionKind
+	TypenameFieldKind
+)
+
+type Selection interface {
+	Kind() Kind
+}
+
+type Field interface {
+	Selection
+	Identifier() string
+	Aliased() string
+	Children() []Selection
+}
+
+type TypeAssertion interface {
+	Selection
+	Type() string
+	Children() []Selection
+}
+
+type TypenameField interface {
+	Selection
+	Type() string
+	Aliased() string
+}
+
+func Dump(selection Selection) {
+	if selection == nil {
+		fmt.Println("Selection <nil>")
+		return
+	}
+
+	var print func(string, Selection)
+	print = func(indent string, sel Selection) {
+		switch v := sel.(type) {
+		case Field:
+			fmt.Printf(indent+"Field %s (%s)\n", v.Identifier(), v.Aliased())
+			for _, subSel := range v.Children() {
+				print(indent+"  ", subSel)
+			}
+		case TypeAssertion:
+			fmt.Printf(indent+"TypeAssertion %s\n", v.Type())
+			for _, subSel := range v.Children() {
+				print(indent+"  ", subSel)
+			}
+		case TypenameField:
+			fmt.Printf(indent+"TypenameField %s (%s)\n", v.Type(), v.Aliased())
+		default:
+			panic(fmt.Errorf("invalid selection %T received", v))
+		}
+	}
+
+	print("", selection)
+}


### PR DESCRIPTION
Added possibility to explore the actual field selection tree, this is attached to the context that the resolver method receive. I'm opening this to gather feedback about this new feature.

Each resolver's context will now be able to access through the graph of elements that were selected as part of the execution of this resolve via the standard go context's value.

The returned field is an interface representing a subset of the functionality of the internal/exec/selected package, enough for the developer to know what was queried by the user.

I'm opening the PR to start a discussion about offering this feature to end user of the library. We have started using it in our own fork of the library.

##### Design

This introduces new API interfaces the would become part of the standard library.

The interface is currently a simple wrapper around elements of `internal/exec/selected/Selection` interface needed to "walk" the selected field. Hopefully, I got the structure right.

I've currently used `Identifier()` instead of `Name()` and `Aliased()` instead of `Alias` to not renamed the field's name since there would be conflict with struct fields in the `internal/exec/selected/Selection` package. If we agree, the internal struct could change so the interface has the best name.

A future addition that I forsee could be:
- A "path" retrieval syntax "a la" gjson to quickly extract some nodes of the selection, for example with the star wars element ".search[]" that would return all type assertion nodes below the `search` field. Exact semantic to be discussed.
- Maybe a visitor pattern to ease the walking of the selection tree.