### PR TITLE
internal/exec: assign parent type name to __typename fields

### DIFF
--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -130,11 +130,16 @@ func collectFieldsToResolve(sels []selected.Selection, s *resolvable.Schema, res
 		case *selected.TypenameField:
 			_, ok := fieldByAlias[sel.Alias]
 			if !ok {
+				res := reflect.ValueOf(typeOf(sel, resolver))
+				f := s.FieldTypename
+				f.TypeName = res.String()
+
 				sf := &selected.SchemaField{
-					Field:       s.Meta.FieldTypename,
+					Field:       f,
 					Alias:       sel.Alias,
-					FixedResult: reflect.ValueOf(typeOf(sel, resolver)),
+					FixedResult: res,
 				}
+
 				field := &fieldToExec{field: sf, resolver: resolver}
 				*fields = append(*fields, field)
 				fieldByAlias[sel.Alias] = field


### PR DESCRIPTION
This change modifies `internal/exec` to attach the parent type name when a `__typename` field is executed so that it is available to any `trace.Tracer` implementations.

Fixes #461.

