### PR TITLE
Fix __type queries sometimes not returning data

### DIFF
--- a/graphql_test.go
+++ b/graphql_test.go
@@ -1544,6 +1544,24 @@ func (r *testBadEnumCharacterResolver) AppearsIn() []string {
 	return []string{"STAR_TREK"}
 }
 
+func TestUnknownType(t *testing.T) {
+	gqltesting.RunTest(t, &gqltesting.Test{
+		Schema: starwarsSchema,
+		Query: `
+			query TypeInfo {
+				__type(name: "unknown-type") {
+					name
+				}
+			}
+		`,
+		ExpectedResult: `
+			{
+				"__type": null
+			}
+		`,
+	})
+}
+
 func TestEnums(t *testing.T) {
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		// Valid input enum supplied in query text

--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -107,7 +107,9 @@ func applySelectionSet(r *Request, s *resolvable.Schema, e *resolvable.Object, s
 						return nil
 					}
 
+					var resolvedType *introspection.Type
 					t, ok := r.Schema.Types[v.String()]
+
 					var resolvedType *introspection.Type
 					if ok {
 						resolvedType = introspection.WrapType(t)

--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -109,8 +109,6 @@ func applySelectionSet(r *Request, s *resolvable.Schema, e *resolvable.Object, s
 
 					var resolvedType *introspection.Type
 					t, ok := r.Schema.Types[v.String()]
-
-					var resolvedType *introspection.Type
 					if ok {
 						resolvedType = introspection.WrapType(t)
 					}

--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -108,8 +108,9 @@ func applySelectionSet(r *Request, s *resolvable.Schema, e *resolvable.Object, s
 					}
 
 					t, ok := r.Schema.Types[v.String()]
-					if !ok {
-						return nil
+					var resolvedType *introspection.Type
+					if ok {
+						resolvedType = introspection.WrapType(t)
 					}
 
 					flattenedSels = append(flattenedSels, &SchemaField{
@@ -117,7 +118,7 @@ func applySelectionSet(r *Request, s *resolvable.Schema, e *resolvable.Object, s
 						Alias:       field.Alias.Name,
 						Sels:        applySelectionSet(r, s, s.Meta.Type, field.SelectionSet),
 						Async:       true,
-						FixedResult: reflect.ValueOf(introspection.WrapType(t)),
+						FixedResult: reflect.ValueOf(resolvedType),
 					})
 				}
 


### PR DESCRIPTION
If the queried type was not defined it would return an empty data section instead of `__type: null`

Fixes #539