### PR TITLE
Rename EntryPoints to RootOperationTypes

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -209,7 +209,7 @@ func (s *Schema) exec(ctx context.Context, queryString string, operationName str
 		return &Response{Errors: []*errors.QueryError{{Message: "graphql-ws protocol header is missing"}}}
 	}
 	if op.Type == query.Mutation {
-		if _, ok := s.schema.EntryPoints["mutation"]; !ok {
+		if _, ok := s.schema.RootOperationTypes["mutation"]; !ok {
 			return &Response{Errors: []*errors.QueryError{{Message: "no mutations are offered by the schema"}}}
 		}
 	}
@@ -273,7 +273,7 @@ func (s *Schema) validateSchema() error {
 }
 
 func validateRootOp(s *schema.Schema, name string, mandatory bool) error {
-	t, ok := s.EntryPoints[name]
+	t, ok := s.RootOperationTypes[name]
 	if !ok {
 		if mandatory {
 			return fmt.Errorf("root operation %q must be defined", name)

--- a/internal/exec/resolvable/resolvable.go
+++ b/internal/exec/resolvable/resolvable.go
@@ -70,19 +70,19 @@ func ApplyResolver(s *schema.Schema, resolver interface{}) (*Schema, error) {
 
 	var query, mutation, subscription Resolvable
 
-	if t, ok := s.EntryPoints["query"]; ok {
+	if t, ok := s.RootOperationTypes["query"]; ok {
 		if err := b.assignExec(&query, t, reflect.TypeOf(resolver)); err != nil {
 			return nil, err
 		}
 	}
 
-	if t, ok := s.EntryPoints["mutation"]; ok {
+	if t, ok := s.RootOperationTypes["mutation"]; ok {
 		if err := b.assignExec(&mutation, t, reflect.TypeOf(resolver)); err != nil {
 			return nil, err
 		}
 	}
 
-	if t, ok := s.EntryPoints["subscription"]; ok {
+	if t, ok := s.RootOperationTypes["subscription"]; ok {
 		if err := b.assignExec(&subscription, t, reflect.TypeOf(resolver)); err != nil {
 			return nil, err
 		}
@@ -362,7 +362,7 @@ func (b *execBuilder) makeFieldExec(typeName string, f *schema.Field, m reflect.
 	var out reflect.Type
 	if methodIndex != -1 {
 		out = m.Type.Out(0)
-		sub, ok := b.schema.EntryPoints["subscription"]
+		sub, ok := b.schema.RootOperationTypes["subscription"]
 		if ok && typeName == sub.TypeName() && out.Kind() == reflect.Chan {
 			out = m.Type.Out(0).Elem()
 		}

--- a/internal/schema/meta.go
+++ b/internal/schema/meta.go
@@ -7,9 +7,9 @@ func init() {
 // newMeta initializes an instance of the meta Schema.
 func newMeta() *Schema {
 	s := &Schema{
-		entryPointNames: make(map[string]string),
-		Types:           make(map[string]NamedType),
-		Directives:      make(map[string]*DirectiveDecl),
+		rootOperationTypeNames: make(map[string]string),
+		Types:                  make(map[string]NamedType),
+		Directives:             make(map[string]*DirectiveDecl),
 	}
 	if err := s.Parse(metaSrc, false); err != nil {
 		panic(err)

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -112,19 +112,19 @@ func Validate(s *schema.Schema, doc *query.Document, variables map[string]interf
 			}
 		}
 
-		var entryPoint schema.NamedType
+		var rootOperationType schema.NamedType
 		switch op.Type {
 		case query.Query:
-			entryPoint = s.EntryPoints["query"]
+			rootOperationType = s.RootOperationTypes["query"]
 		case query.Mutation:
-			entryPoint = s.EntryPoints["mutation"]
+			rootOperationType = s.RootOperationTypes["mutation"]
 		case query.Subscription:
-			entryPoint = s.EntryPoints["subscription"]
+			rootOperationType = s.RootOperationTypes["subscription"]
 		default:
 			panic("unreachable")
 		}
 
-		validateSelectionSet(opc, op.Selections, entryPoint)
+		validateSelectionSet(opc, op.Selections, rootOperationType)
 
 		fragUsed := make(map[*query.FragmentDecl]struct{})
 		markUsedFragments(c, op.Selections, fragUsed)

--- a/introspection/introspection.go
+++ b/introspection/introspection.go
@@ -45,7 +45,7 @@ func (r *Schema) Directives() []*Directive {
 }
 
 func (r *Schema) QueryType() *Type {
-	t, ok := r.schema.EntryPoints["query"]
+	t, ok := r.schema.RootOperationTypes["query"]
 	if !ok {
 		return nil
 	}
@@ -53,7 +53,7 @@ func (r *Schema) QueryType() *Type {
 }
 
 func (r *Schema) MutationType() *Type {
-	t, ok := r.schema.EntryPoints["mutation"]
+	t, ok := r.schema.RootOperationTypes["mutation"]
 	if !ok {
 		return nil
 	}
@@ -61,7 +61,7 @@ func (r *Schema) MutationType() *Type {
 }
 
 func (r *Schema) SubscriptionType() *Type {
-	t, ok := r.schema.EntryPoints["subscription"]
+	t, ok := r.schema.RootOperationTypes["subscription"]
 	if !ok {
 		return nil
 	}

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -24,7 +24,7 @@ func (s *Schema) Subscribe(ctx context.Context, queryString string, operationNam
 	if s.res.Resolver == (reflect.Value{}) {
 		return nil, errors.New("schema created without resolver, can not subscribe")
 	}
-	if _, ok := s.schema.EntryPoints["subscription"]; !ok {
+	if _, ok := s.schema.RootOperationTypes["subscription"]; !ok {
 		return nil, errors.New("no subscriptions are offered by the schema")
 	}
 	return s.subscribe(ctx, queryString, operationName, variables, s.res), nil


### PR DESCRIPTION
Rename entryPoints to RootOperationTypes to align with specification terminology.
see: https://spec.graphql.org/June2018/#sec-Root-Operation-Types