### PR TITLE
Support "Interfaces Implementing Interfaces"

### DIFF
--- a/graphql_test.go
+++ b/graphql_test.go
@@ -4220,3 +4220,54 @@ func TestQueryVariablesValidation(t *testing.T) {
 		}},
 	}})
 }
+
+type interfaceImplementingInterfaceResolver struct{}
+type interfaceImplementingInterfaceExample struct {
+	A string
+	B string
+	C bool
+}
+
+func (r *interfaceImplementingInterfaceResolver) Hey() *interfaceImplementingInterfaceExample {
+	return &interfaceImplementingInterfaceExample{
+		A: "testing",
+		B: "test",
+		C: true,
+	}
+}
+
+func TestInterfaceImplementingInterface(t *testing.T) {
+	gqltesting.RunTests(t, []*gqltesting.Test{{
+		Schema: graphql.MustParseSchema(`
+        interface A {
+          a: String!
+        }
+        interface B implements A {
+          a: String!
+          b: String!
+        }
+        interface C implements B & A {
+          a: String!
+          b: String!
+          c: Boolean!
+        }
+        type ABC implements C {
+          a: String!
+          b: String!
+          c: Boolean!
+        }
+        type Query {
+          hey: ABC
+        }`, &interfaceImplementingInterfaceResolver{}, graphql.UseFieldResolvers(), graphql.UseFieldResolvers()),
+		Query: `query {hey { a b c }}`,
+		ExpectedResult: `
+				{
+					"hey": {
+						"a": "testing",
+						"b": "test",
+						"c": true
+					}
+				}
+			`,
+	}})
+}

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -406,6 +406,16 @@ func parseObjectDef(l *common.Lexer) *types.ObjectTypeDefinition {
 func parseInterfaceDef(l *common.Lexer) *types.InterfaceTypeDefinition {
 	i := &types.InterfaceTypeDefinition{Loc: l.Location(), Name: l.ConsumeIdent()}
 
+	if l.Peek() == scanner.Ident {
+		l.ConsumeKeyword("implements")
+		i.Interfaces = append(i.Interfaces, &types.InterfaceTypeDefinition{Name: l.ConsumeIdent()})
+
+		for l.Peek() == '&' {
+			l.ConsumeToken('&')
+			i.Interfaces = append(i.Interfaces, &types.InterfaceTypeDefinition{Name: l.ConsumeIdent()})
+		}
+	}
+
 	i.Directives = common.ParseDirectives(l)
 
 	l.ConsumeToken('{')

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -875,7 +875,7 @@ Second line of the description.
 }
 
 func TestInterfaceImplementsInterface(t *testing.T) {
-	for _, test := range []struct {
+	for _, tt := range []struct {
 		name                  string
 		sdl                   string
 		useStringDescriptions bool
@@ -890,8 +890,8 @@ func TestInterfaceImplementsInterface(t *testing.T) {
 			}
 			interface Bar implements Foo {
 				field: String!
-      }
-      `,
+			}
+			`,
 			validateSchema: func(s *types.Schema) error {
 				const implementedInterfaceName = "Bar"
 				typ, ok := s.Types[implementedInterfaceName].(*types.InterfaceTypeDefinition)
@@ -922,7 +922,7 @@ func TestInterfaceImplementsInterface(t *testing.T) {
 		{
 			name: "Parses interface transitively implementing an interface that implements an interface",
 			sdl: `
-      interface Foo {
+			interface Foo {
 				field: String!
 			}
 			interface Bar implements Foo {
@@ -931,7 +931,7 @@ func TestInterfaceImplementsInterface(t *testing.T) {
 			interface Baz implements Bar & Foo {
 				field: String!
 			}
-      `,
+			`,
 			validateSchema: func(s *types.Schema) error {
 				const implementedInterfaceName = "Baz"
 				typ, ok := s.Types[implementedInterfaceName].(*types.InterfaceTypeDefinition)
@@ -967,7 +967,7 @@ func TestInterfaceImplementsInterface(t *testing.T) {
 		{
 			name: "Transitively implemented interfaces must also be defined on an implementing type or interface",
 			sdl: `
-		  interface A {
+			interface A {
 				message: String!
 			}
 			interface B implements A {
@@ -979,7 +979,7 @@ func TestInterfaceImplementsInterface(t *testing.T) {
 				name: String!
 				hug: Boolean!
 			}
-		  `,
+			`,
 			validateError: func(err error) error {
 				msg := `graphql: interface "C" must explicitly implement transitive interface "A"`
 				if err == nil || err.Error() != msg {
@@ -989,18 +989,18 @@ func TestInterfaceImplementsInterface(t *testing.T) {
 			},
 		},
 	} {
-		t.Run(test.name, func(t *testing.T) {
-			s, err := schema.ParseSchema(test.sdl, test.useStringDescriptions)
+		t.Run(tt.name, func(t *testing.T) {
+			s, err := schema.ParseSchema(tt.sdl, tt.useStringDescriptions)
 			if err != nil {
-				if test.validateError == nil {
+				if tt.validateError == nil {
 					t.Fatal(err)
 				}
-				if err := test.validateError(err); err != nil {
+				if err := tt.validateError(err); err != nil {
 					t.Fatal(err)
 				}
 			}
-			if test.validateSchema != nil {
-				if err := test.validateSchema(s); err != nil {
+			if tt.validateSchema != nil {
+				if err := tt.validateSchema(s); err != nil {
 					t.Fatal(err)
 				}
 			}

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -873,3 +873,137 @@ Second line of the description.
 		})
 	}
 }
+
+func TestInterfaceImplementsInterface(t *testing.T) {
+	for _, test := range []struct {
+		name                  string
+		sdl                   string
+		useStringDescriptions bool
+		validateError         func(err error) error
+		validateSchema        func(s *types.Schema) error
+	}{
+		{
+			name: "Parses interface implementing other interface",
+			sdl: `
+			interface Foo {
+				field: String!
+			}
+			interface Bar implements Foo {
+				field: String!
+      }
+      `,
+			validateSchema: func(s *types.Schema) error {
+				const implementedInterfaceName = "Bar"
+				typ, ok := s.Types[implementedInterfaceName].(*types.InterfaceTypeDefinition)
+				if !ok {
+					return fmt.Errorf("interface %q not found", implementedInterfaceName)
+				}
+				if len(typ.Fields) != 1 {
+					return fmt.Errorf("invalid number of fields: want %d, have %d", 1, len(typ.Fields))
+				}
+				const fieldName = "field"
+
+				if typ.Fields[0].Name != fieldName {
+					return fmt.Errorf("field %q not found", fieldName)
+				}
+
+				if len(typ.Interfaces) != 1 {
+					return fmt.Errorf("invalid number of implementing interfaces found on %q: want %d, have %d", implementedInterfaceName, 1, len(typ.Interfaces))
+				}
+
+				const implementingInterfaceName = "Foo"
+				if typ.Interfaces[0].Name != implementingInterfaceName {
+					return fmt.Errorf("interface %q not found", implementingInterfaceName)
+				}
+
+				return nil
+			},
+		},
+		{
+			name: "Parses interface transitively implementing an interface that implements an interface",
+			sdl: `
+      interface Foo {
+				field: String!
+			}
+			interface Bar implements Foo {
+				field: String!
+			}
+			interface Baz implements Bar & Foo {
+				field: String!
+			}
+      `,
+			validateSchema: func(s *types.Schema) error {
+				const implementedInterfaceName = "Baz"
+				typ, ok := s.Types[implementedInterfaceName].(*types.InterfaceTypeDefinition)
+				if !ok {
+					return fmt.Errorf("interface %q not found", implementedInterfaceName)
+				}
+				if len(typ.Fields) != 1 {
+					return fmt.Errorf("invalid number of fields: want %d, have %d", 1, len(typ.Fields))
+				}
+				const fieldName = "field"
+
+				if typ.Fields[0].Name != fieldName {
+					return fmt.Errorf("field %q not found", fieldName)
+				}
+
+				if len(typ.Interfaces) != 2 {
+					return fmt.Errorf("invalid number of implementing interfaces found on %q: want %d, have %d", implementedInterfaceName, 2, len(typ.Interfaces))
+				}
+
+				const firstImplementingInterfaceName = "Bar"
+				if typ.Interfaces[0].Name != firstImplementingInterfaceName {
+					return fmt.Errorf("first interface %q not found", firstImplementingInterfaceName)
+				}
+
+				const secondImplementingInterfaceName = "Foo"
+				if typ.Interfaces[1].Name != secondImplementingInterfaceName {
+					return fmt.Errorf("second interface %q not found", secondImplementingInterfaceName)
+				}
+
+				return nil
+			},
+		},
+		{
+			name: "Transitively implemented interfaces must also be defined on an implementing type or interface",
+			sdl: `
+		  interface A {
+				message: String!
+			}
+			interface B implements A {
+				message: String!
+				name: String!
+			}
+			interface C implements B {
+				message: String!
+				name: String!
+				hug: Boolean!
+			}
+		  `,
+			validateError: func(err error) error {
+				msg := `graphql: interface "C" must explicitly implement transitive interface "A"`
+				if err == nil || err.Error() != msg {
+					return fmt.Errorf("expected error %q, but got %q", msg, err)
+				}
+				return nil
+			},
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			s, err := schema.ParseSchema(test.sdl, test.useStringDescriptions)
+			if err != nil {
+				if test.validateError == nil {
+					t.Fatal(err)
+				}
+				if err := test.validateError(err); err != nil {
+					t.Fatal(err)
+				}
+			}
+			if test.validateSchema != nil {
+				if err := test.validateSchema(s); err != nil {
+					t.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/types/interface.go
+++ b/types/interface.go
@@ -2,7 +2,8 @@ package types
 
 import "github.com/graph-gophers/graphql-go/errors"
 
-// InterfaceTypeDefinition represents a list of named fields and their arguments.
+// InterfaceTypeDefinition recusrively defines list of named fields with their arguments via the
+// implementation chain of interfaces.
 //
 // GraphQL objects can then implement these interfaces which requires that the object type will
 // define all fields defined by those interfaces.
@@ -15,6 +16,7 @@ type InterfaceTypeDefinition struct {
 	Desc          string
 	Directives    DirectiveList
 	Loc           errors.Location
+	Interfaces    []*InterfaceTypeDefinition
 }
 
 func (*InterfaceTypeDefinition) Kind() string          { return "INTERFACE" }


### PR DESCRIPTION
Continues work done in https://github.com/graph-gophers/graphql-go/pull/436. Implement https://spec.graphql.org/draft/#sec-Interfaces.Interfaces-Implementing-Interfaces

Key differences:
- Avoids changing the core `Schema` type, sticks to using `Schema.Types` as a means of tracking interface validation.
- Single loop validation of all interface types.
- Improved test coverage.