### PR TITLE
expose packer.Unmarshaler as decode.Unmarshaler to the public

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/.idea
+/.vscode
 /internal/validation/testdata/graphql-js
 /internal/validation/testdata/node_modules
 /vendor

--- a/decode/decode.go
+++ b/decode/decode.go
@@ -1,0 +1,13 @@
+package decode
+
+// Unmarshaler defines the api of Go types mapped to custom GraphQL scalar types
+type Unmarshaler interface {
+	// ImplementsGraphQLType maps the implementing custom Go type
+	// to the GraphQL scalar type in the schema.
+	ImplementsGraphQLType(name string) bool
+	// UnmarshalGraphQL is the custom unmarshaler for the implementing type
+	//
+	// This function will be called whenever you use the
+	// custom GraphQL scalar type as an input
+	UnmarshalGraphQL(input interface{}) error
+}

--- a/graphql.go
+++ b/graphql.go
@@ -10,6 +10,7 @@ import (
 	"github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/internal/common"
 	"github.com/graph-gophers/graphql-go/internal/exec"
+	"github.com/graph-gophers/graphql-go/internal/exec/packer"
 	"github.com/graph-gophers/graphql-go/internal/exec/resolvable"
 	"github.com/graph-gophers/graphql-go/internal/exec/selected"
 	"github.com/graph-gophers/graphql-go/internal/query"
@@ -19,6 +20,9 @@ import (
 	"github.com/graph-gophers/graphql-go/log"
 	"github.com/graph-gophers/graphql-go/trace"
 )
+
+// Unmarshaler defines the public api of Go types mapped to custom GraphQL scalar types
+type Unmarshaler = packer.Unmarshaler
 
 // ParseSchema parses a GraphQL schema and attaches the given root resolver. It returns an error if
 // the Go type signature of the resolvers does not match the schema. If nil is passed as the

--- a/graphql.go
+++ b/graphql.go
@@ -10,7 +10,6 @@ import (
 	"github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/internal/common"
 	"github.com/graph-gophers/graphql-go/internal/exec"
-	"github.com/graph-gophers/graphql-go/internal/exec/packer"
 	"github.com/graph-gophers/graphql-go/internal/exec/resolvable"
 	"github.com/graph-gophers/graphql-go/internal/exec/selected"
 	"github.com/graph-gophers/graphql-go/internal/query"
@@ -20,9 +19,6 @@ import (
 	"github.com/graph-gophers/graphql-go/log"
 	"github.com/graph-gophers/graphql-go/trace"
 )
-
-// Unmarshaler defines the public api of Go types mapped to custom GraphQL scalar types
-type Unmarshaler = packer.Unmarshaler
 
 // ParseSchema parses a GraphQL schema and attaches the given root resolver. It returns an error if
 // the Go type signature of the resolvers does not match the schema. If nil is passed as the

--- a/internal/exec/packer/packer.go
+++ b/internal/exec/packer/packer.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/graph-gophers/graphql-go/decode"
 	"github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/internal/common"
 	"github.com/graph-gophers/graphql-go/internal/schema"
@@ -115,7 +116,7 @@ func (b *Builder) makePacker(schemaType common.Type, reflectType reflect.Type) (
 }
 
 func (b *Builder) makeNonNullPacker(schemaType common.Type, reflectType reflect.Type) (packer, error) {
-	if u, ok := reflect.New(reflectType).Interface().(Unmarshaler); ok {
+	if u, ok := reflect.New(reflectType).Interface().(decode.Unmarshaler); ok {
 		if !u.ImplementsGraphQLType(schemaType.String()) {
 			return nil, fmt.Errorf("can not unmarshal %s into %s", schemaType, reflectType)
 		}
@@ -323,21 +324,10 @@ func (p *unmarshalerPacker) Pack(value interface{}) (reflect.Value, error) {
 	}
 
 	v := reflect.New(p.ValueType)
-	if err := v.Interface().(Unmarshaler).UnmarshalGraphQL(value); err != nil {
+	if err := v.Interface().(decode.Unmarshaler).UnmarshalGraphQL(value); err != nil {
 		return reflect.Value{}, err
 	}
 	return v.Elem(), nil
-}
-
-type Unmarshaler interface {
-	// ImplementsGraphQLType maps the implementing custom Go type
-	// to the GraphQL scalar type in the schema.
-	ImplementsGraphQLType(name string) bool
-	// UnmarshalGraphQL is the custom unmarshaler for the implementing type
-	//
-	// This function will be called whenever you use the
-	// custom GraphQL scalar type as an input
-	UnmarshalGraphQL(input interface{}) error
 }
 
 func unmarshalInput(typ reflect.Type, input interface{}) (interface{}, error) {
@@ -391,7 +381,7 @@ func stripUnderscore(s string) string {
 
 // NullUnmarshaller is an unmarshaller that can handle a nil input
 type NullUnmarshaller interface {
-	Unmarshaler
+	decode.Unmarshaler
 	Nullable()
 }
 

--- a/internal/exec/packer/packer.go
+++ b/internal/exec/packer/packer.go
@@ -330,7 +330,13 @@ func (p *unmarshalerPacker) Pack(value interface{}) (reflect.Value, error) {
 }
 
 type Unmarshaler interface {
+	// ImplementsGraphQLType maps the implementing custom Go type
+	// to the GraphQL scalar type in the schema.
 	ImplementsGraphQLType(name string) bool
+	// UnmarshalGraphQL is the custom unmarshaler for the implementing type
+	//
+	// This function will be called whenever you use the
+	// custom GraphQL scalar type as an input
 	UnmarshalGraphQL(input interface{}) error
 }
 

--- a/internal/exec/resolvable/resolvable.go
+++ b/internal/exec/resolvable/resolvable.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"strings"
 
+	"github.com/graph-gophers/graphql-go/decode"
 	"github.com/graph-gophers/graphql-go/internal/common"
 	"github.com/graph-gophers/graphql-go/internal/exec/packer"
 	"github.com/graph-gophers/graphql-go/internal/schema"
@@ -207,7 +208,7 @@ func makeScalarExec(t *schema.Scalar, resolverType reflect.Type) (Resolvable, er
 		implementsType = t.Name == "String"
 	case *bool:
 		implementsType = t.Name == "Boolean"
-	case packer.Unmarshaler:
+	case decode.Unmarshaler:
 		implementsType = r.ImplementsGraphQLType(t.Name)
 	}
 	if !implementsType {

--- a/time.go
+++ b/time.go
@@ -31,6 +31,10 @@ func (t *Time) UnmarshalGraphQL(input interface{}) error {
 		var err error
 		t.Time, err = time.Parse(time.RFC3339, input)
 		return err
+	case []byte:
+		var err error
+		t.Time, err = time.Parse(time.RFC3339, string(input))
+		return err
 	case int32:
 		t.Time = time.Unix(int64(input), 0)
 		return nil

--- a/time_test.go
+++ b/time_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	. "github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/decode"
 )
 
 func TestTime_ImplementsUnmarshaler(t *testing.T) {
@@ -16,8 +17,8 @@ func TestTime_ImplementsUnmarshaler(t *testing.T) {
 		}
 	}()
 
-	// assert *Time implements Unmarshaler interface
-	var _ Unmarshaler = (*Time)(nil)
+	// assert *Time implements decode.Unmarshaler interface
+	var _ decode.Unmarshaler = (*Time)(nil)
 }
 
 func TestTime_ImplementsGraphQLType(t *testing.T) {

--- a/time_test.go
+++ b/time_test.go
@@ -1,0 +1,158 @@
+package graphql_test
+
+import (
+	"bytes"
+	"encoding/json"
+	"testing"
+	"time"
+
+	. "github.com/graph-gophers/graphql-go"
+)
+
+func TestTime_ImplementsUnmarshaler(t *testing.T) {
+	defer func() {
+		if err := recover(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// assert *Time implements Unmarshaler interface
+	var _ Unmarshaler = (*Time)(nil)
+}
+
+func TestTime_ImplementsGraphQLType(t *testing.T) {
+	gt := new(Time)
+
+	if gt.ImplementsGraphQLType("foobar") {
+		t.Error("Type *Time must not claim to implement GraphQL type 'foobar'")
+	}
+
+	if !gt.ImplementsGraphQLType("Time") {
+		t.Error("Failed asserting *Time implements GraphQL type Time")
+	}
+}
+
+func TestTime_MarshalJSON(t *testing.T) {
+	var err error
+	var b1, b2 []byte
+	ref := time.Date(2021, time.April, 20, 12, 3, 23, 0, time.UTC)
+
+	if b1, err = json.Marshal(ref); err != nil {
+		t.Error(err)
+		return
+	}
+
+	if b2, err = json.Marshal(Time{Time: ref}); err != nil {
+		t.Errorf("MarshalJSON() error = %v", err)
+		return
+	}
+
+	if !bytes.Equal(b1, b2) {
+		t.Errorf("MarshalJSON() got = %s, want = %s", b2, b1)
+	}
+}
+
+func TestTime_UnmarshalGraphQL(t *testing.T) {
+	type args struct {
+		input interface{}
+	}
+
+	ref := time.Date(2021, time.April, 20, 12, 3, 23, 0, time.UTC)
+
+	t.Run("invalid", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			args    args
+			wantErr string
+		}{
+			{
+				name:    "boolean",
+				args:    args{input: true},
+				wantErr: "wrong type for Time: bool",
+			},
+			{
+				name:    "invalid format",
+				args:    args{input: ref.Format(time.ANSIC)},
+				wantErr: `parsing time "Tue Apr 20 12:03:23 2021" as "2006-01-02T15:04:05Z07:00": cannot parse "Tue Apr 20 12:03:23 2021" as "2006"`,
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				gt := new(Time)
+				if err := gt.UnmarshalGraphQL(tt.args.input); err != nil {
+					if err.Error() != tt.wantErr {
+						t.Errorf("UnmarshalGraphQL() error = %v, want = %s", err, tt.wantErr)
+					}
+
+					return
+				}
+
+				t.Error("UnmarshalGraphQL() expected error not raised")
+			})
+		}
+	})
+
+	tests := []struct {
+		name   string
+		args   args
+		wantEq time.Time
+	}{
+		{
+			name: "time.Time",
+			args: args{
+				input: ref,
+			},
+			wantEq: ref,
+		},
+		{
+			name: "string",
+			args: args{
+				input: ref.Format(time.RFC3339),
+			},
+			wantEq: ref,
+		},
+		{
+			name: "bytes",
+			args: args{
+				input: []byte(ref.Format(time.RFC3339)),
+			},
+			wantEq: ref,
+		},
+		{
+			name: "int32",
+			args: args{
+				input: int32(ref.Unix()),
+			},
+			wantEq: ref,
+		},
+		{
+			name: "int64",
+			args: args{
+				input: ref.Unix(),
+			},
+			wantEq: ref,
+		},
+		{
+			name: "float64",
+			args: args{
+				input: float64(ref.Unix()),
+			},
+			wantEq: ref,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gt := new(Time)
+			if err := gt.UnmarshalGraphQL(tt.args.input); err != nil {
+				t.Errorf("UnmarshalGraphQL() error = %v", err)
+				return
+			}
+
+			if !gt.Equal(tt.wantEq) {
+				t.Errorf("UnmarshalGraphQL() got = %v, want = %v", gt, tt.wantEq)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This MR is about issue #449.

In case the interface is not hidden for a reason but by mistake, it would expose it as part of the outer API of the new `decode` package.
I think this makes sense, as implementing types need to follow the API either way, to be even recognized.
