### PR TITLE
Add support for null vs missing input value

### DIFF
--- a/internal/exec/packer/packer.go
+++ b/internal/exec/packer/packer.go
@@ -78,24 +78,37 @@ func (b *Builder) assignPacker(target *packer, schemaType common.Type, reflectTy
 func (b *Builder) makePacker(schemaType common.Type, reflectType reflect.Type) (packer, error) {
 	t, nonNull := unwrapNonNull(schemaType)
 	if !nonNull {
-		if reflectType.Kind() != reflect.Ptr {
-			return nil, fmt.Errorf("%s is not a pointer", reflectType)
+		if reflectType.Kind() == reflect.Ptr {
+			elemType := reflectType.Elem()
+			addPtr := true
+			if _, ok := t.(*schema.InputObject); ok {
+				elemType = reflectType // keep pointer for input objects
+				addPtr = false
+			}
+			elem, err := b.makeNonNullPacker(t, elemType)
+			if err != nil {
+				return nil, err
+			}
+			return &nullPacker{
+				elemPacker: elem,
+				valueType:  reflectType,
+				addPtr:     addPtr,
+			}, nil
+		} else if isNullable(reflectType) {
+			elemType := reflectType
+			addPtr := false
+			elem, err := b.makeNonNullPacker(t, elemType)
+			if err != nil {
+				return nil, err
+			}
+			return &nullPacker{
+				elemPacker: elem,
+				valueType:  reflectType,
+				addPtr:     addPtr,
+			}, nil
+		} else {
+			return nil, fmt.Errorf("%s is not a pointer or a nullable type", reflectType)
 		}
-		elemType := reflectType.Elem()
-		addPtr := true
-		if _, ok := t.(*schema.InputObject); ok {
-			elemType = reflectType // keep pointer for input objects
-			addPtr = false
-		}
-		elem, err := b.makeNonNullPacker(t, elemType)
-		if err != nil {
-			return nil, err
-		}
-		return &nullPacker{
-			elemPacker: elem,
-			valueType:  reflectType,
-			addPtr:     addPtr,
-		}, nil
 	}
 
 	return b.makeNonNullPacker(t, reflectType)
@@ -266,7 +279,7 @@ type nullPacker struct {
 }
 
 func (p *nullPacker) Pack(value interface{}) (reflect.Value, error) {
-	if value == nil {
+	if value == nil && !isNullable(p.valueType) {
 		return reflect.Zero(p.valueType), nil
 	}
 
@@ -305,7 +318,7 @@ type unmarshalerPacker struct {
 }
 
 func (p *unmarshalerPacker) Pack(value interface{}) (reflect.Value, error) {
-	if value == nil {
+	if value == nil && !isNullable(p.ValueType) {
 		return reflect.Value{}, errors.Errorf("got null for non-null")
 	}
 
@@ -368,4 +381,15 @@ func unwrapNonNull(t common.Type) (common.Type, bool) {
 
 func stripUnderscore(s string) string {
 	return strings.Replace(s, "_", "", -1)
+}
+
+// NullUnmarshaller is an unmarshaller that can handle a nil input
+type NullUnmarshaller interface {
+	Unmarshaler
+	Nullable()
+}
+
+func isNullable(t reflect.Type) bool {
+	_, ok := reflect.New(t).Interface().(NullUnmarshaller)
+	return ok
 }

--- a/nullable_types.go
+++ b/nullable_types.go
@@ -1,0 +1,150 @@
+package graphql
+
+import (
+	"fmt"
+)
+
+// NullString is a string that can be null. Use it in input structs to
+// differentiate a value explicitly set to null from an omitted value.
+// When the value is defined (either null or a value) Set is true.
+type NullString struct {
+	Value *string
+	Set   bool
+}
+
+func (NullString) ImplementsGraphQLType(name string) bool {
+	return name == "String"
+}
+
+func (s *NullString) UnmarshalGraphQL(input interface{}) error {
+	s.Set = true
+
+	if input == nil {
+		return nil
+	}
+
+	switch v := input.(type) {
+	case string:
+		s.Value = &v
+		return nil
+	default:
+		return fmt.Errorf("wrong type for String: %T", v)
+	}
+}
+
+func (s *NullString) Nullable() {}
+
+// NullBool is a string that can be null. Use it in input structs to
+// differentiate a value explicitly set to null from an omitted value.
+// When the value is defined (either null or a value) Set is true.
+type NullBool struct {
+	Value *bool
+	Set   bool
+}
+
+func (NullBool) ImplementsGraphQLType(name string) bool {
+	return name == "Boolean"
+}
+
+func (s *NullBool) UnmarshalGraphQL(input interface{}) error {
+	s.Set = true
+
+	if input == nil {
+		return nil
+	}
+
+	switch v := input.(type) {
+	case bool:
+		s.Value = &v
+		return nil
+	default:
+		return fmt.Errorf("wrong type for Boolean: %T", v)
+	}
+}
+
+func (s *NullBool) Nullable() {}
+
+// NullInt is a string that can be null. Use it in input structs to
+// differentiate a value explicitly set to null from an omitted value.
+// When the value is defined (either null or a value) Set is true.
+type NullInt struct {
+	Value *int32
+	Set   bool
+}
+
+func (NullInt) ImplementsGraphQLType(name string) bool {
+	return name == "Int"
+}
+
+func (s *NullInt) UnmarshalGraphQL(input interface{}) error {
+	s.Set = true
+
+	if input == nil {
+		return nil
+	}
+
+	switch v := input.(type) {
+	case int32:
+		s.Value = &v
+		return nil
+	default:
+		return fmt.Errorf("wrong type for Int: %T", v)
+	}
+}
+
+func (s *NullInt) Nullable() {}
+
+// NullFloat is a string that can be null. Use it in input structs to
+// differentiate a value explicitly set to null from an omitted value.
+// When the value is defined (either null or a value) Set is true.
+type NullFloat struct {
+	Value *float64
+	Set   bool
+}
+
+func (NullFloat) ImplementsGraphQLType(name string) bool {
+	return name == "Float"
+}
+
+func (s *NullFloat) UnmarshalGraphQL(input interface{}) error {
+	s.Set = true
+
+	if input == nil {
+		return nil
+	}
+
+	switch v := input.(type) {
+	case float64:
+		s.Value = &v
+		return nil
+	default:
+		return fmt.Errorf("wrong type for Float: %T", v)
+	}
+}
+
+func (s *NullFloat) Nullable() {}
+
+// NullTime is a string that can be null. Use it in input structs to
+// differentiate a value explicitly set to null from an omitted value.
+// When the value is defined (either null or a value) Set is true.
+type NullTime struct {
+	Value *Time
+	Set   bool
+}
+
+func (NullTime) ImplementsGraphQLType(name string) bool {
+	return name == "Time"
+}
+
+func (s *NullTime) UnmarshalGraphQL(input interface{}) error {
+	s.Set = true
+
+	if input == nil {
+		return nil
+	}
+
+	s.Value = new(Time)
+	return s.Value.UnmarshalGraphQL(input)
+}
+
+func (s *NullTime) Nullable() {}


### PR DESCRIPTION
This is an attempt to solve https://github.com/graph-gophers/graphql-go/issues/210 by adding support for nullable non-pointer types. This is inspired by the Null types in the `sql` package.

The idea is to have custom types where we can call `UnmarshalGraphQL` with a `nil` input, thus allowing to differentiate between no value (method not called) and a null value (method called with `nil`).

The main change is to allow a non-pointer type to represent a nullable value if it implements the following interface:
```go
type NullUnmarshaller interface {
	Unmarshaler
	Nullable()
}
```

Also added nullable types for existing scalars: `NullString`, `NullInt`, `NullFloat`, `NullBool` and `NullTime`.

**Example**

```graphql
input MyInput {
    a: String
}

type Query {
    myQuery(input: MyInput!): String!
}
```

```go
type MyInput struct {
	A graphql.NullString
}

type resolver struct{}

func (r *resolver) MyQuery(args struct {
	Input MyInput
}) string {
	if args.Input.A.Valid {
		if args.Input.A.Value == nil {
			// null value provided
		} else {
			// non-null value provided
		}
	} else {
		// field omitted
	}

	return "hello world"
}
```