### PR TITLE
Apollo Federation Spec: Fetch service capabilities

### DIFF
--- a/example/apollo_federation/README.md
+++ b/example/apollo_federation/README.md
@@ -1,6 +1,6 @@
-### Apollo Federation
+# Apollo Federation
 
-A simple example of integration with apollo federation as subgraph.
+A simple example of integration with apollo federation as subgraph. Tested with Go v1.18, Node.js v16.14.2 and yarn 1.22.18.
 
 To run this server
 
@@ -13,3 +13,23 @@ To run this server
 `yarn start`
 
 and go to localhost:4000 to interact
+
+Execute the query:
+
+```
+query {
+  hello
+  hi
+}
+```
+
+and you should see a result similar to this:
+
+```json
+{
+  "data": {
+    "hello": "Hello from subgraph one!",
+    "hi": "Hi from subgraph two!"
+  }
+}
+```

--- a/example/apollo_federation/README.md
+++ b/example/apollo_federation/README.md
@@ -1,0 +1,15 @@
+### Apollo Federation
+
+A simple example of integration with apollo federation as subgraph.
+
+To run this server
+
+`go run ./example/apollo_federation/subgraph_one/server.go`
+
+`go run ./example/apollo_federation/subgraph_two/server.go`
+
+`cd example/apollo_federation/gateway`
+
+`yarn start`
+
+and go to localhost:4000 to interact

--- a/example/apollo_federation/gateway/.gitignore
+++ b/example/apollo_federation/gateway/.gitignore
@@ -1,0 +1,1 @@
+/node_modules

--- a/example/apollo_federation/gateway/index.js
+++ b/example/apollo_federation/gateway/index.js
@@ -1,0 +1,20 @@
+const { ApolloServer }  = require('apollo-server')
+const { ApolloGateway, IntrospectAndCompose } = require('@apollo/gateway');
+
+const gateway = new ApolloGateway({
+    supergraphSdl: new IntrospectAndCompose({
+        subgraphs: [
+            { name: 'one', url: 'http://localhost:4001' },
+            { name: 'two', url: 'http://localhost:4002' },
+        ],
+    }),
+});
+
+const server = new ApolloServer({
+    gateway,
+    subscriptions: false,
+});
+
+server.listen().then(({ url }) => {
+    console.log(`Server ready at ${url}`);
+});

--- a/example/apollo_federation/gateway/index.js
+++ b/example/apollo_federation/gateway/index.js
@@ -4,8 +4,8 @@ const { ApolloGateway, IntrospectAndCompose } = require('@apollo/gateway');
 const gateway = new ApolloGateway({
     supergraphSdl: new IntrospectAndCompose({
         subgraphs: [
-            { name: 'one', url: 'http://localhost:4001' },
-            { name: 'two', url: 'http://localhost:4002' },
+            { name: 'one', url: 'http://localhost:4001/query' },
+            { name: 'two', url: 'http://localhost:4002/query' },
         ],
     }),
 });

--- a/example/apollo_federation/gateway/package.json
+++ b/example/apollo_federation/gateway/package.json
@@ -7,7 +7,7 @@
     "start": "node index.js"
   },
   "dependencies": {
-    "@apollo/gateway": "^0.24.4",
+    "@apollo/gateway": "^0.49.0",
     "apollo-server": "^2.21.1",
     "graphql": "^15.5.0"
   }

--- a/example/apollo_federation/gateway/package.json
+++ b/example/apollo_federation/gateway/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "apollo-federation-gateway",
+  "version": "1.0.0",
+  "description": "Graphql Federation",
+  "main": "index.js",
+  "scripts": {
+    "start": "node index.js"
+  },
+  "dependencies": {
+    "@apollo/gateway": "^0.24.4",
+    "apollo-server": "^2.21.1",
+    "graphql": "^15.5.0"
+  }
+}

