### PR TITLE
Adding modifying field extraction

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -183,9 +183,17 @@ func (s *Schema) ModifyingFields(queryString string, operationName string, varia
 	}
 
 	var fields []string
-	mainField := op.Selections[0].(*query.Field)
-	for _, arg := range mainField.Arguments {
-		fields = append(fields, fieldsFromLiteral(arg.Name.Name, arg.Value)...)
+	for _, selection := range op.Selections {
+		mainField, ok := selection.(*query.Field)
+
+		// not something we could process
+		if !ok {
+			continue
+		}
+
+		for _, arg := range mainField.Arguments {
+			fields = append(fields, fieldsFromLiteral(arg.Name.Name, arg.Value)...)
+		}
 	}
 
 	return opStr, fields, nil

--- a/graphql.go
+++ b/graphql.go
@@ -155,6 +155,58 @@ type Response struct {
 	Extensions map[string]interface{} `json:"extensions,omitempty"`
 }
 
+func (s *Schema) ModifyingFields(queryString string, operationName string, variables map[string]interface{}) (string, []string, []*errors.QueryError) {
+	doc, qErr := query.Parse(queryString)
+	if qErr != nil {
+		return "", nil, []*errors.QueryError{qErr}
+	}
+
+	if err := validation.Validate(s.schema, doc, variables, s.maxDepth); err != nil {
+		return "", nil, err
+	}
+
+	op, err := getOperation(doc, operationName)
+	if err != nil {
+		return "", nil, []*errors.QueryError{errors.Errorf("%s", err)}
+	}
+
+	opStr := string(op.Type)
+	// We are not modifying if we are querying or subscribing
+	if op.Type != query.Mutation {
+		return opStr, nil, nil
+	}
+
+	if op.Type == query.Mutation {
+		if _, ok := s.schema.EntryPoints["mutation"]; !ok {
+			return opStr, nil, []*errors.QueryError{{Message: "no mutations are offered by the schema"}}
+		}
+	}
+
+	var fields []string
+	mainField := op.Selections[0].(*query.Field)
+	for _, arg := range mainField.Arguments {
+		fields = append(fields, fieldsFromLiteral(arg.Name.Name, arg.Value)...)
+	}
+
+	return opStr, fields, nil
+}
+
+func fieldsFromLiteral(prefix string, lit common.Literal) []string {
+	var fields []string
+	switch t := lit.(type) {
+	case *common.ObjectLit:
+		for _, field := range t.Fields {
+			for _, fn := range fieldsFromLiteral(fmt.Sprintf("%s.%s", prefix, field.Name.Name), field.Value) {
+				fields = append(fields, fn)
+			}
+		}
+	default:
+		fields = append(fields, prefix)
+	}
+
+	return fields
+}
+
 // Validate validates the given query with the schema.
 func (s *Schema) Validate(queryString string) []*errors.QueryError {
 	return s.ValidateWithVariables(queryString, nil)

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -3932,6 +3932,22 @@ func TestSchema_ModifyingFields(t *testing.T) {
 			nil,
 		},
 		{
+			`mutation typenameSelectionPrior($name: String!) {
+				__typename
+				addPerson(person: {
+					firstName: $name,
+					lastName: "Fixed Last Name"
+				}) { id }
+			}`,
+			"typenameSelectionPrior",
+			map[string]interface{}{
+				"name": "Variable First Name",
+			},
+			string(query.Mutation),
+			nil,
+			[]string{"person.firstName", "person.lastName"},
+		},
+		{
 			`mutation addPersonSimpleFields($name: String!) {
 				addPerson(person: {
 					firstName: $name,


### PR DESCRIPTION
Adding a method for extract the fields that are being modifying in a mutation. The idea is to have a list of fields where each field is identified by the path (type.field). e.g.

Having as schema and query:
```
...
input PersonInput {
    firstName: String!,
    middleName: String,
    lastName: String!
    location: LocationInput
}

input LocationInput {
    name: String!,
    description: String
}
...

mutation addingPerson($name: String!) {
    addPerson(person: {
        firstName: $name,
        middleName: null,
        lastName: "Fixed Last Name",
        location: {
            name: "Fixed Location Name"
        }
    }) { id }
}
```

The list of fields that are being modified are:
`person.firstName`, `person.middleName`, `person.lastName`, `person.location.name`

Note that `person.location.description` is not provided, hence, it won't be listed.