### PR TITLE
Adding support for partial returns under context deadlines

### DIFF
--- a/internal/exec/subscribe.go
+++ b/internal/exec/subscribe.go
@@ -154,7 +154,7 @@ func (r *Request) Subscribe(ctx context.Context, s *resolvable.Schema, op *query
 					}()
 
 					if err := subCtx.Err(); err != nil {
-						c <- &Response{Errors: []*errors.QueryError{errors.Errorf("%s", err)}}
+						c <- &Response{Data: out.Bytes(), Errors: []*errors.QueryError{errors.Errorf("%s", err)}}
 						return
 					}
 

--- a/internal/exec/subscribe.go
+++ b/internal/exec/subscribe.go
@@ -154,7 +154,7 @@ func (r *Request) Subscribe(ctx context.Context, s *resolvable.Schema, op *query
 					}()
 
 					if err := subCtx.Err(); err != nil {
-						c <- &Response{Data: out.Bytes(), Errors: []*errors.QueryError{errors.Errorf("%s", err)}}
+						c <- &Response{Data: nil, Errors: []*errors.QueryError{errors.Errorf("%s", err)}}
 						return
 					}
 

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -1,0 +1,71 @@
+package graphql_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	graphql "github.com/graph-gophers/graphql-go"
+	qerrors "github.com/graph-gophers/graphql-go/errors"
+	"github.com/graph-gophers/graphql-go/gqltesting"
+)
+
+type TimeoutTest struct {
+}
+
+func (r *TimeoutTest) Message(args struct{ Timeout int32 }) *string {
+	time.Sleep(time.Duration(args.Timeout) * time.Millisecond)
+	s := "Success!"
+	return &s
+}
+
+func TestSchemaSubscribe_CustomResolverTimeout_(t *testing.T) {
+	cxt, _ := context.WithDeadline(context.Background(), time.Now().Add(10*time.Millisecond)) // This test now depends on the simplest resolver returning within 10 milliseconds
+	cxt2, cancelFunc := context.WithDeadline(context.Background(), time.Now().Add(50*time.Millisecond))
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		cancelFunc()
+	}()
+	gqltesting.RunTests(t, []*gqltesting.Test{
+		{
+			Schema: graphql.MustParseSchema(`
+			schema {
+				query: Query
+			}
+
+			type Query {
+				Message(Timeout: Int!): String
+			}
+		`, &TimeoutTest{}),
+			Query: `
+			{
+			m1: Message(Timeout: 1) 
+			m2: Message(Timeout: 2000) 
+			}
+		`,
+			ExpectedResult: ` { "m1": "Success!", "m2": null }`,
+			ExpectedErrors: []*qerrors.QueryError{qerrors.Errorf("context deadline exceeded")},
+			Context:        cxt,
+		},
+		{
+			Schema: graphql.MustParseSchema(`
+			schema {
+				query: Query
+			}
+
+			type Query {
+				Message(Timeout: Int!): String
+			}
+		`, &TimeoutTest{}),
+			Query: `
+			{
+			m1: Message(Timeout: 20) 
+			m2: Message(Timeout: 2000) 
+			}
+		`,
+			ExpectedResult: ` { "m1": null, "m2": null }`,
+			ExpectedErrors: []*qerrors.QueryError{qerrors.Errorf("context canceled")},
+			Context:        cxt2,
+		},
+	})
+}

--- a/timeout_test.go
+++ b/timeout_test.go
@@ -19,53 +19,94 @@ func (r *TimeoutTest) Message(args struct{ Timeout int32 }) *string {
 	return &s
 }
 