--- a/example/apollo_federation/subgraph_one/server.go
+++ b/example/apollo_federation/subgraph_one/server.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+	"log"
+	"net/http"
+)
+
+var schema = `
+	schema {
+		query: Query
+	}
+	
+	type Query {
+		hello: String!
+	}
+`
+
+type resolver struct {}
+
+func (r *resolver) Hello() string {
+	return "Hello, world! from subgraph one."
+}
+
+func main() {
+	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers(), graphql.MaxParallelism(20)}
+	schema := graphql.MustParseSchema(schema, &resolver{}, opts...)
+
+	http.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(page)
+	}))
+
+	http.Handle("/query", &relay.Handler{Schema: schema})
+
+	log.Fatal(http.ListenAndServe(":4001", nil))
+}
+
+var page = []byte(`
+<!DOCTYPE html>
+<html>
+	<head>
+		<link href="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.11/graphiql.min.css" rel="stylesheet" />
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/es6-promise/4.1.1/es6-promise.auto.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/react/16.2.0/umd/react.production.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.2.0/umd/react-dom.production.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.11/graphiql.min.js"></script>
+	</head>
+	<body style="width: 100%; height: 100%; margin: 0; overflow: hidden;">
+		<div id="graphiql" style="height: 100vh;">Loading...</div>
+		<script>
+			function graphQLFetcher(graphQLParams) {
+				return fetch("/query", {
+					method: "post",
+					body: JSON.stringify(graphQLParams),
+					credentials: "include",
+				}).then(function (response) {
+					return response.text();
+				}).then(function (responseBody) {
+					try {
+						return JSON.parse(responseBody);
+					} catch (error) {
+						return responseBody;
+					}
+				});
+			}
+
+			ReactDOM.render(
+				React.createElement(GraphiQL, {fetcher: graphQLFetcher}),
+				document.getElementById("graphiql")
+			);
+		</script>
+	</body>
+</html>
+`)

