### PR TITLE
Add support for interfaces implementing other interfaces

### DIFF
--- a/example/social/introspect.json
+++ b/example/social/introspect.json
@@ -15,10 +15,7 @@
           }
         ],
         "description": "Marks an element of a GraphQL schema as no longer supported.",
-        "locations": [
-          "FIELD_DEFINITION",
-          "ENUM_VALUE"
-        ],
+        "locations": ["FIELD_DEFINITION", "ENUM_VALUE"],
         "name": "deprecated"
       },
       {
@@ -39,11 +36,7 @@
           }
         ],
         "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
         "name": "include"
       },
       {
@@ -64,11 +57,7 @@
           }
         ],
         "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
         "name": "skip"
       }
     ],
@@ -132,7 +121,7 @@
           }
         ],
         "inputFields": null,
-        "interfaces": null,
+        "interfaces": [],
         "kind": "INTERFACE",
         "name": "Admin",
         "possibleTypes": [
@@ -236,7 +225,7 @@
           }
         ],
         "inputFields": null,
-        "interfaces": null,
+        "interfaces": [],
         "kind": "INTERFACE",
         "name": "Person",
         "possibleTypes": [

--- a/example/starwars/introspect.json
+++ b/example/starwars/introspect.json
@@ -15,10 +15,7 @@
           }
         ],
         "description": "Marks an element of a GraphQL schema as no longer supported.",
-        "locations": [
-          "FIELD_DEFINITION",
-          "ENUM_VALUE"
-        ],
+        "locations": ["FIELD_DEFINITION", "ENUM_VALUE"],
         "name": "deprecated"
       },
       {
@@ -39,11 +36,7 @@
           }
         ],
         "description": "Directs the executor to include this field or fragment only when the `if` argument is true.",
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
         "name": "include"
       },
       {
@@ -64,11 +57,7 @@
           }
         ],
         "description": "Directs the executor to skip this field or fragment when the `if` argument is true.",
-        "locations": [
-          "FIELD",
-          "FRAGMENT_SPREAD",
-          "INLINE_FRAGMENT"
-        ],
+        "locations": ["FIELD", "FRAGMENT_SPREAD", "INLINE_FRAGMENT"],
         "name": "skip"
       }
     ],
@@ -205,7 +194,7 @@
           }
         ],
         "inputFields": null,
-        "interfaces": null,
+        "interfaces": [],
         "kind": "INTERFACE",
         "name": "Character",
         "possibleTypes": [

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -2204,7 +2204,7 @@ func TestIntrospection(t *testing.T) {
 					"b": {
 						"name": "Character",
 						"kind": "INTERFACE",
-						"interfaces": null,
+						"interfaces": [],
 						"possibleTypes": [
 							{
 								"name": "Human"

--- a/internal/common/lexer_test.go
+++ b/internal/common/lexer_test.go
@@ -94,21 +94,21 @@ func TestConsume(t *testing.T) {
 	}
 }
 
-var multilineStringTests = []consumeTestCase {
+var multilineStringTests = []consumeTestCase{
 	{
-		description: "Oneline strings are okay",
-		definition: `"Hello World"`,
-		expected: "",
-		failureExpected: false,
-		useStringDescriptions: true,		
+		description:           "Oneline strings are okay",
+		definition:            `"Hello World"`,
+		expected:              "",
+		failureExpected:       false,
+		useStringDescriptions: true,
 	},
 	{
 		description: "Multiline strings are not allowed",
 		definition: `"Hello
 				 World"`,
-		expected: `graphql: syntax error: literal not terminated (line 1, column 1)`,
-		failureExpected: true,
-		useStringDescriptions: true,		
+		expected:              `graphql: syntax error: literal not terminated (line 1, column 1)`,
+		failureExpected:       true,
+		useStringDescriptions: true,
 	},
 }
 
@@ -130,5 +130,5 @@ func TestMultilineString(t *testing.T) {
 				t.Fatalf("Test '%s' failed with error: '%s'", test.description, err.Error())
 			}
 		})
-	}	
+	}
 }

--- a/introspection/introspection.go
+++ b/introspection/introspection.go
@@ -121,13 +121,18 @@ func (r *Type) Fields(args *struct{ IncludeDeprecated bool }) *[]*Field {
 }
 
 func (r *Type) Interfaces() *[]*Type {
-	t, ok := r.typ.(*schema.Object)
-	if !ok {
+	var ifaces []*schema.Interface
+	switch t := r.typ.(type) {
+	case *schema.Object:
+		ifaces = t.Interfaces
+	case *schema.Interface:
+		ifaces = t.Interfaces
+	default:
 		return nil
 	}
 
-	l := make([]*Type, len(t.Interfaces))
-	for i, intf := range t.Interfaces {
+	l := make([]*Type, len(ifaces))
+	for i, intf := range ifaces {
 		l[i] = &Type{intf}
 	}
 	return &l


### PR DESCRIPTION
To fix issue [Add support for interfaces implementing other interfaces](https://github.com/graph-gophers/graphql-go/issues/416)

To match new draft spec here: http://spec.graphql.org/draft/#sec-Interfaces.Interfaces-Implementing-Interfaces
Allows the following functionality:
```graphql
interface Node {
  id: ID!
}

interface Resource implements Node {
  id: ID!
  url: String
}
```


The implementation here isn't massively efficient, I check multiple interfaces multiple times, mostly due to the requirement that

> Transitively implemented interfaces (interfaces implemented by the interface that is being implemented) must also be defined on an implementing type or interface. For example, Image cannot implement Resource without also implementing Node:
https://spec.graphql.org/draft/#sel-FAHbhBHCAACGB35P

There's definitely a more efficient solution than the one here, really just wanted an opinion as to whether it is worth it. 

Thanks
Tom