### PR TITLE
Coerce float64 to int32 in `NullInt` and vice versa in `NullFloat`

### DIFF
--- a/nullable_types.go
+++ b/nullable_types.go
@@ -2,6 +2,7 @@ package graphql
 
 import (
 	"fmt"
+	"math"
 )
 
 // NullString is a string that can be null. Use it in input structs to
@@ -87,6 +88,13 @@ func (s *NullInt) UnmarshalGraphQL(input interface{}) error {
 	case int32:
 		s.Value = &v
 		return nil
+	case float64:
+		coerced := int32(v)
+		if v < math.MinInt32 || v > math.MaxInt32 || float64(coerced) != v {
+			return fmt.Errorf("not a 32-bit integer")
+		}
+		s.Value = &coerced
+		return nil
 	default:
 		return fmt.Errorf("wrong type for Int: %T", v)
 	}
@@ -116,6 +124,14 @@ func (s *NullFloat) UnmarshalGraphQL(input interface{}) error {
 	switch v := input.(type) {
 	case float64:
 		s.Value = &v
+		return nil
+	case int32:
+		coerced := float64(v)
+		s.Value = &coerced
+		return nil
+	case int:
+		coerced := float64(v)
+		s.Value = &coerced
 		return nil
 	default:
 		return fmt.Errorf("wrong type for Float: %T", v)

--- a/nullable_types_test.go
+++ b/nullable_types_test.go
@@ -1,0 +1,214 @@
+package graphql_test
+
+import (
+	"math"
+	"testing"
+
+	. "github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/decode"
+)
+
+func TestNullInt_ImplementsUnmarshaler(t *testing.T) {
+	defer func() {
+		if err := recover(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// assert *NullInt implements decode.Unmarshaler interface
+	var _ decode.Unmarshaler = (*NullInt)(nil)
+}
+
+func TestNullInt_UnmarshalGraphQL(t *testing.T) {
+	type args struct {
+		input interface{}
+	}
+
+	a := float64(math.MaxInt32 + 1)
+	b := float64(math.MinInt32 - 1)
+	c := 1234.6
+	good := int32(1234)
+	ref := NullInt{
+		Value: &good,
+		Set:   true,
+	}
+
+	t.Run("invalid", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			args    args
+			wantErr string
+		}{
+			{
+				name:    "boolean",
+				args:    args{input: true},
+				wantErr: "wrong type for Int: bool",
+			},
+			{
+				name: "int32 out of range (+)",
+				args: args{
+					input: a,
+				},
+				wantErr: "not a 32-bit integer",
+			},
+			{
+				name: "int32 out of range (-)",
+				args: args{
+					input: b,
+				},
+				wantErr: "not a 32-bit integer",
+			},
+			{
+				name: "non-integer",
+				args: args{
+					input: c,
+				},
+				wantErr: "not a 32-bit integer",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				gt := new(NullInt)
+				if err := gt.UnmarshalGraphQL(tt.args.input); err != nil {
+					if err.Error() != tt.wantErr {
+						t.Errorf("UnmarshalGraphQL() error = %v, want = %s", err, tt.wantErr)
+					}
+
+					return
+				}
+
+				t.Error("UnmarshalGraphQL() expected error not raised")
+			})
+		}
+	})
+
+	tests := []struct {
+		name   string
+		args   args
+		wantEq NullInt
+	}{
+		{
+			name: "int32",
+			args: args{
+				input: good,
+			},
+			wantEq: ref,
+		},
+		{
+			name: "float64",
+			args: args{
+				input: float64(good),
+			},
+			wantEq: ref,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gt := new(NullInt)
+			if err := gt.UnmarshalGraphQL(tt.args.input); err != nil {
+				t.Errorf("UnmarshalGraphQL() error = %v", err)
+				return
+			}
+
+			if *gt.Value != *tt.wantEq.Value {
+				t.Errorf("UnmarshalGraphQL() got = %v, want = %v", *gt.Value, *tt.wantEq.Value)
+			}
+		})
+	}
+}
+
+func TestNullFloat_ImplementsUnmarshaler(t *testing.T) {
+	defer func() {
+		if err := recover(); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	// assert *NullFloat implements decode.Unmarshaler interface
+	var _ decode.Unmarshaler = (*NullFloat)(nil)
+}
+
+func TestNullFloat_UnmarshalGraphQL(t *testing.T) {
+	type args struct {
+		input interface{}
+	}
+
+	good := float64(1234)
+	ref := NullFloat{
+		Value: &good,
+		Set:   true,
+	}
+
+	t.Run("invalid", func(t *testing.T) {
+		tests := []struct {
+			name    string
+			args    args
+			wantErr string
+		}{
+			{
+				name:    "boolean",
+				args:    args{input: true},
+				wantErr: "wrong type for Float: bool",
+			},
+		}
+
+		for _, tt := range tests {
+			t.Run(tt.name, func(t *testing.T) {
+				gt := new(NullFloat)
+				if err := gt.UnmarshalGraphQL(tt.args.input); err != nil {
+					if err.Error() != tt.wantErr {
+						t.Errorf("UnmarshalGraphQL() error = %v, want = %s", err, tt.wantErr)
+					}
+
+					return
+				}
+
+				t.Error("UnmarshalGraphQL() expected error not raised")
+			})
+		}
+	})
+
+	tests := []struct {
+		name   string
+		args   args
+		wantEq NullFloat
+	}{
+		{
+			name: "int",
+			args: args{
+				input: int(good),
+			},
+			wantEq: ref,
+		},
+		{
+			name: "int32",
+			args: args{
+				input: int32(good),
+			},
+			wantEq: ref,
+		},
+		{
+			name: "float64",
+			args: args{
+				input: good,
+			},
+			wantEq: ref,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gt := new(NullFloat)
+			if err := gt.UnmarshalGraphQL(tt.args.input); err != nil {
+				t.Errorf("UnmarshalGraphQL() error = %v", err)
+				return
+			}
+
+			if *gt.Value != *tt.wantEq.Value {
+				t.Errorf("UnmarshalGraphQL() got = %v, want = %v", *gt.Value, *tt.wantEq.Value)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I have been using the new `NullInt` type in one of my projects and received an error `wrong type for Int: float64`.

According to the GraphQL spec (http://spec.graphql.org/June2018/#sec-Scalars) and the rest of the code that coerces a `float64` type to `int32`, we should also be doing it for the built-in `NullInt` and `NullFloat`. 

We know that when Go unmarshals JSON (https://golang.org/pkg/encoding/json/#Unmarshal), that any JSON number is stored in a `float64`, so it is definitely necessary for `NullInt`. Therefore, the `NullFloat` changes made here are probably unnecessary.

I think this makes sense; please let me know if you have any feedback.