### PR TITLE
Add graphql.Time example

### DIFF
--- a/example/scalar_time/server.go
+++ b/example/scalar_time/server.go
@@ -1,0 +1,31 @@
+package main
+
+import (
+	"log"
+	"net/http"
+	"time"
+
+	graphql "github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+)
+
+type query struct{}
+
+func (_ *query) CurrentTime() graphql.Time {
+	return graphql.Time{Time: time.Now()}
+}
+
+func main() {
+	s := `
+		scalar Time
+
+		type Query {
+			currentTime: Time!
+		}
+	`
+	schema := graphql.MustParseSchema(s, &query{})
+	http.Handle("/query", &relay.Handler{Schema: schema})
+
+	log.Println("Listen in port :8080")
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}


### PR DESCRIPTION
fix #488
I added an example of `graphql.Time`.