### PR TITLE
fix minor unreachable code caused by t.Fatalf

### DIFF
--- a/gqltesting/testing.go
+++ b/gqltesting/testing.go
@@ -51,8 +51,7 @@ func RunTest(t *testing.T, test *Test) {
 
 	if test.ExpectedResult == "" {
 		if result.Data != nil {
-			t.Fatalf("got: %s", result.Data)
-			t.Fatalf("want: null")
+			t.Fatalf("got: %s, want: null", result.Data)
 		}
 		return
 	}


### PR DESCRIPTION
https://pkg.go.dev/testing#T.Fatalf
> Fatalf is equivalent to Logf followed by FailNow.

https://pkg.go.dev/testing#T.FailNow
> FailNow marks the function as having failed and stops its execution by calling runtime.Goexit (which then runs all deferred calls in the current goroutine). 


see https://go.dev/play/p/LkLbybLy_oi for example
```go
package main

import (
	"testing"
)

func TestLastIndex(t *testing.T) {
	t.Fatalf("this line will print and exit")
	t.Fatalf("this line cant print")
}

/* output:
=== RUN   TestLastIndex
    prog.go:8: this line will print and exit
--- FAIL: TestLastIndex (0.00s)
FAIL

Program exited.
*/
```
