### PR TITLE
internal/exec/resolvable: include struct field name in errors

### DIFF
--- a/graphql_test.go
+++ b/graphql_test.go
@@ -3074,6 +3074,8 @@ type inputArgumentsObjectMismatch2 struct{}
 
 type inputArgumentsObjectMismatch3 struct{}
 
+type fieldNameMismatch struct{}
+
 type helloInput struct {
 	Name string
 }
@@ -3082,7 +3084,7 @@ type helloOutput struct {
 	Name string
 }
 
-func (*helloOutput) Hello() helloOutput {
+func (*fieldNameMismatch) Hello() helloOutput {
 	return helloOutput{}
 }
 
@@ -3228,7 +3230,7 @@ func TestInputArguments_failSchemaParsing(t *testing.T) {
 		},
 		"Struct field name inclusion": {
 			Args: args{
-				Resolver: &helloOutput{},
+				Resolver: &fieldNameMismatch{},
 				Opts:     []graphql.SchemaOpt{graphql.UseFieldResolvers()},
 				Schema: `
 					type Query {
@@ -3239,7 +3241,7 @@ func TestInputArguments_failSchemaParsing(t *testing.T) {
 					}
 				`,
 			},
-			Want: want{Error: "string is not a pointer\n\tused by (graphql_test.helloOutput).Name\n\tused by (*graphql_test.helloOutput).Hello"},
+			Want: want{Error: "string is not a pointer\n\tused by (graphql_test.helloOutput).Name\n\tused by (*graphql_test.fieldNameMismatch).Hello"},
 		},
 	}
 

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -3078,6 +3078,14 @@ type helloInput struct {
 	Name string
 }
 
+type helloOutput struct {
+	Name string
+}
+
+func (*helloOutput) Hello() helloOutput {
+	return helloOutput{}
+}
+
 type helloInputMismatch struct {
 	World string
 }
@@ -3110,6 +3118,7 @@ func TestInputArguments_failSchemaParsing(t *testing.T) {
 	type args struct {
 		Resolver interface{}
 		Schema   string
+		Opts     []graphql.SchemaOpt
 	}
 	type want struct {
 		Error string
@@ -3217,6 +3226,21 @@ func TestInputArguments_failSchemaParsing(t *testing.T) {
 			},
 			Want: want{Error: "field \"Input\": *struct { Thing string } does not define field \"name\" (hint: missing `args struct { ... }` wrapper for field arguments, or missing field on input struct)\n\tused by (*graphql_test.inputArgumentsObjectMismatch3).Hello"},
 		},
+		"Struct field name inclusion": {
+			Args: args{
+				Resolver: &helloOutput{},
+				Opts:     []graphql.SchemaOpt{graphql.UseFieldResolvers()},
+				Schema: `
+					type Query {
+						hello(): HelloOutput!
+					}
+					type HelloOutput {
+						name: Int
+					}
+				`,
+			},
+			Want: want{Error: "string is not a pointer\n\tused by (graphql_test.helloOutput).Name\n\tused by (*graphql_test.helloOutput).Hello"},
+		},
 	}
 
 	for name, tt := range testTable {
@@ -3224,7 +3248,7 @@ func TestInputArguments_failSchemaParsing(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
 
-			_, err := graphql.ParseSchema(tt.Args.Schema, tt.Args.Resolver)
+			_, err := graphql.ParseSchema(tt.Args.Schema, tt.Args.Resolver, tt.Args.Opts...)
 			if err == nil || err.Error() != tt.Want.Error {
 				t.Log("Schema parsing error mismatch")
 				t.Logf("got: %s", err)

--- a/internal/exec/resolvable/resolvable.go
+++ b/internal/exec/resolvable/resolvable.go
@@ -256,7 +256,13 @@ func (b *execBuilder) makeObjectExec(typeName string, fields types.FieldsDefinit
 		}
 		fe, err := b.makeFieldExec(typeName, f, m, sf, methodIndex, fieldIndex, methodHasReceiver)
 		if err != nil {
-			return nil, fmt.Errorf("%s\n\tused by (%s).%s", err, resolverType, m.Name)
+			var resolverName string
+			if methodIndex != -1 {
+				resolverName = m.Name
+			} else {
+				resolverName = sf.Name
+			}
+			return nil, fmt.Errorf("%s\n\tused by (%s).%s", err, resolverType, resolverName)
 		}
 		Fields[f.Name] = fe
 	}


### PR DESCRIPTION
We were only adding method name, which meant that it was taking
an empty string if the resolver was a struct field. This was
making the error messages hard to parse as the user can't know
which field has the error.

Added a check to use the correct variable.

Earlier:

```
can not use int64 as Float
        used by (*api4.channelMember).
```

Now:

```
can not use int64 as Float
        used by (*api4.channelMember).LastViewedAt
```