### PR TITLE
all: fix golangci lint errors in the codebase

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,36 @@
+run:
+  timeout: 5m
+
+linters-settings:
+  gofmt:
+    simplify: true
+  govet:
+    check-shadowing: true
+    enable-all: true
+    disable:
+      - fieldalignment
+      - composites # remove later
+      - deepequalerrors # remove later
+
+linters:
+  disable-all: true
+  enable:
+    - deadcode
+    - gofmt
+    - gosimple
+    - govet
+    - ineffassign
+    - exportloopref
+    - structcheck
+    - staticcheck
+    - unconvert
+    - unused
+    - varcheck
+    # - misspell add later
+    - goimports
+
+issues:
+  exclude-rules:
+    - linters:
+      - unused
+      path: "graphql_test.go"

--- a/example/scalar_map/server.go
+++ b/example/scalar_map/server.go
@@ -10,19 +10,17 @@ import (
 	"github.com/graph-gophers/graphql-go/relay"
 )
 
-
 type Args struct {
 	Name string
 	Data types.Map
 }
 
-
 type mutation struct{}
 
-func (_ *mutation) Hello(args Args) string { 
+func (_ *mutation) Hello(args Args) string {
 
 	fmt.Println(args)
-	
+
 	return "Args accept!"
 }
 

--- a/example/scalar_map/types/map.go
+++ b/example/scalar_map/types/map.go
@@ -2,10 +2,10 @@ package types
 
 import "fmt"
 
-type Map map[string]interface {}
+type Map map[string]interface{}
 
 func (Map) ImplementsGraphQLType(name string) bool {
-	return name == "Map" 
+	return name == "Map"
 }
 
 func (j *Map) UnmarshalGraphQL(input interface{}) error {

--- a/graphql.go
+++ b/graphql.go
@@ -132,7 +132,7 @@ func Tracer(tracer trace.Tracer) SchemaOpt {
 
 // ValidationTracer is used to trace validation errors. It defaults to trace.NoopValidationTracer.
 // Deprecated: context is needed to support tracing correctly. Use a Tracer which implements trace.ValidationTracerContext.
-func ValidationTracer(tracer trace.ValidationTracer) SchemaOpt {
+func ValidationTracer(tracer trace.ValidationTracer) SchemaOpt { //nolint:staticcheck
 	return func(s *Schema) {
 		s.validationTracer = &validationBridgingTracer{tracer: tracer}
 	}
@@ -297,7 +297,7 @@ func (s *Schema) validateSchema() error {
 }
 
 type validationBridgingTracer struct {
-	tracer trace.ValidationTracer
+	tracer trace.ValidationTracer //nolint:staticcheck
 }
 
 func (t *validationBridgingTracer) TraceValidation(context.Context) trace.TraceValidationFinishFunc {

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -715,7 +715,7 @@ func TestNilInterface(t *testing.T) {
 				}
 			`,
 			ExpectedErrors: []*gqlerrors.QueryError{
-				&gqlerrors.QueryError{
+				{
 					Message:       "x",
 					Path:          []interface{}{"b"},
 					ResolverError: errors.New("x"),
@@ -753,7 +753,7 @@ func TestErrorPropagationInLists(t *testing.T) {
 				null
 			`,
 			ExpectedErrors: []*gqlerrors.QueryError{
-				&gqlerrors.QueryError{
+				{
 					Message:       droidNotFoundError.Error(),
 					Path:          []interface{}{"findDroids", 1, "name"},
 					ResolverError: droidNotFoundError,
@@ -795,7 +795,7 @@ func TestErrorPropagationInLists(t *testing.T) {
 				}
 			`,
 			ExpectedErrors: []*gqlerrors.QueryError{
-				&gqlerrors.QueryError{
+				{
 					Message:       droidNotFoundError.Error(),
 					Path:          []interface{}{"findDroids", 1, "name"},
 					ResolverError: droidNotFoundError,
@@ -829,7 +829,7 @@ func TestErrorPropagationInLists(t *testing.T) {
 				}
 			`,
 			ExpectedErrors: []*gqlerrors.QueryError{
-				&gqlerrors.QueryError{
+				{
 					Message: `graphql: got nil for non-null "Droid"`,
 					Path:    []interface{}{"findNilDroids", 1},
 				},
@@ -906,7 +906,7 @@ func TestErrorPropagationInLists(t *testing.T) {
 				}
 			`,
 			ExpectedErrors: []*gqlerrors.QueryError{
-				&gqlerrors.QueryError{
+				{
 					Message:       quoteError.Error(),
 					ResolverError: quoteError,
 					Path:          []interface{}{"findDroids", 0, "quotes"},
@@ -941,12 +941,12 @@ func TestErrorPropagationInLists(t *testing.T) {
 				}
 			`,
 			ExpectedErrors: []*gqlerrors.QueryError{
-				&gqlerrors.QueryError{
+				{
 					Message:       quoteError.Error(),
 					ResolverError: quoteError,
 					Path:          []interface{}{"findNilDroids", 0, "quotes"},
 				},
-				&gqlerrors.QueryError{
+				{
 					Message: `graphql: got nil for non-null "Droid"`,
 					Path:    []interface{}{"findNilDroids", 1},
 				},
@@ -985,7 +985,7 @@ func TestErrorWithExtensions(t *testing.T) {
 				null
 			`,
 			ExpectedErrors: []*gqlerrors.QueryError{
-				&gqlerrors.QueryError{
+				{
 					Message:       droidNotFoundError.Error(),
 					Path:          []interface{}{"FindDroid"},
 					ResolverError: droidNotFoundError,
@@ -1021,7 +1021,7 @@ func TestErrorWithNoExtensions(t *testing.T) {
 				null
 			`,
 			ExpectedErrors: []*gqlerrors.QueryError{
-				&gqlerrors.QueryError{
+				{
 					Message:       err.Error(),
 					Path:          []interface{}{"DismissVader"},
 					ResolverError: err,

--- a/internal/common/lexer_test.go
+++ b/internal/common/lexer_test.go
@@ -94,21 +94,21 @@ func TestConsume(t *testing.T) {
 	}
 }
 
-var multilineStringTests = []consumeTestCase {
+var multilineStringTests = []consumeTestCase{
 	{
-		description: "Oneline strings are okay",
-		definition: `"Hello World"`,
-		expected: "",
-		failureExpected: false,
-		useStringDescriptions: true,		
+		description:           "Oneline strings are okay",
+		definition:            `"Hello World"`,
+		expected:              "",
+		failureExpected:       false,
+		useStringDescriptions: true,
 	},
 	{
 		description: "Multiline strings are not allowed",
 		definition: `"Hello
 				 World"`,
-		expected: `graphql: syntax error: literal not terminated (line 1, column 1)`,
-		failureExpected: true,
-		useStringDescriptions: true,		
+		expected:              `graphql: syntax error: literal not terminated (line 1, column 1)`,
+		failureExpected:       true,
+		useStringDescriptions: true,
 	},
 }
 
@@ -130,5 +130,5 @@ func TestMultilineString(t *testing.T) {
 				t.Fatalf("Test '%s' failed with error: '%s'", test.description, err.Error())
 			}
 		})
-	}	
+	}
 }

--- a/internal/exec/resolvable/meta.go
+++ b/internal/exec/resolvable/meta.go
@@ -1,7 +1,6 @@
 package resolvable
 
 import (
-	"fmt"
 	"reflect"
 
 	"github.com/graph-gophers/graphql-go/introspection"
@@ -42,7 +41,7 @@ func newMeta(s *types.Schema) *Meta {
 			Name: "__typename",
 			Type: &types.NonNull{OfType: s.Types["String"]},
 		},
-		TraceLabel: fmt.Sprintf("GraphQL field: __typename"),
+		TraceLabel: "GraphQL field: __typename",
 	}
 
 	fieldSchema := Field{
@@ -50,7 +49,7 @@ func newMeta(s *types.Schema) *Meta {
 			Name: "__schema",
 			Type: s.Types["__Schema"],
 		},
-		TraceLabel: fmt.Sprintf("GraphQL field: __schema"),
+		TraceLabel: "GraphQL field: __schema",
 	}
 
 	fieldType := Field{
@@ -58,7 +57,7 @@ func newMeta(s *types.Schema) *Meta {
 			Name: "__type",
 			Type: s.Types["__Type"],
 		},
-		TraceLabel: fmt.Sprintf("GraphQL field: __type"),
+		TraceLabel: "GraphQL field: __type",
 	}
 
 	return &Meta{

--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -176,8 +176,8 @@ func applyFragment(r *Request, s *resolvable.Schema, e *resolvable.Object, frag 
 		t := r.Schema.Resolve(frag.On.Name)
 		face, ok := t.(*types.InterfaceTypeDefinition)
 		if !ok && frag.On.Name != "" {
-			a, ok := e.TypeAssertions[frag.On.Name]
-			if !ok {
+			a, ok2 := e.TypeAssertions[frag.On.Name]
+			if !ok2 {
 				panic(fmt.Errorf("%q does not implement %q", frag.On, e.Name)) // TODO proper error handling
 			}
 

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -11,8 +11,8 @@ import (
 
 const (
 	Query        types.OperationType = "QUERY"
-	Mutation                         = "MUTATION"
-	Subscription                     = "SUBSCRIPTION"
+	Mutation     types.OperationType = "MUTATION"
+	Subscription types.OperationType = "SUBSCRIPTION"
 )
 
 func Parse(queryString string) (*types.ExecutableDefinition, *errors.QueryError) {

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -469,9 +469,9 @@ Second line of the description.
 					return fmt.Errorf("Expected 3 possible types, but instead got %d types", len(typ.UnionMemberTypes))
 				}
 				posible := map[string]struct{}{
-					"Coloured": struct{}{},
-					"Named":    struct{}{},
-					"Numbered": struct{}{},
+					"Coloured": {},
+					"Named":    {},
+					"Numbered": {},
 				}
 				for _, pt := range typ.UnionMemberTypes {
 					if _, ok := posible[pt.Name]; !ok {
@@ -503,11 +503,11 @@ Second line of the description.
 					return fmt.Errorf("Expected 5 enum values, but instead got %d types", len(typ.EnumValuesDefinition))
 				}
 				posible := map[string]struct{}{
-					"AUD": struct{}{},
-					"USD": struct{}{},
-					"EUR": struct{}{},
-					"BGN": struct{}{},
-					"GBP": struct{}{},
+					"AUD": {},
+					"USD": {},
+					"EUR": {},
+					"BGN": {},
+					"GBP": {},
 				}
 				for _, v := range typ.EnumValuesDefinition {
 					if _, ok := posible[v.EnumValue]; !ok {
@@ -604,9 +604,9 @@ Second line of the description.
 					return fmt.Errorf("Expected 3 possible types, but instead got %d types", len(typ.UnionMemberTypes))
 				}
 				posible := map[string]struct{}{
-					"Coloured": struct{}{},
-					"Named":    struct{}{},
-					"Numbered": struct{}{},
+					"Coloured": {},
+					"Named":    {},
+					"Numbered": {},
 				}
 				for _, pt := range typ.UnionMemberTypes {
 					if _, ok := posible[pt.Name]; !ok {
@@ -641,10 +641,10 @@ Second line of the description.
 					return fmt.Errorf("Expected 4 fields, but instead got %d types", len(typ.Values))
 				}
 				posible := map[string]struct{}{
-					"id":       struct{}{},
-					"name":     struct{}{},
-					"category": struct{}{},
-					"tags":     struct{}{},
+					"id":       {},
+					"name":     {},
+					"category": {},
+					"tags":     {},
 				}
 				for _, pt := range typ.Values {
 					if _, ok := posible[pt.Name.Name]; !ok {
@@ -741,9 +741,9 @@ Second line of the description.
 					return fmt.Errorf("Expected 3 fields, but instead got %d types", len(typ.Fields))
 				}
 				fields := map[string]struct{}{
-					"id":       struct{}{},
-					"name":     struct{}{},
-					"category": struct{}{},
+					"id":       {},
+					"name":     {},
+					"category": {},
 				}
 				for _, f := range typ.Fields {
 					if _, ok := fields[f.Name]; !ok {
@@ -861,8 +861,8 @@ Second line of the description.
 				if test.validateError == nil {
 					t.Fatal(err)
 				}
-				if err := test.validateError(err); err != nil {
-					t.Fatal(err)
+				if err2 := test.validateError(err); err2 != nil {
+					t.Fatal(err2)
 				}
 			}
 			if test.validateSchema != nil {

--- a/relay/relay.go
+++ b/relay/relay.go
@@ -40,7 +40,7 @@ func UnmarshalSpec(id graphql.ID, v interface{}) error {
 	if i == -1 {
 		return errors.New("invalid graphql.ID")
 	}
-	return json.Unmarshal([]byte(s[i+1:]), v)
+	return json.Unmarshal(s[i+1:], v)
 }
 
 type Handler struct {


### PR DESCRIPTION
Added a base golangci-config to the codebase to get
started. Some more changes are pending, and those
checks are commented out in the config.

Once this gets merged, we can work on enabling those
gradually.

For full reference, here are the errors which were fixed:

```
example/scalar_map/types/map.go:5: File is not `gofmt`-ed with `-s` (gofmt)
type Map map[string]interface {}
internal/common/lexer_test.go:97: File is not `gofmt`-ed with `-s` (gofmt)
var multilineStringTests = []consumeTestCase {
internal/schema/schema_test.go:472: File is not `gofmt`-ed with `-s` (gofmt)
                                        "Coloured": struct{}{},
                                        "Named":    struct{}{},
                                        "Numbered": struct{}{},
relay/relay.go:43:30: unnecessary conversion (unconvert)
        return json.Unmarshal([]byte(s[i+1:]), v)
                                    ^
internal/exec/resolvable/meta.go:45:15: S1039: unnecessary use of fmt.Sprintf (gosimple)
                TraceLabel: fmt.Sprintf("GraphQL field: __typename"),
                            ^
internal/exec/resolvable/meta.go:53:15: S1039: unnecessary use of fmt.Sprintf (gosimple)
                TraceLabel: fmt.Sprintf("GraphQL field: __schema"),
                            ^
internal/exec/resolvable/meta.go:61:15: S1039: unnecessary use of fmt.Sprintf (gosimple)
                TraceLabel: fmt.Sprintf("GraphQL field: __type"),
                            ^
internal/exec/selected/selected.go:179:7: shadow: declaration of "ok" shadows declaration at line 177 (govet)
                        a, ok := e.TypeAssertions[frag.On.Name]
                           ^
internal/schema/schema_test.go:864:8: shadow: declaration of "err" shadows declaration at line 859 (govet)
                                if err := test.validateError(err); err != nil {
                                   ^
graphql.go:135:30: SA1019: trace.ValidationTracer is deprecated: use ValidationTracerContext. (staticcheck)
func ValidationTracer(tracer trace.ValidationTracer) SchemaOpt {
                             ^
graphql.go:300:9: SA1019: trace.ValidationTracer is deprecated: use ValidationTracerContext. (staticcheck)
        tracer trace.ValidationTracer
               ^
internal/query/query.go:13:2: SA9004: only the first constant in this group has an explicit type (staticcheck)
        Query        types.OperationType = "QUERY"
```