### PR TITLE
Add option for custom panic handler

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ func (r *helloWorldResolver) Hello(ctx context.Context) (string, error) {
 - `Tracer(tracer trace.Tracer)` is used to trace queries and fields. It defaults to `trace.OpenTracingTracer`.
 - `ValidationTracer(tracer trace.ValidationTracer)` is used to trace validation errors. It defaults to `trace.NoopValidationTracer`.
 - `Logger(logger log.Logger)` is used to log panics during query execution. It defaults to `exec.DefaultLogger`.
+- `PanicHandler(panicHandler errors.PanicHandler)` is used to transform panics into errors during query execution. It defaults to `errors.DefaultPanicHandler`.
 - `DisableIntrospection()` disables introspection queries.
 
 ### Custom Errors

--- a/errors/panic_handler.go
+++ b/errors/panic_handler.go
@@ -1,0 +1,18 @@
+package errors
+
+import (
+	"context"
+)
+
+// PanicHandler is the interface used to create custom panic errors that occur during query execution
+type PanicHandler interface {
+	MakePanicError(ctx context.Context, value interface{}) *QueryError
+}
+
+// DefaultPanicHandler is the default PanicHandler
+type DefaultPanicHandler struct{}
+
+// MakePanicError creates a new QueryError from a panic that occurred during execution
+func (h *DefaultPanicHandler) MakePanicError(ctx context.Context, value interface{}) *QueryError {
+	return Errorf("graphql: panic occurred: %v", value)
+}

--- a/errors/panic_handler.go
+++ b/errors/panic_handler.go
@@ -14,5 +14,5 @@ type DefaultPanicHandler struct{}
 
 // MakePanicError creates a new QueryError from a panic that occurred during execution
 func (h *DefaultPanicHandler) MakePanicError(ctx context.Context, value interface{}) *QueryError {
-	return Errorf("graphql: panic occurred: %v", value)
+	return Errorf("panic occurred: %v", value)
 }

--- a/errors/panic_handler_test.go
+++ b/errors/panic_handler_test.go
@@ -1,0 +1,24 @@
+package errors
+
+import (
+	"context"
+	"testing"
+)
+
+func TestDefaultPanicHandler(t *testing.T) {
+	handler := &DefaultPanicHandler{}
+	qErr := handler.MakePanicError(context.Background(), "foo")
+	if qErr == nil {
+		t.Fatal("Panic error must not be nil")
+	}
+	const (
+		expectedMessage = "panic occurred: foo"
+		expectedError   = "graphql: " + expectedMessage
+	)
+	if qErr.Error() != expectedError {
+		t.Errorf("Unexpected panic error message: %q != %q", qErr.Error(), expectedError)
+	}
+	if qErr.Message != expectedMessage {
+		t.Errorf("Unexpected panic QueryError.Message: %q != %q", qErr.Message, expectedMessage)
+	}
+}

--- a/graphql.go
+++ b/graphql.go
@@ -30,6 +30,7 @@ func ParseSchema(schemaString string, resolver interface{}, opts ...SchemaOpt) (
 		maxParallelism: 10,
 		tracer:         trace.OpenTracingTracer{},
 		logger:         &log.DefaultLogger{},
+		panicHandler:   &errors.DefaultPanicHandler{},
 	}
 	for _, opt := range opts {
 		opt(s)
@@ -78,6 +79,7 @@ type Schema struct {
 	tracer                   trace.Tracer
 	validationTracer         trace.ValidationTracerContext
 	logger                   log.Logger
+	panicHandler             errors.PanicHandler
 	useStringDescriptions    bool
 	disableIntrospection     bool
 	subscribeResolverTimeout time.Duration
@@ -140,6 +142,14 @@ func ValidationTracer(tracer trace.ValidationTracer) SchemaOpt {
 func Logger(logger log.Logger) SchemaOpt {
 	return func(s *Schema) {
 		s.logger = logger
+	}
+}
+
+// PanicHandler is used to customize the panic errors during query execution.
+// It defaults to errors.DefaultPanicHandler.
+func PanicHandler(panicHandler errors.PanicHandler) SchemaOpt {
+	return func(s *Schema) {
+		s.panicHandler = panicHandler
 	}
 }
 
@@ -244,9 +254,10 @@ func (s *Schema) exec(ctx context.Context, queryString string, operationName str
 			Schema:               s.schema,
 			DisableIntrospection: s.disableIntrospection,
 		},
-		Limiter: make(chan struct{}, s.maxParallelism),
-		Tracer:  s.tracer,
-		Logger:  s.logger,
+		Limiter:      make(chan struct{}, s.maxParallelism),
+		Tracer:       s.tracer,
+		Logger:       s.logger,
+		PanicHandler: s.panicHandler,
 	}
 	varTypes := make(map[string]*introspection.Type)
 	for _, v := range op.Vars {

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -57,6 +57,7 @@ func (s *Schema) subscribe(ctx context.Context, queryString string, operationNam
 		Limiter:                  make(chan struct{}, s.maxParallelism),
 		Tracer:                   s.tracer,
 		Logger:                   s.logger,
+		PanicHandler:             s.panicHandler,
 		SubscribeResolverTimeout: s.subscribeResolverTimeout,
 	}
 	varTypes := make(map[string]*introspection.Type)


### PR DESCRIPTION

Add option for custom panic handler.

Revives previous PR https://github.com/graph-gophers/graphql-go/pull/329 by @hampusohlsson (was closed from inactivity) and adds tests.
Copying previous PR description:

> This PR adds an option to provide a custom error handler for panics.
> 
> By giving more control over the panic error creation, it's possible for the consumer of this library to capture the panics and format the message, add extenstions and send to 3rd party error reporting services.
> 
> I opted for keeping existing `log.LogPanic` functionality to not make breaking changes. But you can write your own panic handler that implements both interfaces. Here's an example of how I'm using a custom panic handler.
> 
> ```go
> // main.go
> ...
> panicHandler := &myerrorlib.PanicHandler{}
> rootSchema := graphql.MustParseSchema(
> 	schema.GetRootSchema(),
> 	resolvers.NewRootResolver(),
> 	graphql.Logger(panicHandler),
> 	graphql.PanicHandler(panicHandler),
> )
> ...
> ```
> 
> and then in my case I'll provide a custom PanicHandler like so:
> 
> ```go
> package myerrorlib
> 
> import (
> 	"context"
> 	"github.com/graph-gophers/graphql-go/errors"
> )
> 
> type PanicHandler struct{}
> 
> // LogPanic is a no-op to silence the default panic logging.
> // Implements the Logger interface from `graph-gophers/graphql-go/log` 
> func (p *PanicHandler) LogPanic(ctx context.Context, value interface{}) {
> 	return
> }
> 
> // MakePanicError logs and reports the error using the common error library.
> // Implements the PanicHandler interface from `graph-gophers/graphql-go/errors` 
> func (p *PanicHandler) MakePanicError(
> 	ctx context.Context,
> 	value interface{},
> ) *errors.QueryError {
> 	// create and report custom error for 3rd party logging
> 	err := createAndReportErrorf(ctx, "panic: %s", value)
> 	return &errors.QueryError{
> 		Message:    err.Error(),
> 		// Decorate error with status code, trace id etc...
> 		Extensions: err.Extensions(),
> 	}
> }
> ```
