### PR TITLE
Add location fields to type definitions

### DIFF
--- a/internal/schema/schema_internal_test.go
+++ b/internal/schema/schema_internal_test.go
@@ -1,6 +1,7 @@
 package schema
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/graph-gophers/graphql-go/errors"
@@ -19,7 +20,10 @@ func TestParseInterfaceDef(t *testing.T) {
 	tests := []testCase{{
 		description: "Parses simple interface",
 		definition:  "Greeting { field: String }",
-		expected:    &types.InterfaceTypeDefinition{Name: "Greeting", Fields: types.FieldsDefinition{&types.FieldDefinition{Name: "field"}}},
+		expected: &types.InterfaceTypeDefinition{
+			Name:   "Greeting",
+			Loc:    errors.Location{1, 1},
+			Fields: types.FieldsDefinition{&types.FieldDefinition{Name: "field"}}},
 	}}
 
 	for _, test := range tests {
@@ -49,19 +53,19 @@ func TestParseObjectDef(t *testing.T) {
 	tests := []testCase{{
 		description: "Parses type inheriting single interface",
 		definition:  "Hello implements World { field: String }",
-		expected:    &types.ObjectTypeDefinition{Name: "Hello", InterfaceNames: []string{"World"}},
+		expected:    &types.ObjectTypeDefinition{Name: "Hello", Loc: errors.Location{1, 1}, InterfaceNames: []string{"World"}},
 	}, {
 		description: "Parses type inheriting multiple interfaces",
 		definition:  "Hello implements Wo & rld { field: String }",
-		expected:    &types.ObjectTypeDefinition{Name: "Hello", InterfaceNames: []string{"Wo", "rld"}},
+		expected:    &types.ObjectTypeDefinition{Name: "Hello", Loc: errors.Location{1, 1}, InterfaceNames: []string{"Wo", "rld"}},
 	}, {
 		description: "Parses type inheriting multiple interfaces with leading ampersand",
 		definition:  "Hello implements & Wo & rld { field: String }",
-		expected:    &types.ObjectTypeDefinition{Name: "Hello", InterfaceNames: []string{"Wo", "rld"}},
+		expected:    &types.ObjectTypeDefinition{Name: "Hello", Loc: errors.Location{1, 1}, InterfaceNames: []string{"Wo", "rld"}},
 	}, {
 		description: "Allows legacy SDL interfaces",
 		definition:  "Hello implements Wo, rld { field: String }",
-		expected:    &types.ObjectTypeDefinition{Name: "Hello", InterfaceNames: []string{"Wo", "rld"}},
+		expected:    &types.ObjectTypeDefinition{Name: "Hello", Loc: errors.Location{1, 1}, InterfaceNames: []string{"Wo", "rld"}},
 	}}
 
 	for _, test := range tests {
@@ -75,6 +79,230 @@ func TestParseObjectDef(t *testing.T) {
 			compareErrors(t, test.err, err)
 			compareObjects(t, test.expected, actual)
 		})
+	}
+}
+
+func TestParseUnionDef(t *testing.T) {
+	type testCase struct {
+		description string
+		definition  string
+		expected    *types.Union
+		err         *errors.QueryError
+	}
+
+	tests := []testCase{
+		{
+			description: "Parses a union",
+			definition:  "Foo = Bar | Qux | Quux",
+			expected: &types.Union{
+				Name:      "Foo",
+				TypeNames: []string{"Bar", "Qux", "Quux"},
+				Loc:       errors.Location{1, 1},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			var actual *types.Union
+			lex := setup(t, test.definition)
+
+			parse := func() { actual = parseUnionDef(lex) }
+			err := lex.CatchSyntaxError(parse)
+
+			compareErrors(t, test.err, err)
+			compareUnions(t, test.expected, actual)
+		})
+	}
+}
+
+func TestParseEnumDef(t *testing.T) {
+	type testCase struct {
+		description string
+		definition  string
+		expected    *types.EnumTypeDefinition
+		err         *errors.QueryError
+	}
+
+	tests := []testCase{
+		{
+			description: "parses EnumTypeDefinition on single line",
+			definition:  "Foo { BAR QUX }",
+			expected: &types.EnumTypeDefinition{
+				Name: "Foo",
+				EnumValuesDefinition: []*types.EnumValueDefinition{
+					{
+						EnumValue: "BAR",
+						Loc:       errors.Location{1, 7},
+					},
+					{
+						EnumValue: "QUX",
+						Loc:       errors.Location{1, 11},
+					},
+				},
+				Loc: errors.Location{1, 1},
+			},
+		},
+		{
+			description: "parses EnumtypeDefinition with new lines",
+			definition: `Foo { 
+				BAR
+				QUX
+			}`,
+			expected: &types.EnumTypeDefinition{
+				Name: "Foo",
+				EnumValuesDefinition: []*types.EnumValueDefinition{
+					{
+						EnumValue: "BAR",
+						Loc:       errors.Location{2, 5},
+					},
+					{
+						EnumValue: "QUX",
+						Loc:       errors.Location{3, 5},
+					},
+				},
+				Loc: errors.Location{1, 1},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			var actual *types.EnumTypeDefinition
+			lex := setup(t, test.definition)
+
+			parse := func() { actual = parseEnumDef(lex) }
+			err := lex.CatchSyntaxError(parse)
+
+			compareErrors(t, test.err, err)
+			compareEnumTypeDefs(t, test.expected, actual)
+		})
+	}
+}
+
+func TestParseDirectiveDef(t *testing.T) {
+	type testCase struct {
+		description string
+		definition  string
+		expected    *types.DirectiveDefinition
+		err         *errors.QueryError
+	}
+
+	tests := []*testCase{
+		{
+			description: "parses DirectiveDefinition",
+			definition:  "@Foo on FIELD",
+			expected: &types.DirectiveDefinition{
+				Name:      "Foo",
+				Loc:       errors.Location{1, 2},
+				Locations: []string{"FIELD"},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			var actual *types.DirectiveDefinition
+			lex := setup(t, test.definition)
+
+			parse := func() { actual = parseDirectiveDef(lex) }
+			err := lex.CatchSyntaxError(parse)
+
+			compareErrors(t, test.err, err)
+			compareDirectiveDefinitions(t, test.expected, actual)
+		})
+	}
+}
+
+func TestParseInputDef(t *testing.T) {
+	type testCase struct {
+		description string
+		definition  string
+		expected    *types.InputObject
+		err         *errors.QueryError
+	}
+
+	tests := []testCase{
+		{
+			description: "parses an input object type definition",
+			definition:  "Foo { qux: String }",
+			expected: &types.InputObject{
+				Name:   "Foo",
+				Values: nil,
+				Loc:    errors.Location{1, 1},
+			},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.description, func(t *testing.T) {
+			var actual *types.InputObject
+			lex := setup(t, test.definition)
+
+			parse := func() { actual = parseInputDef(lex) }
+			err := lex.CatchSyntaxError(parse)
+
+			compareErrors(t, test.err, err)
+			compareInputObjectTypeDefinition(t, test.expected, actual)
+		})
+	}
+}
+
+func compareDirectiveDefinitions(t *testing.T, expected *types.DirectiveDefinition, actual *types.DirectiveDefinition) {
+	t.Helper()
+
+	checkNilCase(t, expected, actual)
+
+	if expected.Name != actual.Name {
+		t.Fatalf("wrong DirectiveDefinition name: want %q, got %q", expected.Name, actual.Name)
+	}
+
+	if !reflect.DeepEqual(expected.Locations, actual.Locations) {
+		t.Errorf("wrong DirectiveDefinition locations: want %v, got %v", expected.Locations, actual.Locations)
+	}
+
+	compareLoc(t, "DirectiveDefinition", expected.Loc, actual.Loc)
+}
+
+func compareInputObjectTypeDefinition(t *testing.T, expected, actual *types.InputObject) {
+	t.Helper()
+
+	checkNilCase(t, expected, actual)
+
+	if expected.Name != actual.Name {
+		t.Fatalf("wrong InputObject name: want %q, got %q", expected.Name, actual.Name)
+	}
+
+	compareLoc(t, "InputObjectTypeDefinition", expected.Loc, actual.Loc)
+}
+
+func compareEnumTypeDefs(t *testing.T, expected, actual *types.EnumTypeDefinition) {
+	t.Helper()
+
+	checkNilCase(t, expected, actual)
+
+	if expected.Name != actual.Name {
+		t.Fatalf("wrong EnumTypeDefinition name: want %q, got %q", expected.Name, actual.Name)
+	}
+
+	compareLoc(t, "EnumValueDefinition", expected.Loc, actual.Loc)
+
+	for i, definition := range expected.EnumValuesDefinition {
+		expectedValue, expectedLoc := definition.EnumValue, definition.Loc
+		actualDef := actual.EnumValuesDefinition[i]
+
+		if expectedValue != actualDef.EnumValue {
+			t.Fatalf("wrong EnumValue: want %q, got %q", expectedValue, actualDef.EnumValue)
+		}
+
+		compareLoc(t, "EnumValue "+expectedValue, expectedLoc, actualDef.Loc)
+	}
+}
+
+func compareLoc(t *testing.T, typeName string, expected, actual errors.Location) {
+	t.Helper()
+	if expected != actual {
+		t.Errorf("wrong location on %s: want %v, got %v", typeName, expected, actual)
 	}
 }
 
@@ -99,19 +327,13 @@ func compareErrors(t *testing.T, expected, actual *errors.QueryError) {
 func compareInterfaces(t *testing.T, expected, actual *types.InterfaceTypeDefinition) {
 	t.Helper()
 
-	// TODO: We can probably extract this switch statement into its own function.
-	switch {
-	case expected == nil && actual == nil:
-		return
-	case expected == nil && actual != nil:
-		t.Fatalf("wanted nil, got an unexpected result: %#v", actual)
-	case expected != nil && actual == nil:
-		t.Fatalf("wanted non-nil result, got nil")
-	}
+	checkNilCase(t, expected, actual)
 
 	if expected.Name != actual.Name {
 		t.Errorf("wrong interface name: want %q, got %q", expected.Name, actual.Name)
 	}
+
+	compareLoc(t, "InterfaceTypeDefinition", expected.Loc, actual.Loc)
 
 	if len(expected.Fields) != len(actual.Fields) {
 		t.Fatalf("wanted %d field definitions, got %d", len(expected.Fields), len(actual.Fields))
@@ -124,17 +346,24 @@ func compareInterfaces(t *testing.T, expected, actual *types.InterfaceTypeDefini
 	}
 }
 
+func compareUnions(t *testing.T, expected, actual *types.Union) {
+	t.Helper()
+
+	checkNilCase(t, expected, actual)
+
+	if expected.Name != actual.Name {
+		t.Errorf("wrong object name: want %q, got %q", expected.Name, actual.Name)
+	}
+
+	if !reflect.DeepEqual(expected, actual) {
+		t.Errorf("wrong type names: want %v, got %v", expected.TypeNames, actual.TypeNames)
+	}
+}
+
 func compareObjects(t *testing.T, expected, actual *types.ObjectTypeDefinition) {
 	t.Helper()
 
-	switch {
-	case expected == nil && expected == actual:
-		return
-	case expected == nil && actual != nil:
-		t.Fatalf("wanted nil, got an unexpected result: %#v", actual)
-	case expected != nil && actual == nil:
-		t.Fatalf("wanted non-nil result, got nil")
-	}
+	checkNilCase(t, expected, actual)
 
 	if expected.Name != actual.Name {
 		t.Errorf("wrong object name: want %q, got %q", expected.Name, actual.Name)
@@ -153,6 +382,19 @@ func compareObjects(t *testing.T, expected, actual *types.ObjectTypeDefinition) 
 		if expectedName != actualName {
 			t.Errorf("wrong interface name: want %q, got %q", expectedName, actualName)
 		}
+	}
+}
+
+func checkNilCase(t *testing.T, a, b interface{}) {
+	t.Helper()
+
+	switch {
+	case a == nil && a == b:
+		return
+	case a == nil && b != nil:
+		t.Fatalf("wanted nil, got an unexpected result: %#v", b)
+	case a != nil && b == nil:
+		t.Fatalf("wanted non-nil result, got nil")
 	}
 }
 

--- a/types/directive.go
+++ b/types/directive.go
@@ -1,5 +1,7 @@
 package types
 
+import "github.com/graph-gophers/graphql-go/errors"
+
 // Directive is a representation of the GraphQL Directive.
 //
 // http://spec.graphql.org/draft/#sec-Language.Directives
@@ -16,6 +18,7 @@ type DirectiveDefinition struct {
 	Desc      string
 	Locations []string
 	Arguments ArgumentsDefinition
+	Loc       errors.Location
 }
 
 type DirectiveList []*Directive

--- a/types/enum.go
+++ b/types/enum.go
@@ -1,5 +1,7 @@
 package types
 
+import "github.com/graph-gophers/graphql-go/errors"
+
 // EnumTypeDefinition defines a set of possible enum values.
 //
 // Like scalar types, an EnumTypeDefinition also represents a leaf value in a GraphQL type system.
@@ -10,6 +12,7 @@ type EnumTypeDefinition struct {
 	EnumValuesDefinition []*EnumValueDefinition
 	Desc                 string
 	Directives           DirectiveList
+	Loc                  errors.Location
 }
 
 // EnumValueDefinition are unique values that may be serialized as a string: the name of the
@@ -20,6 +23,7 @@ type EnumValueDefinition struct {
 	EnumValue  string
 	Directives DirectiveList
 	Desc       string
+	Loc        errors.Location
 }
 
 func (*EnumTypeDefinition) Kind() string          { return "ENUM" }

--- a/types/extension.go
+++ b/types/extension.go
@@ -1,5 +1,7 @@
 package types
 
+import "github.com/graph-gophers/graphql-go/errors"
+
 // Extension type defines a GraphQL type extension.
 // Schemas, Objects, Inputs and Scalars can be extended.
 //
@@ -7,4 +9,5 @@ package types
 type Extension struct {
 	Type       NamedType
 	Directives DirectiveList
+	Loc        errors.Location
 }

--- a/types/field.go
+++ b/types/field.go
@@ -1,5 +1,7 @@
 package types
 
+import "github.com/graph-gophers/graphql-go/errors"
+
 // FieldDefinition is a representation of a GraphQL FieldDefinition.
 //
 // http://spec.graphql.org/draft/#FieldDefinition
@@ -9,6 +11,7 @@ type FieldDefinition struct {
 	Type       Type
 	Directives DirectiveList
 	Desc       string
+	Loc        errors.Location
 }
 
 // FieldsDefinition is a list of an ObjectTypeDefinition's Fields.

--- a/types/input.go
+++ b/types/input.go
@@ -38,6 +38,7 @@ type InputObject struct {
 	Desc       string
 	Values     ArgumentsDefinition
 	Directives DirectiveList
+	Loc        errors.Location
 }
 
 func (*InputObject) Kind() string          { return "INPUT_OBJECT" }

--- a/types/interface.go
+++ b/types/interface.go
@@ -1,5 +1,7 @@
 package types
 
+import "github.com/graph-gophers/graphql-go/errors"
+
 // InterfaceTypeDefinition represents a list of named fields and their arguments.
 //
 // GraphQL objects can then implement these interfaces which requires that the object type will
@@ -12,6 +14,7 @@ type InterfaceTypeDefinition struct {
 	Fields        FieldsDefinition
 	Desc          string
 	Directives    DirectiveList
+	Loc           errors.Location
 }
 
 func (*InterfaceTypeDefinition) Kind() string          { return "INTERFACE" }

--- a/types/object.go
+++ b/types/object.go
@@ -1,5 +1,7 @@
 package types
 
+import "github.com/graph-gophers/graphql-go/errors"
+
 // ObjectTypeDefinition represents a GraphQL ObjectTypeDefinition.
 //
 // type FooObject {
@@ -8,13 +10,13 @@ package types
 //
 // https://spec.graphql.org/draft/#sec-Objects
 type ObjectTypeDefinition struct {
-	Name       string
-	Interfaces []*InterfaceTypeDefinition
-	Fields     FieldsDefinition
-	Desc       string
-	Directives DirectiveList
-
+	Name           string
+	Interfaces     []*InterfaceTypeDefinition
+	Fields         FieldsDefinition
+	Desc           string
+	Directives     DirectiveList
 	InterfaceNames []string
+	Loc            errors.Location
 }
 
 func (*ObjectTypeDefinition) Kind() string          { return "OBJECT" }

--- a/types/scalar.go
+++ b/types/scalar.go
@@ -1,5 +1,7 @@
 package types
 
+import "github.com/graph-gophers/graphql-go/errors"
+
 // ScalarTypeDefinition types represent primitive leaf values (e.g. a string or an integer) in a GraphQL type
 // system.
 //
@@ -11,6 +13,7 @@ type ScalarTypeDefinition struct {
 	Name       string
 	Desc       string
 	Directives DirectiveList
+	Loc        errors.Location
 }
 
 func (*ScalarTypeDefinition) Kind() string          { return "SCALAR" }

--- a/types/union.go
+++ b/types/union.go
@@ -1,5 +1,7 @@
 package types
 
+import "github.com/graph-gophers/graphql-go/errors"
+
 // Union types represent objects that could be one of a list of GraphQL object types, but provides no
 // guaranteed fields between those types.
 //
@@ -13,6 +15,7 @@ type Union struct {
 	Desc             string
 	Directives       DirectiveList
 	TypeNames        []string
+	Loc              errors.Location
 }
 
 func (*Union) Kind() string          { return "UNION" }


### PR DESCRIPTION
Addresses #444 

# Overview
This change adds a `Loc: errors.Location` field to all definition structs defined in the `types` package. These struct fields are populated when the schema is parsed; the `Line` and `Column` fields in `errors.Location` represents the first character of the *identifier* for that definition.

For example:
```graphql
directive @foo ON FIELD_DEFINITION # line: 1 column: 12
type Foo { }                       # line: 2 column: 6
input FooInput { }                 # line: 3 column: 7
# ...etc
```

This change strictly adds the `Loc: errors.Location` field to definitions that don't already have it. Definitions that already have location fields such as [`InputValueDefinition`](https://github.com/graph-gophers/graphql-go/blob/8a96404e06f14f259c40f43b4ebf1864565e) were not touched.

## Motiviation and Examples
Tools built against a schema will most certainly need line/column source mapping as an additional form of identification when the `name` of a definition isn't enough. 

For a specific example: as explained in #444, location data is important in our usage of graphql-go because a majority of schema validation occurs after parsing the schema (i.e. the schema syntax is valid, but there are other issues that aren't caught by the parser). Without location data on definitions, we won't be able to surface the lines and columns of domain-specific schema issues in our error messages. 

Below are a few examples that I hope can showcase the importance of location data in definitions

### Loc on ObjectTypeDefinition
Given the syntax-valid schema below:
```graphql
type uncapitalizedtypename { 
  a: String
}
```

The `Loc` field in `ObjectTypeDefinition` will allow us to produce the following error:
```
schema.graphql:1:6: uncapitalizedtypename: Type names must be TitleCase.
```

### Loc on FieldDefinition
```graphql
type Foo {
  accountVerified: Boolean
}
```

The `Loc` field in `FieldDefinition` will allow us to produce the following error:
```
schema.graphql:2:3: accountVerified: Boolean field names should be prefixed by "is", "can", ...
```