--- a/example/apollo_federation/subgraph_one/server.go
+++ b/example/apollo_federation/subgraph_one/server.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/graph-gophers/graphql-go"
-	"github.com/graph-gophers/graphql-go/relay"
 	"log"
 	"net/http"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
 )
 
 var schema = `
@@ -17,60 +18,17 @@ var schema = `
 	}
 `
 
-type resolver struct {}
+type resolver struct{}
 
 func (r *resolver) Hello() string {
-	return "Hello, world! from subgraph one."
+	return "Hello from subgraph one!"
 }
 
 func main() {
 	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers(), graphql.MaxParallelism(20)}
 	schema := graphql.MustParseSchema(schema, &resolver{}, opts...)
 
-	http.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write(page)
-	}))
-
 	http.Handle("/query", &relay.Handler{Schema: schema})
 
 	log.Fatal(http.ListenAndServe(":4001", nil))
 }
-
-var page = []byte(`
-<!DOCTYPE html>
-<html>
-	<head>
-		<link href="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.11/graphiql.min.css" rel="stylesheet" />
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/es6-promise/4.1.1/es6-promise.auto.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/react/16.2.0/umd/react.production.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.2.0/umd/react-dom.production.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.11/graphiql.min.js"></script>
-	</head>
-	<body style="width: 100%; height: 100%; margin: 0; overflow: hidden;">
-		<div id="graphiql" style="height: 100vh;">Loading...</div>
-		<script>
-			function graphQLFetcher(graphQLParams) {
-				return fetch("/query", {
-					method: "post",
-					body: JSON.stringify(graphQLParams),
-					credentials: "include",
-				}).then(function (response) {
-					return response.text();
-				}).then(function (responseBody) {
-					try {
-						return JSON.parse(responseBody);
-					} catch (error) {
-						return responseBody;
-					}
-				});
-			}
-
-			ReactDOM.render(
-				React.createElement(GraphiQL, {fetcher: graphQLFetcher}),
-				document.getElementById("graphiql")
-			);
-		</script>
-	</body>
-</html>
-`)

--- a/example/apollo_federation/subgraph_two/server.go
+++ b/example/apollo_federation/subgraph_two/server.go
@@ -1,0 +1,76 @@
+package main
+
+import (
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+	"log"
+	"net/http"
+)
+
+var schema = `
+	schema {
+		query: Query
+	}
+	
+	type Query {
+		hi: String!
+	}
+`
+
+type resolver struct {}
+
+func (r *resolver) Hi() string {
+	return "Hi, world! from subgraph two."
+}
+
+func main() {
+	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers(), graphql.MaxParallelism(20)}
+	schema := graphql.MustParseSchema(schema, &resolver{}, opts...)
+
+	http.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(page)
+	}))
+
+	http.Handle("/query", &relay.Handler{Schema: schema})
+
+	log.Fatal(http.ListenAndServe(":4002", nil))
+}
+
+var page = []byte(`
+<!DOCTYPE html>
+<html>
+	<head>
+		<link href="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.11/graphiql.min.css" rel="stylesheet" />
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/es6-promise/4.1.1/es6-promise.auto.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/react/16.2.0/umd/react.production.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.2.0/umd/react-dom.production.min.js"></script>
+		<script src="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.11/graphiql.min.js"></script>
+	</head>
+	<body style="width: 100%; height: 100%; margin: 0; overflow: hidden;">
+		<div id="graphiql" style="height: 100vh;">Loading...</div>
+		<script>
+			function graphQLFetcher(graphQLParams) {
+				return fetch("/query", {
+					method: "post",
+					body: JSON.stringify(graphQLParams),
+					credentials: "include",
+				}).then(function (response) {
+					return response.text();
+				}).then(function (responseBody) {
+					try {
+						return JSON.parse(responseBody);
+					} catch (error) {
+						return responseBody;
+					}
+				});
+			}
+
+			ReactDOM.render(
+				React.createElement(GraphiQL, {fetcher: graphQLFetcher}),
+				document.getElementById("graphiql")
+			);
+		</script>
+	</body>
+</html>
+`)

--- a/example/apollo_federation/subgraph_two/server.go
+++ b/example/apollo_federation/subgraph_two/server.go
@@ -1,10 +1,11 @@
 package main
 
 import (
-	"github.com/graph-gophers/graphql-go"
-	"github.com/graph-gophers/graphql-go/relay"
 	"log"
 	"net/http"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
 )
 
 var schema = `
@@ -17,60 +18,17 @@ var schema = `
 	}
 `
 
-type resolver struct {}
+type resolver struct{}
 
 func (r *resolver) Hi() string {
-	return "Hi, world! from subgraph two."
+	return "Hi from subgraph two!"
 }
 
 func main() {
 	opts := []graphql.SchemaOpt{graphql.UseFieldResolvers(), graphql.MaxParallelism(20)}
 	schema := graphql.MustParseSchema(schema, &resolver{}, opts...)
 
-	http.Handle("/", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Write(page)
-	}))
-
 	http.Handle("/query", &relay.Handler{Schema: schema})
 
 	log.Fatal(http.ListenAndServe(":4002", nil))
 }
-
-var page = []byte(`
-<!DOCTYPE html>
-<html>
-	<head>
-		<link href="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.11/graphiql.min.css" rel="stylesheet" />
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/es6-promise/4.1.1/es6-promise.auto.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/fetch/2.0.3/fetch.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/react/16.2.0/umd/react.production.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/react-dom/16.2.0/umd/react-dom.production.min.js"></script>
-		<script src="https://cdnjs.cloudflare.com/ajax/libs/graphiql/0.11.11/graphiql.min.js"></script>
-	</head>
-	<body style="width: 100%; height: 100%; margin: 0; overflow: hidden;">
-		<div id="graphiql" style="height: 100vh;">Loading...</div>
-		<script>
-			function graphQLFetcher(graphQLParams) {
-				return fetch("/query", {
-					method: "post",
-					body: JSON.stringify(graphQLParams),
-					credentials: "include",
-				}).then(function (response) {
-					return response.text();
-				}).then(function (responseBody) {
-					try {
-						return JSON.parse(responseBody);
-					} catch (error) {
-						return responseBody;
-					}
-				});
-			}
-
-			ReactDOM.render(
-				React.createElement(GraphiQL, {fetcher: graphQLFetcher}),
-				document.getElementById("graphiql")
-			);
-		</script>
-	</body>
-</html>
-`)