+func (r *TimeoutTest) MetaMessage() MetaMessage {
+	m := MetaMessage{}
+	return m
+}
+
+type MetaMessage struct {
+}
+
+func (m MetaMessage) Msg(args struct{ Timeout int32 }) string {
+	time.Sleep(time.Duration(args.Timeout) * time.Millisecond)
+	s := "MetaSuccess!"
+	return s
+}
+
 func TestSchemaSubscribe_CustomResolverTimeout_(t *testing.T) {
 	cxt, _ := context.WithDeadline(context.Background(), time.Now().Add(10*time.Millisecond)) // This test now depends on the simplest resolver returning within 10 milliseconds
 	cxt2, cancelFunc := context.WithDeadline(context.Background(), time.Now().Add(50*time.Millisecond))
+	cxt3, _ := context.WithDeadline(context.Background(), time.Now().Add(500*time.Millisecond)) // This test now depends on the simplest resolver returning within 10 milliseconds
 	go func() {
-		time.Sleep(10 * time.Millisecond)
+		time.Sleep(20 * time.Millisecond)
 		cancelFunc()
 	}()
 	gqltesting.RunTests(t, []*gqltesting.Test{
-		{
+		{ // test that one feature will sucessfully return
 			Schema: graphql.MustParseSchema(`
-			schema {
-				query: Query
-			}
+					schema {
+						query: Query
+					}
 
-			type Query {
-				Message(Timeout: Int!): String
-			}
-		`, &TimeoutTest{}),
+					type Query {
+						Message(Timeout: Int!): String
+					}
+				`, &TimeoutTest{}),
 			Query: `
-			{
-			m1: Message(Timeout: 1) 
-			m2: Message(Timeout: 2000) 
-			}
-		`,
+					{
+					m1: Message(Timeout: 1)
+					m2: Message(Timeout: 2000)
+					}
+				`,
 			ExpectedResult: ` { "m1": "Success!", "m2": null }`,
 			ExpectedErrors: []*qerrors.QueryError{qerrors.Errorf("context deadline exceeded")},
 			Context:        cxt,
 		},
-		{
+		{ // test that canceling works properly
+			Schema: graphql.MustParseSchema(`
+					schema {
+						query: Query
+					}
+
+					type Query {
+						Message(Timeout: Int!): String
+					}
+				`, &TimeoutTest{}),
+			Query: `
+					{
+					m1: Message(Timeout: 1)
+					m2: Message(Timeout: 2000)
+					}
+				`,
+			ExpectedResult: ` { "m1": "Success!", "m2": null }`,
+			ExpectedErrors: []*qerrors.QueryError{qerrors.Errorf("context canceled")},
+			Context:        cxt2,
+		},
+		{ // test that when we timeout on non-nullable fields we return valid JSON
 			Schema: graphql.MustParseSchema(`
 			schema {
 				query: Query
 			}
 
+			type MetaMessage {
+				Msg(Timeout: Int!): String!
+			}
+
 			type Query {
-				Message(Timeout: Int!): String
+				MetaMessage: MetaMessage!
 			}
 		`, &TimeoutTest{}),
 			Query: `
 			{
-			m1: Message(Timeout: 20) 
-			m2: Message(Timeout: 2000) 
+			MetaMessage {
+					m1: Msg(Timeout: 1000)
+					m2: Msg(Timeout: 1000)
+				}
 			}
 		`,
-			ExpectedResult: ` { "m1": null, "m2": null }`,
-			ExpectedErrors: []*qerrors.QueryError{qerrors.Errorf("context canceled")},
-			Context:        cxt2,
+			ExpectedResult: ` { "MetaMessage": {"m1":null, "m2": null }}`,
+			ExpectedErrors: []*qerrors.QueryError{qerrors.Errorf("context deadline exceeded")},
+			Context:        cxt3,
 		},
 	})
 }


### PR DESCRIPTION
# Motivation

We'd like to support taking in a timeout/deadline at the request level and returning as many of the fields as we can within that deadline.

Initial investigations showed that if any resolvers take longer than the deadline then no data is returned.

# Within the scope of this PR

We add the ability to return all fields that have completed if a context times out or is canceled.
Adding two test cases that verify behavior for context timing out as well as context cancellation.

# Outside the scope of this PR

* Extending this support to cover the synchronous code path. This currently only supports the async code path.
* Add an error message that identifies which field timed out
* Supporting context canceling properly for subscriptions

# Misc
Additionally it looks like we've added support for building the response & returning it as soon as the context times out. Previously if we gave a context deadline but our resolvers did not respect it then we'd block until the http request is closed or the resolver returns, at which point we'd throw away the output & return an error.