### PR TITLE
Make some more golang-ci improvements

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,6 @@ linters-settings:
     enable-all: true
     disable:
       - fieldalignment
-      - composites # remove later
       - deepequalerrors # remove later
 
 linters:
@@ -26,7 +25,7 @@ linters:
     - unconvert
     - unused
     - varcheck
-    # - misspell add later
+    - misspell
     - goimports
 
 issues:

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -4144,15 +4144,15 @@ func checkFieldTraces(t *testing.T, want, have []fieldTrace) {
 		t.Errorf("mismatched field traces: expected %d but got %d: %#v", len(want), len(have), have)
 	}
 
-	type comparsion struct {
+	type comparison struct {
 		want fieldTrace
 		have fieldTrace
 	}
 
-	m := map[string]comparsion{}
+	m := map[string]comparison{}
 
 	for _, ft := range want {
-		m[ft.fieldName] = comparsion{want: ft}
+		m[ft.fieldName] = comparison{want: ft}
 	}
 
 	for _, ft := range have {

--- a/internal/common/lexer.go
+++ b/internal/common/lexer.go
@@ -123,7 +123,7 @@ func (l *Lexer) ConsumeIdentWithLoc() types.Ident {
 	loc := l.Location()
 	name := l.sc.TokenText()
 	l.ConsumeToken(scanner.Ident)
-	return types.Ident{name, loc}
+	return types.Ident{Name: name, Loc: loc}
 }
 
 func (l *Lexer) ConsumeKeyword(keyword string) {

--- a/internal/common/literals.go
+++ b/internal/common/literals.go
@@ -15,12 +15,12 @@ func ParseLiteral(l *Lexer, constOnly bool) types.Value {
 			panic("unreachable")
 		}
 		l.ConsumeToken('$')
-		return &types.Variable{l.ConsumeIdent(), loc}
+		return &types.Variable{Name: l.ConsumeIdent(), Loc: loc}
 
 	case scanner.Int, scanner.Float, scanner.String, scanner.Ident:
 		lit := l.ConsumeLiteral()
 		if lit.Type == scanner.Ident && lit.Text == "null" {
-			return &types.NullValue{loc}
+			return &types.NullValue{Loc: loc}
 		}
 		lit.Loc = loc
 		return lit
@@ -37,7 +37,7 @@ func ParseLiteral(l *Lexer, constOnly bool) types.Value {
 			list = append(list, ParseLiteral(l, constOnly))
 		}
 		l.ConsumeToken(']')
-		return &types.ListValue{list, loc}
+		return &types.ListValue{Values: list, Loc: loc}
 
 	case '{':
 		l.ConsumeToken('{')
@@ -46,10 +46,10 @@ func ParseLiteral(l *Lexer, constOnly bool) types.Value {
 			name := l.ConsumeIdentWithLoc()
 			l.ConsumeToken(':')
 			value := ParseLiteral(l, constOnly)
-			fields = append(fields, &types.ObjectField{name, value})
+			fields = append(fields, &types.ObjectField{Name: name, Value: value})
 		}
 		l.ConsumeToken('}')
-		return &types.ObjectValue{fields, loc}
+		return &types.ObjectValue{Fields: fields, Loc: loc}
 
 	default:
 		l.SyntaxError("invalid value")

--- a/internal/schema/schema_internal_test.go
+++ b/internal/schema/schema_internal_test.go
@@ -22,7 +22,7 @@ func TestParseInterfaceDef(t *testing.T) {
 		definition:  "Greeting { field: String }",
 		expected: &types.InterfaceTypeDefinition{
 			Name:   "Greeting",
-			Loc:    errors.Location{1, 1},
+			Loc:    errors.Location{Line: 1, Column: 1},
 			Fields: types.FieldsDefinition{&types.FieldDefinition{Name: "field"}}},
 	}}
 
@@ -53,19 +53,19 @@ func TestParseObjectDef(t *testing.T) {
 	tests := []testCase{{
 		description: "Parses type inheriting single interface",
 		definition:  "Hello implements World { field: String }",
-		expected:    &types.ObjectTypeDefinition{Name: "Hello", Loc: errors.Location{1, 1}, InterfaceNames: []string{"World"}},
+		expected:    &types.ObjectTypeDefinition{Name: "Hello", Loc: errors.Location{Line: 1, Column: 1}, InterfaceNames: []string{"World"}},
 	}, {
 		description: "Parses type inheriting multiple interfaces",
 		definition:  "Hello implements Wo & rld { field: String }",
-		expected:    &types.ObjectTypeDefinition{Name: "Hello", Loc: errors.Location{1, 1}, InterfaceNames: []string{"Wo", "rld"}},
+		expected:    &types.ObjectTypeDefinition{Name: "Hello", Loc: errors.Location{Line: 1, Column: 1}, InterfaceNames: []string{"Wo", "rld"}},
 	}, {
 		description: "Parses type inheriting multiple interfaces with leading ampersand",
 		definition:  "Hello implements & Wo & rld { field: String }",
-		expected:    &types.ObjectTypeDefinition{Name: "Hello", Loc: errors.Location{1, 1}, InterfaceNames: []string{"Wo", "rld"}},
+		expected:    &types.ObjectTypeDefinition{Name: "Hello", Loc: errors.Location{Line: 1, Column: 1}, InterfaceNames: []string{"Wo", "rld"}},
 	}, {
 		description: "Allows legacy SDL interfaces",
 		definition:  "Hello implements Wo, rld { field: String }",
-		expected:    &types.ObjectTypeDefinition{Name: "Hello", Loc: errors.Location{1, 1}, InterfaceNames: []string{"Wo", "rld"}},
+		expected:    &types.ObjectTypeDefinition{Name: "Hello", Loc: errors.Location{Line: 1, Column: 1}, InterfaceNames: []string{"Wo", "rld"}},
 	}}
 
 	for _, test := range tests {
@@ -97,7 +97,7 @@ func TestParseUnionDef(t *testing.T) {
 			expected: &types.Union{
 				Name:      "Foo",
 				TypeNames: []string{"Bar", "Qux", "Quux"},
-				Loc:       errors.Location{1, 1},
+				Loc:       errors.Location{Line: 1, Column: 1},
 			},
 		},
 	}
@@ -133,14 +133,14 @@ func TestParseEnumDef(t *testing.T) {
 				EnumValuesDefinition: []*types.EnumValueDefinition{
 					{
 						EnumValue: "BAR",
-						Loc:       errors.Location{1, 7},
+						Loc:       errors.Location{Line: 1, Column: 7},
 					},
 					{
 						EnumValue: "QUX",
-						Loc:       errors.Location{1, 11},
+						Loc:       errors.Location{Line: 1, Column: 11},
 					},
 				},
-				Loc: errors.Location{1, 1},
+				Loc: errors.Location{Line: 1, Column: 1},
 			},
 		},
 		{
@@ -154,14 +154,14 @@ func TestParseEnumDef(t *testing.T) {
 				EnumValuesDefinition: []*types.EnumValueDefinition{
 					{
 						EnumValue: "BAR",
-						Loc:       errors.Location{2, 5},
+						Loc:       errors.Location{Line: 2, Column: 5},
 					},
 					{
 						EnumValue: "QUX",
-						Loc:       errors.Location{3, 5},
+						Loc:       errors.Location{Line: 3, Column: 5},
 					},
 				},
-				Loc: errors.Location{1, 1},
+				Loc: errors.Location{Line: 1, Column: 1},
 			},
 		},
 	}
@@ -194,7 +194,7 @@ func TestParseDirectiveDef(t *testing.T) {
 			definition:  "@Foo on FIELD",
 			expected: &types.DirectiveDefinition{
 				Name:      "Foo",
-				Loc:       errors.Location{1, 2},
+				Loc:       errors.Location{Line: 1, Column: 2},
 				Locations: []string{"FIELD"},
 			},
 		},
@@ -229,7 +229,7 @@ func TestParseInputDef(t *testing.T) {
 			expected: &types.InputObject{
 				Name:   "Foo",
 				Values: nil,
-				Loc:    errors.Location{1, 1},
+				Loc:    errors.Location{Line: 1, Column: 1},
 			},
 		},
 	}


### PR DESCRIPTION
- We enable the misspell linter.
- We use keyed composite literals.