### PR TITLE
Allow deprecated directive on arguments

### DIFF
--- a/example/social/introspect.json
+++ b/example/social/introspect.json
@@ -17,7 +17,8 @@
         "description": "Marks an element of a GraphQL schema as no longer supported.",
         "locations": [
           "FIELD_DEFINITION",
-          "ENUM_VALUE"
+          "ENUM_VALUE",
+          "ARGUMENT_DEFINITION"
         ],
         "name": "deprecated"
       },

--- a/example/starwars/introspect.json
+++ b/example/starwars/introspect.json
@@ -17,7 +17,8 @@
         "description": "Marks an element of a GraphQL schema as no longer supported.",
         "locations": [
           "FIELD_DEFINITION",
-          "ENUM_VALUE"
+          "ENUM_VALUE",
+          "ARGUMENT_DEFINITION"
         ],
         "name": "deprecated"
       },

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -1701,6 +1701,23 @@ func TestEnums(t *testing.T) {
 	})
 }
 
+type testDeprecatedArgsResolver struct{}
+
+func (r *testDeprecatedArgsResolver) A(args struct{ B *string }) int32 {
+	return 0
+}
+
+func TestDeprecatedArgs(t *testing.T) {
+	graphql.MustParseSchema(`
+		schema {
+			query: Query
+		}
+		type Query {
+			a(b: String @deprecated): Int!
+		}
+	`, &testDeprecatedArgsResolver{})
+}
+
 func TestInlineFragments(t *testing.T) {
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
@@ -2474,7 +2491,8 @@ func TestIntrospection(t *testing.T) {
 									"description": "Marks an element of a GraphQL schema as no longer supported.",
 									"locations": [
 										"FIELD_DEFINITION",
-										"ENUM_VALUE"
+										"ENUM_VALUE",
+										"ARGUMENT_DEFINITION"
 									],
 									"args": [
 										{

--- a/internal/common/values.go
+++ b/internal/common/values.go
@@ -27,9 +27,11 @@ func ParseArgumentList(l *Lexer) types.ArgumentList {
 		name := l.ConsumeIdentWithLoc()
 		l.ConsumeToken(':')
 		value := ParseLiteral(l, false)
+		directives := ParseDirectives(l)
 		args = append(args, &types.Argument{
-			Name:  name,
-			Value: value,
+			Name:       name,
+			Value:      value,
+			Directives: directives,
 		})
 	}
 	l.ConsumeToken(')')

--- a/internal/schema/meta.go
+++ b/internal/schema/meta.go
@@ -57,7 +57,7 @@ var metaSrc = `
 		# for how to access supported similar data. Formatted in
 		# [Markdown](https://daringfireball.net/projects/markdown/).
 		reason: String = "No longer supported"
-	) on FIELD_DEFINITION | ENUM_VALUE
+	) on FIELD_DEFINITION | ENUM_VALUE | ARGUMENT_DEFINITION
 
 	# Provides a scalar specification URL for specifying the behavior of custom scalar types.
 	directive @specifiedBy(

--- a/types/argument.go
+++ b/types/argument.go
@@ -4,8 +4,9 @@ package types
 //
 // https://spec.graphql.org/draft/#sec-Language.Arguments
 type Argument struct {
-	Name  Ident
-	Value Value
+	Name       Ident
+	Value      Value
+	Directives DirectiveList
 }
 
 // ArgumentList is a collection of GraphQL Arguments.


### PR DESCRIPTION
This PR allows `@deprecated` directive on field args in order to keep this library in sync with the GraphQL spec.

Resolves #204 