### PR TITLE
Fix issue graphql.Time unmarshal time check #432

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,5 +1,8 @@
 module github.com/graph-gophers/graphql-go
 
-require github.com/opentracing/opentracing-go v1.1.0
+require (
+	github.com/opentracing/opentracing-go v1.1.0
+	github.com/stretchr/testify v1.7.0
+)
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,12 @@
+github.com/davecgh/go-spew v1.1.0 h1:ZDRjVQ15GmhC3fiQ8ni8+OwkZQO4DARzQgrnXU1Liz8=
+github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/opentracing/opentracing-go v1.1.0 h1:pWlfV3Bxv7k65HYwkikxat0+s3pV4bsqf19k25Ur8rU=
 github.com/opentracing/opentracing-go v1.1.0/go.mod h1:UkNAQd3GIcIGf0SeVgPpRdFStlNbqXla1AfSYxPUl2o=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
+github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
+github.com/stretchr/testify v1.7.0 h1:nwc3DEeHmmLAfoZucVR881uASk0Mfjw8xYJ99tb5CcY=
+github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
+gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/time.go
+++ b/time.go
@@ -35,7 +35,13 @@ func (t *Time) UnmarshalGraphQL(input interface{}) error {
 		t.Time = time.Unix(int64(input), 0)
 		return nil
 	case int64:
-		t.Time = time.Unix(input, 0)
+		if input >= 1e10 {
+			sec := input / 1e9
+			nsec := input - (sec * 1e9)
+			t.Time = time.Unix(sec, nsec)
+		} else {
+			t.Time = time.Unix(input, 0)
+		}
 		return nil
 	case float64:
 		t.Time = time.Unix(int64(input), 0)

--- a/time_test.go
+++ b/time_test.go
@@ -1,0 +1,50 @@
+package graphql
+
+import (
+	"testing"
+	"time"
+)
+
+var timeTestCases = []interface{}{
+	time.Now(),
+	int32(1),
+	time.Now().Unix(),
+	time.Now().UnixNano(),
+	float64(-1),
+	"2006-01-02T15:04:05Z",
+}
+
+func TestImplementsGraphQLType(t *testing.T) {
+	time := Time{}
+	if !time.ImplementsGraphQLType("Time") {
+		t.Fail()
+	}
+}
+
+func TestUnmarshalGraphQL(t *testing.T) {
+	var err error
+	testTime := &Time{}
+
+	for _, timeType := range timeTestCases {
+		if err = testTime.UnmarshalGraphQL(timeType); err != nil {
+			t.Fatalf("Failed to unmarshal %#v to Time: %s", timeType, err.Error())
+		}
+	}
+
+	if err = testTime.UnmarshalGraphQL(false); err == nil {
+		t.Fatalf("Unmarshaling of %T to Time should be failed.", false)
+	}
+}
+
+func TestMarshalJSON(t *testing.T) {
+	exampleTime := "\"0001-01-01T00:00:00Z\""
+	testTime := &Time{}
+
+	buf, err := testTime.MarshalJSON()
+	if err != nil {
+		t.Fatalf("Failed to marshal time to JSON: %s", err.Error())
+	}
+	if string(buf) != exampleTime {
+		t.Fatalf("Failed to marshal Time to JSON, expected %s, but instead got %s", exampleTime, buf)
+	}
+}


### PR DESCRIPTION
Now we can use both unix timestamps:

```
t.UnmarshalGraphQL(time.Now().UnixNano())
t.UnmarshalGraphQL(time.Now().Unix())
```