### PR TITLE
Fix parseObjectDef will terminate when object has bad syntax (#491)

### DIFF
--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -408,19 +408,19 @@ func parseObjectDef(l *common.Lexer) *types.ObjectTypeDefinition {
 			continue
 		}
 
-		if l.Peek() == scanner.Ident {
-			l.ConsumeKeyword("implements")
-
-			for l.Peek() != '{' && l.Peek() != '@' {
-				if l.Peek() == '&' {
-					l.ConsumeToken('&')
-				}
-
-				object.InterfaceNames = append(object.InterfaceNames, l.ConsumeIdent())
-			}
-			continue
+		if l.Peek() != scanner.Ident {
+			break
 		}
 
+		l.ConsumeKeyword("implements")
+
+		for l.Peek() != '{' && l.Peek() != '@' {
+			if l.Peek() == '&' {
+				l.ConsumeToken('&')
+			}
+
+			object.InterfaceNames = append(object.InterfaceNames, l.ConsumeIdent())
+		}
 	}
 	l.ConsumeToken('{')
 	object.Fields = parseFieldsDef(l)

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -232,6 +232,19 @@ Second line of the description.
 			},
 		},
 		{
+			name: "Parses type invalid syntax",
+			sdl: `
+			type U = T
+			`,
+			validateError: func(err error) error {
+				msg := `graphql: syntax error: unexpected "=", expecting "{" (line 2, column 11)`
+				if err == nil || err.Error() != msg {
+					return fmt.Errorf("expected error %q, but got %q", msg, err)
+				}
+				return nil
+			},
+		},
+		{
 			name: "Description is correctly parsed for non-described types",
 			sdl: `
 			"Some description."


### PR DESCRIPTION
Fixes issue described by @brandonbloom here: https://github.com/graph-gophers/graphql-go/issues/491.