### PR TITLE
Add exported IsNullable method to nullable types

### DIFF
--- a/nullable_types.go
+++ b/nullable_types.go
@@ -2,6 +2,9 @@ package graphql
 
 import (
 	"fmt"
+	"reflect"
+
+	"github.com/graph-gophers/graphql-go/internal/exec/packer"
 )
 
 // NullString is a string that can be null. Use it in input structs to
@@ -10,6 +13,13 @@ import (
 type NullString struct {
 	Value *string
 	Set   bool
+}
+
+// IsNullable takes a type and returns whether it represents a Nullable value
+// as defined by NullUnmarshaller
+func IsNullable(t reflect.Type) bool {
+	_, ok := reflect.New(t).Interface().(packer.NullUnmarshaller)
+	return ok
 }
 
 func (NullString) ImplementsGraphQLType(name string) bool {


### PR DESCRIPTION
I was very happy to see https://github.com/graph-gophers/graphql-go/pull/430 merged and am now using it. However, in my project, I felt that having an exported `IsNullable` method would be useful, especially when implementing `Nullable` custom scalar types.

This will allow one to verify that custom `Nullable` implementations correctly implement the `NullUnmarshaller` interface.

It also allows us to verify the type of the input field for things like gRPC field masks.

E.g., previously, if one had a traditional nullable field, we would not be able to generate gRPC field masks accurately for partial updates because if a field was `nil` we would not add the field mask. Now, users can check if a field `IsNullable`, and if it is, check if the `Set` field is `true` or `false`, in order to set a field mask accurately.

Hopefully this method is safe to export; it would be helpful for our project and I hope it will be useful to others who want to take advantage of the new Nullable functionality.