--- a/example/social/introspect.json
+++ b/example/social/introspect.json
@@ -590,6 +590,33 @@
         "possibleTypes": null
       },
       {
+        "description": null,
+        "enumValues": null,
+        "fields": [
+          {
+            "args": [],
+            "deprecationReason": null,
+            "description": null,
+            "isDeprecated": false,
+            "name": "sdl",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "kind": "OBJECT",
+        "name": "_Service",
+        "possibleTypes": null
+      },
+      {
         "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior\nin ways field arguments will not suffice, such as conditionally including or\nskipping a field. Directives provide this by describing additional information\nto the executor.",
         "enumValues": null,
         "fields": [

--- a/example/starwars/introspect.json
+++ b/example/starwars/introspect.json
@@ -1232,6 +1232,33 @@
         "possibleTypes": null
       },
       {
+        "description": null,
+        "enumValues": null,
+        "fields": [
+          {
+            "args": [],
+            "deprecationReason": null,
+            "description": null,
+            "isDeprecated": false,
+            "name": "sdl",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "String",
+                "ofType": null
+              }
+            }
+          }
+        ],
+        "inputFields": null,
+        "interfaces": [],
+        "kind": "OBJECT",
+        "name": "_Service",
+        "possibleTypes": null
+      },
+      {
         "description": "A Directive provides a way to describe alternate runtime execution and type validation behavior in a GraphQL document.\n\nIn some cases, you need to provide options to alter GraphQL's execution behavior\nin ways field arguments will not suffice, such as conditionally including or\nskipping a field. Directives provide this by describing additional information\nto the executor.",
         "enumValues": null,
         "fields": [

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -2144,6 +2144,7 @@ func TestIntrospection(t *testing.T) {
 							{ "name": "SearchResult" },
 							{ "name": "Starship" },
 							{ "name": "String" },
+							{ "name": "_Service" },
 							{ "name": "__Directive" },
 							{ "name": "__DirectiveLocation" },
 							{ "name": "__EnumValue" },
@@ -4323,6 +4324,39 @@ func TestCircularFragmentMaxDepth(t *testing.T) {
 					{Line: 10, Column: 20},
 				},
 			}},
+		},
+	})
+}
+
+func TestQueryService(t *testing.T) {
+	t.Parallel()
+
+	schemaString := `
+	schema {
+		query: Query
+	}
+
+	type Query {
+		hello: String!
+	}`
+
+	gqltesting.RunTests(t, []*gqltesting.Test{
+		{
+			Schema: graphql.MustParseSchema(schemaString, &helloWorldResolver1{}),
+			Query: `
+				{
+					_service{
+						sdl
+					}
+				}
+			`,
+			ExpectedResult: fmt.Sprintf(`
+				{
+					"_service": {
+						"sdl": "\n\tschema {\n\t\tquery: Query\n\t}\n\n\ttype Query {\n\t\thello: String!\n\t}"
+					}
+				}
+			`),
 		},
 	})
 }

