### PR TITLE
Optional support for querying fields yet unknown in the schema.

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -109,6 +109,14 @@ func UseFieldResolvers() SchemaOpt {
 	}
 }
 
+// AllowUnknownFields specifies whether a query containing unknown fields
+// is permitted or not.
+func AllowUnknownFields() SchemaOpt {
+	return func(s *Schema) {
+		s.schema.AllowUnknownFields = true
+	}
+}
+
 // MaxDepth specifies the maximum field nesting depth in a query. The default is 0 which disables max depth checking.
 func MaxDepth(n int) SchemaOpt {
 	return func(s *Schema) {

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -335,6 +335,9 @@ func validateSelection(c *opContext, sel types.Selection, t types.NamedType) {
 		default:
 			f = fields(t).Get(fieldName)
 			if f == nil && t != nil {
+				if c.schema.AllowUnknownFields {
+					return
+				}
 				suggestion := makeSuggestion("Did you mean", fields(t).Names(), fieldName)
 				c.addErr(sel.Alias.Loc, "FieldsOnCorrectType", "Cannot query field %q on type %q.%s", fieldName, t, suggestion)
 			}

--- a/types/schema.go
+++ b/types/schema.go
@@ -30,6 +30,8 @@ type Schema struct {
 
 	UseFieldResolvers bool
 
+	AllowUnknownFields bool
+
 	EntryPointNames map[string]string
 	Objects         []*ObjectTypeDefinition
 	Unions          []*Union


### PR DESCRIPTION
Background: Most GraphQL servers assume that the server just needs to be
backwards-compatible, not forwards-compatible. There are scenarios, however, where
a server might be on an older software version, and therefore schema, than a client.
A distributed microservices landscape, for instance, could give rise to such a
scenario.

Now you might have a client (microservice C) querying a server (microservice S)
for a field that S does not yet know about. For instance because C was deployed
before S, or S had to be reverted to a previous version due to a bug. In such a
a case you'd want S to degrade gracefully when a query for a field comes in that
it doesn't know about. Presumably that field was added to the schema in a future
version that C has but S doesn't.

This patch adds support for just this scenario and this behavior. If
AllowUnknownFields is enabled, graphql-go will still resolve the query as best
as it can, fill in 'null' for the unknown field(s), and produce a corresponding
entry in the errors list, rather than failing the entire query altogether.