### PR TITLE
add support for repeatable directives

### DIFF
--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -524,7 +524,7 @@ func parseDirectiveDef(l *common.Lexer) *types.DirectiveDefinition {
 
 	for {
 		loc := l.ConsumeIdent()
-		if ok, err := regexp.MatchString("^[A-Z_]+$", loc); err != nil || !ok {
+		if ok, err := regexp.MatchString("^[A-Z][A-Z_]+$", loc); err != nil || !ok {
 			l.SyntaxError(fmt.Sprintf("expected directive location-spec to be SNAKE_CASE, but got %q", loc))
 		}
 		d.Locations = append(d.Locations, loc)

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -514,7 +514,7 @@ func parseDirectiveDef(l *common.Lexer) *types.DirectiveDefinition {
 
 	switch x := l.ConsumeIdent(); x {
 	case "on":
-		d.Repeatable = false
+		// no-op; Go doesn't fallthrough by default
 	case "repeatable":
 		d.Repeatable = true
 		l.ConsumeKeyword("on")

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -513,6 +513,7 @@ func parseDirectiveDef(l *common.Lexer) *types.DirectiveDefinition {
 
 	switch x := l.ConsumeIdent(); x {
 	case "on":
+		d.Repeatable = false
 	case "repeatable":
 		d.Repeatable = true
 		l.ConsumeKeyword("on")

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -511,7 +511,13 @@ func parseDirectiveDef(l *common.Lexer) *types.DirectiveDefinition {
 		l.ConsumeToken(')')
 	}
 
-	l.ConsumeKeyword("on")
+	switch x := l.ConsumeIdent(); x {
+	case "on":
+	case "repeatable":
+		l.ConsumeKeyword("on")
+	default:
+		l.SyntaxError(fmt.Sprintf(`unexpected %q, expecting "on" or "repeatable"`, x))
+	}
 
 	for {
 		loc := l.ConsumeIdent()

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -514,6 +514,7 @@ func parseDirectiveDef(l *common.Lexer) *types.DirectiveDefinition {
 	switch x := l.ConsumeIdent(); x {
 	case "on":
 	case "repeatable":
+		d.Repeatable = true
 		l.ConsumeKeyword("on")
 	default:
 		l.SyntaxError(fmt.Sprintf(`unexpected %q, expecting "on" or "repeatable"`, x))

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -524,8 +524,8 @@ func parseDirectiveDef(l *common.Lexer) *types.DirectiveDefinition {
 
 	for {
 		loc := l.ConsumeIdent()
-		if _, ok := legalDirectiveFieldLocations[loc]; !ok {
-			l.SyntaxError(fmt.Sprintf("%q is not a legal directive location (options: %v)", loc, legalDirectiveFieldLocationsSlice))
+		if _, ok := legalDirectiveLocationNames[loc]; !ok {
+			l.SyntaxError(fmt.Sprintf("%q is not a legal directive location (options: %v)", loc, legalDirectiveLocationNames))
 		}
 		if ok, err := regexp.MatchString("^[A-Z][A-Z_]*$", loc); err != nil || !ok {
 			l.SyntaxError(fmt.Sprintf("expected directive location-spec to be SNAKE_CASE, but got %q", loc))
@@ -600,7 +600,7 @@ func parseFieldsDef(l *common.Lexer) types.FieldsDefinition {
 	return fields
 }
 
-var legalDirectiveFieldLocations = map[string]struct{}{
+var legalDirectiveLocationNames = map[string]struct{}{
 	"SCHEMA":                 {},
 	"SCALAR":                 {},
 	"OBJECT":                 {},
@@ -621,9 +621,9 @@ var legalDirectiveFieldLocations = map[string]struct{}{
 	"INLINE_FRAGMENT":        {},
 	"VARIABLE_DEFINITION":    {},
 }
-var legalDirectiveFieldLocationsSlice = func() []string {
+var legalDirectiveLocationNamesSlice = func() []string {
 	var words []string
-	for loc, _ := range legalDirectiveFieldLocations {
+	for loc, _ := range legalDirectiveLocationNames {
 		words = append(words, loc)
 	}
 	return words

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -524,10 +524,7 @@ func parseDirectiveDef(l *common.Lexer) *types.DirectiveDefinition {
 
 	for {
 		loc := l.ConsumeIdent()
-		if _, ok := legalDirectiveFieldLocations[loc]; !ok {
-			l.SyntaxError(fmt.Sprintf("%q is not a legal directive location (options: %v)", loc, legalDirectiveFieldLocationsSlice))
-		}
-		if ok, err := regexp.MatchString("^[A-Z][A-Z_]*$", loc); err != nil || !ok {
+		if ok, err := regexp.MatchString("^[A-Z_]+$", loc); err != nil || !ok {
 			l.SyntaxError(fmt.Sprintf("expected directive location-spec to be SNAKE_CASE, but got %q", loc))
 		}
 		d.Locations = append(d.Locations, loc)
@@ -599,32 +596,3 @@ func parseFieldsDef(l *common.Lexer) types.FieldsDefinition {
 	}
 	return fields
 }
-
-var legalDirectiveFieldLocations = map[string]struct{}{
-	"SCHEMA":                 {},
-	"SCALAR":                 {},
-	"OBJECT":                 {},
-	"FIELD_DEFINITION":       {},
-	"ARGUMENT_DEFINITION":    {},
-	"INTERFACE":              {},
-	"UNION":                  {},
-	"ENUM":                   {},
-	"ENUM_VALUE":             {},
-	"INPUT_OBJECT":           {},
-	"INPUT_FIELD_DEFINITION": {},
-	"QUERY":                  {},
-	"MUTATION":               {},
-	"SUBSCRIPTION":           {},
-	"FIELD":                  {},
-	"FRAGMENT_DEFINITION":    {},
-	"FRAGMENT_SPREAD":        {},
-	"INLINE_FRAGMENT":        {},
-	"VARIABLE_DEFINITION":    {},
-}
-var legalDirectiveFieldLocationsSlice = func() []string {
-	var words []string
-	for loc, _ := range legalDirectiveFieldLocations {
-		words = append(words, loc)
-	}
-	return words
-}()

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -2,7 +2,6 @@ package schema
 
 import (
 	"fmt"
-	"regexp"
 	"text/scanner"
 
 	"github.com/graph-gophers/graphql-go/errors"
@@ -527,9 +526,6 @@ func parseDirectiveDef(l *common.Lexer) *types.DirectiveDefinition {
 		if _, ok := legalDirectiveLocationNames[loc]; !ok {
 			l.SyntaxError(fmt.Sprintf("%q is not a legal directive location (options: %v)", loc, legalDirectiveLocationNames))
 		}
-		if ok, err := regexp.MatchString("^[A-Z][A-Z_]*$", loc); err != nil || !ok {
-			l.SyntaxError(fmt.Sprintf("expected directive location-spec to be SNAKE_CASE, but got %q", loc))
-		}
 		d.Locations = append(d.Locations, loc)
 		if l.Peek() != '|' {
 			break
@@ -621,10 +617,3 @@ var legalDirectiveLocationNames = map[string]struct{}{
 	"INLINE_FRAGMENT":        {},
 	"VARIABLE_DEFINITION":    {},
 }
-var legalDirectiveLocationNamesSlice = func() []string {
-	var words []string
-	for loc, _ := range legalDirectiveLocationNames {
-		words = append(words, loc)
-	}
-	return words
-}()

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -524,7 +524,10 @@ func parseDirectiveDef(l *common.Lexer) *types.DirectiveDefinition {
 
 	for {
 		loc := l.ConsumeIdent()
-		if ok, err := regexp.MatchString("^[A-Z_]+$", loc); err != nil || !ok {
+		if _, ok := legalDirectiveFieldLocations[loc]; !ok {
+			l.SyntaxError(fmt.Sprintf("%q is not a legal directive location (options: %v)", loc, legalDirectiveFieldLocationsSlice))
+		}
+		if ok, err := regexp.MatchString("^[A-Z][A-Z_]*$", loc); err != nil || !ok {
 			l.SyntaxError(fmt.Sprintf("expected directive location-spec to be SNAKE_CASE, but got %q", loc))
 		}
 		d.Locations = append(d.Locations, loc)
@@ -596,3 +599,32 @@ func parseFieldsDef(l *common.Lexer) types.FieldsDefinition {
 	}
 	return fields
 }
+
+var legalDirectiveFieldLocations = map[string]struct{}{
+	"SCHEMA":                 {},
+	"SCALAR":                 {},
+	"OBJECT":                 {},
+	"FIELD_DEFINITION":       {},
+	"ARGUMENT_DEFINITION":    {},
+	"INTERFACE":              {},
+	"UNION":                  {},
+	"ENUM":                   {},
+	"ENUM_VALUE":             {},
+	"INPUT_OBJECT":           {},
+	"INPUT_FIELD_DEFINITION": {},
+	"QUERY":                  {},
+	"MUTATION":               {},
+	"SUBSCRIPTION":           {},
+	"FIELD":                  {},
+	"FRAGMENT_DEFINITION":    {},
+	"FRAGMENT_SPREAD":        {},
+	"INLINE_FRAGMENT":        {},
+	"VARIABLE_DEFINITION":    {},
+}
+var legalDirectiveFieldLocationsSlice = func() []string {
+	var words []string
+	for loc, _ := range legalDirectiveFieldLocations {
+		words = append(words, loc)
+	}
+	return words
+}()

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -524,7 +524,10 @@ func parseDirectiveDef(l *common.Lexer) *types.DirectiveDefinition {
 
 	for {
 		loc := l.ConsumeIdent()
-		if ok, err := regexp.MatchString("^[A-Z][A-Z_]+$", loc); err != nil || !ok {
+		if _, ok := legalDirectiveFieldLocations[loc]; !ok {
+			l.SyntaxError(fmt.Sprintf("%q is not a legal directive location (options: %v)", loc, legalDirectiveFieldLocationsSlice))
+		}
+		if ok, err := regexp.MatchString("^[A-Z][A-Z_]*$", loc); err != nil || !ok {
 			l.SyntaxError(fmt.Sprintf("expected directive location-spec to be SNAKE_CASE, but got %q", loc))
 		}
 		d.Locations = append(d.Locations, loc)
@@ -596,3 +599,32 @@ func parseFieldsDef(l *common.Lexer) types.FieldsDefinition {
 	}
 	return fields
 }
+
+var legalDirectiveFieldLocations = map[string]struct{}{
+	"SCHEMA":                 {},
+	"SCALAR":                 {},
+	"OBJECT":                 {},
+	"FIELD_DEFINITION":       {},
+	"ARGUMENT_DEFINITION":    {},
+	"INTERFACE":              {},
+	"UNION":                  {},
+	"ENUM":                   {},
+	"ENUM_VALUE":             {},
+	"INPUT_OBJECT":           {},
+	"INPUT_FIELD_DEFINITION": {},
+	"QUERY":                  {},
+	"MUTATION":               {},
+	"SUBSCRIPTION":           {},
+	"FIELD":                  {},
+	"FRAGMENT_DEFINITION":    {},
+	"FRAGMENT_SPREAD":        {},
+	"INLINE_FRAGMENT":        {},
+	"VARIABLE_DEFINITION":    {},
+}
+var legalDirectiveFieldLocationsSlice = func() []string {
+	var words []string
+	for loc, _ := range legalDirectiveFieldLocations {
+		words = append(words, loc)
+	}
+	return words
+}()

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -2,6 +2,7 @@ package schema
 
 import (
 	"fmt"
+	"regexp"
 	"text/scanner"
 
 	"github.com/graph-gophers/graphql-go/errors"
@@ -523,6 +524,9 @@ func parseDirectiveDef(l *common.Lexer) *types.DirectiveDefinition {
 
 	for {
 		loc := l.ConsumeIdent()
+		if ok, err := regexp.MatchString("^[A-Z_]+$", loc); err != nil || !ok {
+			l.SyntaxError(fmt.Sprintf("expected directive location-spec to be SNAKE_CASE, but got %q", loc))
+		}
 		d.Locations = append(d.Locations, loc)
 		if l.Peek() != '|' {
 			break

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -876,7 +876,7 @@ Second line of the description.
 			},
 		},
 		{
-			name: "Sets Directive.Repeatable iff `repeatable` keyword is given",
+			name: "Sets Directive.Repeatable if `repeatable` keyword is given",
 			sdl: `
 			directive @nonrepeatabledirective on SCALAR
 			directive @repeatabledirective repeatable on SCALAR

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -2,6 +2,7 @@ package schema_test
 
 import (
 	"fmt"
+	"strings"
 	"testing"
 
 	"github.com/graph-gophers/graphql-go/internal/schema"
@@ -912,9 +913,9 @@ Second line of the description.
 			scalar MyScalar @mydirective
 			`,
 			validateError: func(err error) error {
-				msg := `graphql: syntax error: expected directive location-spec to be SNAKE_CASE, but got "on" (line 2, column 33)`
-				if err == nil || err.Error() != msg {
-					return fmt.Errorf("expected error %q, but got %q", msg, err)
+				prefix := `graphql: syntax error: "on" is not a legal directive location`
+				if err == nil || !strings.HasPrefix(err.Error(), prefix) {
+					return fmt.Errorf("expected error starting with %q, but got %q", prefix, err)
 				}
 				return nil
 			},

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -836,7 +836,7 @@ Second line of the description.
 
 			union Union @uniondirective = Photo | Person
 
-			scalar Repeatable @repeatabledirective @repeatabledirective
+			scalar Mass @repeatabledirective @repeatabledirective
 			`,
 			validateSchema: func(s *types.Schema) error {
 				namedEntityDirectives := s.Types["NamedEntity"].(*types.InterfaceTypeDefinition).Directives
@@ -868,9 +868,9 @@ Second line of the description.
 					return fmt.Errorf("missing directive on Union union, expected @uniondirective but got %v", unionDirectives)
 				}
 
-				repeatableDirectives := s.Types["Repeatable"].(*types.ScalarTypeDefinition).Directives
-				if len(repeatableDirectives) != 2 || repeatableDirectives[0].Name.Name != "repeatabledirective" || repeatableDirectives[1].Name.Name != "repeatabledirective" {
-					return fmt.Errorf("missing directive on Repeatable scalar, expected @repeatabledirective @repeatabledirective but got %v", repeatableDirectives)
+				massDirectives := s.Types["Mass"].(*types.ScalarTypeDefinition).Directives
+				if len(massDirectives) != 2 || massDirectives[0].Name.Name != "repeatabledirective" || massDirectives[1].Name.Name != "repeatabledirective" {
+					return fmt.Errorf("missing directive on Repeatable scalar, expected @repeatabledirective @repeatabledirective but got %v", massDirectives)
 				}
 				return nil
 			},

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -2,7 +2,6 @@ package schema_test
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/graph-gophers/graphql-go/internal/schema"
@@ -913,9 +912,9 @@ Second line of the description.
 			scalar MyScalar @mydirective
 			`,
 			validateError: func(err error) error {
-				prefix := `graphql: syntax error: "on" is not a legal directive location`
-				if err == nil || !strings.HasPrefix(err.Error(), prefix) {
-					return fmt.Errorf("expected error starting with %q, but got %q", prefix, err)
+				msg := `graphql: syntax error: expected directive location-spec to be SNAKE_CASE, but got "on" (line 2, column 33)`
+				if err == nil || err.Error() != msg {
+					return fmt.Errorf("expected error %q, but got %q", msg, err)
 				}
 				return nil
 			},

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -813,6 +813,7 @@ Second line of the description.
 				| ENUM_VALUE
 				| INPUT_OBJECT
 				| INPUT_FIELD_DEFINITION
+			directive @repeatabledirective repeatable on SCALAR
 
 			interface NamedEntity @directive { name: String }
 
@@ -834,6 +835,8 @@ Second line of the description.
 			}
 
 			union Union @uniondirective = Photo | Person
+
+			scalar Repeatable @repeatabledirective @repeatabledirective
 			`,
 			validateSchema: func(s *types.Schema) error {
 				namedEntityDirectives := s.Types["NamedEntity"].(*types.InterfaceTypeDefinition).Directives
@@ -863,6 +866,11 @@ Second line of the description.
 				unionDirectives := s.Types["Union"].(*types.Union).Directives
 				if len(unionDirectives) != 1 || unionDirectives[0].Name.Name != "uniondirective" {
 					return fmt.Errorf("missing directive on Union union, expected @uniondirective but got %v", unionDirectives)
+				}
+
+				repeatableDirectives := s.Types["Repeatable"].(*types.ScalarTypeDefinition).Directives
+				if len(repeatableDirectives) != 2 || repeatableDirectives[0].Name.Name != "repeatabledirective" || repeatableDirectives[1].Name.Name != "repeatabledirective" {
+					return fmt.Errorf("missing directive on Repeatable scalar, expected @repeatabledirective @repeatabledirective but got %v", repeatableDirectives)
 				}
 				return nil
 			},

--- a/types/directive.go
+++ b/types/directive.go
@@ -14,11 +14,12 @@ type Directive struct {
 //
 // http://spec.graphql.org/draft/#sec-Type-System.Directives
 type DirectiveDefinition struct {
-	Name      string
-	Desc      string
-	Locations []string
-	Arguments ArgumentsDefinition
-	Loc       errors.Location
+	Name       string
+	Desc       string
+	Repeatable bool
+	Locations  []string
+	Arguments  ArgumentsDefinition
+	Loc        errors.Location
 }
 
 type DirectiveList []*Directive


### PR DESCRIPTION
[The October 2021 spec](https://spec.graphql.org/October2021/#sec-Directives-Are-Unique-Per-Location) ([changelog](https://github.com/graphql/graphql-spec/blob/main/changelogs/October2021.md), [commit](https://github.com/graphql/graphql-spec/commit/be33a640a8d12eb177f7cce0c61a1fad770a3430)) introduced an optional keyword `repeatable` in directive definitions. ([The June 2018 spec](https://spec.graphql.org/June2018/#sec-Directives-Are-Unique-Per-Location) requires that all directives be unique; graphql-go doesn't enforce that, but nor does it recognize the `repeatable` keyword.)

Context: I'm working in a codebase where I want to repeat a directive, and a different tool requires that we mark it `repeatable`; but if I do that, then graphql-go SyntaxErrors.