### PR TITLE
Improve type assertion method argument validation (require zero)

### DIFF
--- a/internal/exec/resolvable/resolvable.go
+++ b/internal/exec/resolvable/resolvable.go
@@ -277,7 +277,15 @@ func (b *execBuilder) makeObjectExec(typeName string, fields types.FieldsDefinit
 			if methodIndex == -1 {
 				return nil, fmt.Errorf("%s does not resolve %q: missing method %q to convert to %q", resolverType, typeName, "To"+impl.Name, impl.Name)
 			}
-			if resolverType.Method(methodIndex).Type.NumOut() != 2 {
+			m := resolverType.Method(methodIndex)
+			expectedIn := 0
+			if methodHasReceiver {
+				expectedIn = 1
+			}
+			if m.Type.NumIn() != expectedIn {
+				return nil, fmt.Errorf("%s does not resolve %q: method %q should't have any arguments", resolverType, typeName, "To"+impl.Name)
+			}
+			if m.Type.NumOut() != 2 {
 				return nil, fmt.Errorf("%s does not resolve %q: method %q should return a value and a bool indicating success", resolverType, typeName, "To"+impl.Name)
 			}
 			a := &TypeAssertion{
@@ -324,7 +332,7 @@ func (b *execBuilder) makeFieldExec(typeName string, f *types.FieldDefinition, m
 
 		if len(f.Arguments) > 0 {
 			if len(in) == 0 {
-				return nil, fmt.Errorf("must have parameter for field arguments")
+				return nil, fmt.Errorf("must have `args struct { ... }` argument for field arguments")
 			}
 			var err error
 			argsPacker, err = b.packerBuilder.MakeStructPacker(f.Arguments, in[0])
@@ -335,7 +343,7 @@ func (b *execBuilder) makeFieldExec(typeName string, f *types.FieldDefinition, m
 		}
 
 		if len(in) > 0 {
-			return nil, fmt.Errorf("too many parameters")
+			return nil, fmt.Errorf("too many arguments")
 		}
 
 		maxNumOfReturns := 2


### PR DESCRIPTION
It's tempting to include a context argument (or think it's allowed), but not discover that this will fail until a query is executed. Validating the resolver during schema parsing reduces the chance of inadvertent errors here.

We've run into this several times and even considered opening a PR to support passing `context.Context` into type assertion methods before realizing that it's better to handle loading and errors in the parent resolver instead. This validation should help avoid this confusion for others.
