### PR TITLE
Added ability to use your own directives usage

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -82,6 +82,7 @@ type Schema struct {
 	useStringDescriptions    bool
 	disableIntrospection     bool
 	subscribeResolverTimeout time.Duration
+	visitors                 map[string]types.DirectiveVisitor
 }
 
 func (s *Schema) ASTSchema() *types.Schema {
@@ -165,6 +166,14 @@ func DisableIntrospection() SchemaOpt {
 func SubscribeResolverTimeout(timeout time.Duration) SchemaOpt {
 	return func(s *Schema) {
 		s.subscribeResolverTimeout = timeout
+	}
+}
+
+// DirectiveVisitors allows to pass custom directive visitors that will be able to handle
+// your GraphQL schema directives.
+func DirectiveVisitors(visitors map[string]types.DirectiveVisitor) SchemaOpt {
+	return func(s *Schema) {
+		s.visitors = visitors
 	}
 }
 
@@ -257,6 +266,7 @@ func (s *Schema) exec(ctx context.Context, queryString string, operationName str
 		Tracer:       s.tracer,
 		Logger:       s.logger,
 		PanicHandler: s.panicHandler,
+		Visitors:     s.visitors,
 	}
 	varTypes := make(map[string]*introspection.Type)
 	for _, v := range op.Vars {

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/graph-gophers/graphql-go/gqltesting"
 	"github.com/graph-gophers/graphql-go/introspection"
 	"github.com/graph-gophers/graphql-go/trace"
+	"github.com/graph-gophers/graphql-go/types"
 )
 
 type helloWorldResolver1 struct{}
@@ -46,6 +47,27 @@ func (r *helloSnakeResolver2) HelloHTML(ctx context.Context) (string, error) {
 
 func (r *helloSnakeResolver2) SayHello(ctx context.Context, args struct{ FullName string }) (string, error) {
 	return "Hello " + args.FullName + "!", nil
+}
+
+type customDirectiveVisitor struct {
+	beforeWasCalled bool
+}
+
+func (v *customDirectiveVisitor) Before(ctx context.Context, directive *types.Directive, input interface{}) error {
+	v.beforeWasCalled = true
+	return nil
+}
+
+func (v *customDirectiveVisitor) After(ctx context.Context, directive *types.Directive, output interface{}) (interface{}, error) {
+	if v.beforeWasCalled == false {
+		return nil, errors.New("Before directive visitor method wasn't called.")
+	}
+
+	if value, ok := directive.Arguments.Get("customAttribute"); ok {
+		return fmt.Sprintf("Directive '%s' (with arg '%s') modified result: %s", directive.Name.Name, value.String(), output.(string)), nil
+	} else {
+		return fmt.Sprintf("Directive '%s' modified result: %s", directive.Name.Name, output.(string)), nil
+	}
 }
 
 type theNumberResolver struct {
@@ -191,7 +213,6 @@ func TestHelloWorld(t *testing.T) {
 				}
 			`,
 		},
-
 		{
 			Schema: graphql.MustParseSchema(`
 				schema {
@@ -210,6 +231,67 @@ func TestHelloWorld(t *testing.T) {
 			ExpectedResult: `
 				{
 					"hello": "Hello world!"
+				}
+			`,
+		},
+	})
+}
+
+func TestCustomDirective(t *testing.T) {
+	t.Parallel()
+
+	gqltesting.RunTests(t, []*gqltesting.Test{
+		{
+			Schema: graphql.MustParseSchema(`
+				directive @customDirective on FIELD_DEFINITION
+
+				schema {
+					query: Query
+				}
+
+				type Query {
+					hello_html: String! @customDirective
+				}
+			`, &helloSnakeResolver1{},
+				graphql.DirectiveVisitors(map[string]types.DirectiveVisitor{
+					"customDirective": &customDirectiveVisitor{},
+				})),
+			Query: `
+				{
+					hello_html
+				}
+			`,
+			ExpectedResult: `
+				{
+					"hello_html": "Directive 'customDirective' modified result: Hello snake!"
+				}
+			`,
+		},
+		{
+			Schema: graphql.MustParseSchema(`
+				directive @customDirective(
+					customAttribute: String!
+			    ) on FIELD_DEFINITION
+
+				schema {
+					query: Query
+				}
+
+				type Query {
+					say_hello(full_name: String!): String! @customDirective(customAttribute: hi)
+				}
+			`, &helloSnakeResolver1{},
+				graphql.DirectiveVisitors(map[string]types.DirectiveVisitor{
+					"customDirective": &customDirectiveVisitor{},
+				})),
+			Query: `
+				{
+					say_hello(full_name: "Johnny")
+				}
+			`,
+			ExpectedResult: `
+				{
+					"say_hello": "Directive 'customDirective' (with arg 'hi') modified result: Hello Johnny!"
 				}
 			`,
 		},

--- a/types/directive.go
+++ b/types/directive.go
@@ -1,6 +1,10 @@
 package types
 
-import "github.com/graph-gophers/graphql-go/errors"
+import (
+	"context"
+
+	"github.com/graph-gophers/graphql-go/errors"
+)
 
 // Directive is a representation of the GraphQL Directive.
 //
@@ -22,6 +26,11 @@ type DirectiveDefinition struct {
 }
 
 type DirectiveList []*Directive
+
+type DirectiveVisitor interface {
+	Before(ctx context.Context, directive *Directive, input interface{}) error
+	After(ctx context.Context, directive *Directive, output interface{}) (interface{}, error)
+}
 
 // Returns the Directive in the DirectiveList by name or nil if not found.
 func (l DirectiveList) Get(name string) *Directive {


### PR DESCRIPTION
Hi,

## Description

This PR goal is to bring ability to use so custom directives, as mentioned in issue https://github.com/graph-gophers/graphql-go/issues/151.

I would be interested in having feedbacks, mainly on the way that I am currently re-using the `internal/common` package exported to be used publicly in `pkg/common`: maybe I could just copy objects I need (but I need a lot of these defined in package ;-)).

## Example usage

Assuming that I have the following schema:

```graphql
directive @customDirective(
	customAttribute: String!
) on FIELD_DEFINITION

schema {
	query: Query
}

type Query {
	myTestQuery: String! @customDirective(customAttribute: hi)
}
```

I can use the directive in my resolver by adding a new argument:

```go
func (r *customDirectiveResolver) MyTestQuery(ctx context.Context, directives common.DirectiveList) string {
	customDirective := directives.Get("customDirective")
	customAttribute, _ := customDirective.Args.Get("customAttribute")

	return fmt.Sprintf(
		"Hello custom directive '%s' with attribute value '%s'!",
		customDirective.Name.Name,
		customAttribute.String(),
	)
}
```

Thank you!