--- a/internal/exec/resolvable/meta.go
+++ b/internal/exec/resolvable/meta.go
@@ -12,8 +12,10 @@ type Meta struct {
 	FieldSchema   Field
 	FieldType     Field
 	FieldTypename Field
+	FieldService  Field
 	Schema        *Object
 	Type          *Object
+	Service       *Object
 }
 
 func newMeta(s *types.Schema) *Meta {
@@ -28,6 +30,12 @@ func newMeta(s *types.Schema) *Meta {
 
 	metaType := s.Types["__Type"].(*types.ObjectTypeDefinition)
 	t, err := b.makeObjectExec(metaType.Name, metaType.Fields, nil, false, reflect.TypeOf(&introspection.Type{}))
+	if err != nil {
+		panic(err)
+	}
+
+	metaService := s.Types["_Service"].(*types.ObjectTypeDefinition)
+	sv, err := b.makeObjectExec(metaService.Name, metaService.Fields, nil, false, reflect.TypeOf(&introspection.Service{}))
 	if err != nil {
 		panic(err)
 	}
@@ -60,11 +68,21 @@ func newMeta(s *types.Schema) *Meta {
 		TraceLabel: "GraphQL field: __type",
 	}
 
+	fieldService := Field{
+		FieldDefinition: types.FieldDefinition{
+			Name: "_service",
+			Type: s.Types["_Service"],
+		},
+		TraceLabel: "GraphQL field: _service",
+	}
+
 	return &Meta{
 		FieldSchema:   fieldSchema,
 		FieldTypename: fieldTypename,
 		FieldType:     fieldType,
+		FieldService:  fieldService,
 		Schema:        so,
 		Type:          t,
+		Service:       sv,
 	}
 }

--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -121,6 +121,17 @@ func applySelectionSet(r *Request, s *resolvable.Schema, e *resolvable.Object, s
 					})
 				}
 
+			case "_service":
+				if !r.DisableIntrospection {
+					flattenedSels = append(flattenedSels, &SchemaField{
+						Field:       s.Meta.FieldService,
+						Alias:       field.Alias.Name,
+						Sels:        applySelectionSet(r, s, s.Meta.Service, field.SelectionSet),
+						Async:       true,
+						FixedResult: reflect.ValueOf(introspection.WrapService(r.Schema)),
+					})
+				}
+
 			default:
 				fe := e.Fields[field.Name.Name]
 

--- a/internal/schema/meta.go
+++ b/internal/schema/meta.go
@@ -200,4 +200,8 @@ var metaSrc = `
 		# Indicates this type is a non-null. ` + "`" + `ofType` + "`" + ` is a valid field.
 		NON_NULL
 	}
+
+	type _Service {
+		sdl: String!
+	}
 `

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -161,6 +161,8 @@ func Parse(s *types.Schema, schemaString string, useStringDescriptions bool) err
 		}
 	}
 
+	s.SchemaString = schemaString
+
 	return nil
 }
 

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -327,6 +327,11 @@ func validateSelection(c *opContext, sel types.Selection, t types.NamedType) {
 				},
 				Type: c.schema.Types["__Type"],
 			}
+		case "_service":
+			f = &types.FieldDefinition{
+				Name: "_service",
+				Type: c.schema.Types["_Service"],
+			}
 		default:
 			f = fields(t).Get(fieldName)
 			if f == nil && t != nil {

--- a/introspection/introspection.go
+++ b/introspection/introspection.go
@@ -310,3 +310,16 @@ func (r *Directive) Args() []*InputValue {
 	}
 	return l
 }
+
+type Service struct {
+	schema *types.Schema
+}
+
+// WrapService is only used internally.
+func WrapService(schema *types.Schema) *Service {
+	return &Service{schema}
+}
+
+func (r *Service) SDL() string {
+	return r.schema.SchemaString
+}

--- a/types/schema.go
+++ b/types/schema.go
@@ -35,6 +35,7 @@ type Schema struct {
 	Unions          []*Union
 	Enums           []*EnumTypeDefinition
 	Extensions      []*Extension
+	SchemaString    string
 }
 
 func (s *Schema) Resolve(name string) Type {


### PR DESCRIPTION
Related to this issue #120, to integrate with Apollo Federation we need to fulfill their specification at minimal with fetch service capabilities
`Schema composition at the gateway requires having each service's schema, annotated with its federation configuration. This information is fetched from each service using _service, an enhanced introspection entry point added to the query root of each federated service.`
With these changes, we can use graphql-go as subgraph behind Apollo Federation Gateway even though it's still not fully implements the specification, but at least it's one step closer
 
This already works with simple schema stitching