### PR TITLE
DisableIntrospection should skip __typename

### DIFF
--- a/graphql_test.go
+++ b/graphql_test.go
@@ -2614,6 +2614,44 @@ func TestIntrospectionDisableIntrospection(t *testing.T) {
 				}
 			`,
 		},
+
+		{
+			Schema: starwarsSchemaNoIntrospection,
+			Query: `
+				{
+					search(text: "an") {
+						__typename
+						... on Human {
+							name
+						}
+						... on Droid {
+							name
+						}
+						... on Starship {
+							name
+						}
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+					"search": [
+						{
+							"__typename": "Human",
+							"name": "Han Solo"
+						},
+						{
+							"__typename": "Human",
+							"name": "Leia Organa"
+						},
+						{
+							"__typename": "Starship",
+							"name": "TIE Advanced x1"
+						}
+					]
+				}
+			`,
+		},
 	})
 }
 
@@ -2997,7 +3035,7 @@ func TestInput(t *testing.T) {
 	})
 }
 
-type inputArgumentsHello struct {}
+type inputArgumentsHello struct{}
 
 type inputArgumentsScalarMismatch1 struct{}
 

--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -81,12 +81,12 @@ func applySelectionSet(r *Request, s *resolvable.Schema, e *resolvable.Object, s
 
 			switch field.Name.Name {
 			case "__typename":
-				if !r.DisableIntrospection {
-					flattenedSels = append(flattenedSels, &TypenameField{
-						Object: *e,
-						Alias:  field.Alias.Name,
-					})
-				}
+				// __typename is available even though r.DisableIntrospection == true
+				// because it is necessary when using union types and interfaces: https://graphql.org/learn/schema/#union-types
+				flattenedSels = append(flattenedSels, &TypenameField{
+					Object: *e,
+					Alias:  field.Alias.Name,
+				})
 
 			case "__schema":
 				if !r.DisableIntrospection {


### PR DESCRIPTION
`__typename` is defined in GraphQL spec [4.4](http://spec.graphql.org/June2018/#sec-Type-Name-Introspection), and when we use [union types](https://graphql.org/learn/schema/#union-types), the `__typename` field is usually used for differentiating different data types from each other on the client.

It is safe to expose the `__typename` field when `DisableIntrospection` because attackers can not get the type fields with `__typename`.