### PR TITLE
ci: setup SemaphoreCI v2

### DIFF
--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -1,0 +1,20 @@
+version: v1.0
+name: Go
+agent:
+  machine:
+    type: e1-standard-2
+    os_image: ubuntu2004
+blocks:
+  - name: Test
+    task:
+      jobs:
+        - name: go test
+          commands:
+            - sem-version go 1.11
+            - "export GO111MODULE=on"
+            - "export GOPATH=~/go"
+            - "export PATH=/home/semaphore/go/bin:$PATH"
+            - checkout
+            - go get ./...
+            - go test ./...
+            - go build -v .

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -10,11 +10,12 @@ blocks:
       jobs:
         - name: go test
           commands:
-            - sem-version go 1.17.5
+            - sem-version go 1.17
             - export GO111MODULE=on
             - export GOPATH=~/go
             - 'export PATH=/home/semaphore/go/bin:$PATH'
             - checkout
+            - go version
             - go get ./...
             - go test ./...
             - go build -v .

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -10,7 +10,7 @@ blocks:
       jobs:
         - name: go test
           commands:
-            - sem-version go 1.17
+            - sem-version go 1.17.5
             - export GO111MODULE=on
             - export GOPATH=~/go
             - 'export PATH=/home/semaphore/go/bin:$PATH'

--- a/.semaphore/semaphore.yml
+++ b/.semaphore/semaphore.yml
@@ -10,10 +10,10 @@ blocks:
       jobs:
         - name: go test
           commands:
-            - sem-version go 1.11
-            - "export GO111MODULE=on"
-            - "export GOPATH=~/go"
-            - "export PATH=/home/semaphore/go/bin:$PATH"
+            - sem-version go 1.17
+            - export GO111MODULE=on
+            - export GOPATH=~/go
+            - 'export PATH=/home/semaphore/go/bin:$PATH'
             - checkout
             - go get ./...
             - go test ./...


### PR DESCRIPTION
This project uses an old version of Semaphore CI currently with an outdated version of Go configured to test and build the code. In addition to using a current version of Go to test and build the project, we'd also like to be able to add linters (see #478).

This branch was generated by SemaphoreCI itself.