### PR TITLE
Rename EntryPoints to RootOperationTypes

### DIFF
--- a/graphql.go
+++ b/graphql.go
@@ -232,7 +232,7 @@ func (s *Schema) exec(ctx context.Context, queryString string, operationName str
 		return &Response{Errors: []*errors.QueryError{{Message: "graphql-ws protocol header is missing"}}}
 	}
 	if op.Type == query.Mutation {
-		if _, ok := s.schema.EntryPoints["mutation"]; !ok {
+		if _, ok := s.schema.RootOperationTypes["mutation"]; !ok {
 			return &Response{Errors: []*errors.QueryError{{Message: "no mutations are offered by the schema"}}}
 		}
 	}
@@ -305,7 +305,7 @@ func (t *validationBridgingTracer) TraceValidation(context.Context) func([]*erro
 }
 
 func validateRootOp(s *types.Schema, name string, mandatory bool) error {
-	t, ok := s.EntryPoints[name]
+	t, ok := s.RootOperationTypes[name]
 	if !ok {
 		if mandatory {
 			return fmt.Errorf("root operation %q must be defined", name)

--- a/internal/exec/resolvable/resolvable.go
+++ b/internal/exec/resolvable/resolvable.go
@@ -70,19 +70,19 @@ func ApplyResolver(s *types.Schema, resolver interface{}) (*Schema, error) {
 
 	var query, mutation, subscription Resolvable
 
-	if t, ok := s.EntryPoints["query"]; ok {
+	if t, ok := s.RootOperationTypes["query"]; ok {
 		if err := b.assignExec(&query, t, reflect.TypeOf(resolver)); err != nil {
 			return nil, err
 		}
 	}
 
-	if t, ok := s.EntryPoints["mutation"]; ok {
+	if t, ok := s.RootOperationTypes["mutation"]; ok {
 		if err := b.assignExec(&mutation, t, reflect.TypeOf(resolver)); err != nil {
 			return nil, err
 		}
 	}
 
-	if t, ok := s.EntryPoints["subscription"]; ok {
+	if t, ok := s.RootOperationTypes["subscription"]; ok {
 		if err := b.assignExec(&subscription, t, reflect.TypeOf(resolver)); err != nil {
 			return nil, err
 		}
@@ -377,7 +377,7 @@ func (b *execBuilder) makeFieldExec(typeName string, f *types.FieldDefinition, m
 	var out reflect.Type
 	if methodIndex != -1 {
 		out = m.Type.Out(0)
-		sub, ok := b.schema.EntryPoints["subscription"]
+		sub, ok := b.schema.RootOperationTypes["subscription"]
 		if ok && typeName == sub.TypeName() && out.Kind() == reflect.Chan {
 			out = m.Type.Out(0).Elem()
 		}

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -67,13 +67,13 @@ func Parse(s *types.Schema, schemaString string, useStringDescriptions bool) err
 			s.EntryPointNames["subscription"] = "Subscription"
 		}
 	}
-	s.EntryPoints = make(map[string]types.NamedType)
+	s.RootOperationTypes = make(map[string]types.NamedType)
 	for key, name := range s.EntryPointNames {
 		t, ok := s.Types[name]
 		if !ok {
 			return errors.Errorf("type %q not found", name)
 		}
-		s.EntryPoints[key] = t
+		s.RootOperationTypes[key] = t
 	}
 
 	// Interface types need validation: https://spec.graphql.org/draft/#sec-Interfaces.Interfaces-Implementing-Interfaces

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -117,11 +117,11 @@ func Validate(s *types.Schema, doc *types.ExecutableDefinition, variables map[st
 		var entryPoint types.NamedType
 		switch op.Type {
 		case query.Query:
-			entryPoint = s.EntryPoints["query"]
+			entryPoint = s.RootOperationTypes["query"]
 		case query.Mutation:
-			entryPoint = s.EntryPoints["mutation"]
+			entryPoint = s.RootOperationTypes["mutation"]
 		case query.Subscription:
-			entryPoint = s.EntryPoints["subscription"]
+			entryPoint = s.RootOperationTypes["subscription"]
 		default:
 			panic("unreachable")
 		}

--- a/introspection/introspection.go
+++ b/introspection/introspection.go
@@ -44,7 +44,7 @@ func (r *Schema) Directives() []*Directive {
 }
 
 func (r *Schema) QueryType() *Type {
-	t, ok := r.schema.EntryPoints["query"]
+	t, ok := r.schema.RootOperationTypes["query"]
 	if !ok {
 		return nil
 	}
@@ -52,7 +52,7 @@ func (r *Schema) QueryType() *Type {
 }
 
 func (r *Schema) MutationType() *Type {
-	t, ok := r.schema.EntryPoints["mutation"]
+	t, ok := r.schema.RootOperationTypes["mutation"]
 	if !ok {
 		return nil
 	}
@@ -60,7 +60,7 @@ func (r *Schema) MutationType() *Type {
 }
 
 func (r *Schema) SubscriptionType() *Type {
-	t, ok := r.schema.EntryPoints["subscription"]
+	t, ok := r.schema.RootOperationTypes["subscription"]
 	if !ok {
 		return nil
 	}

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -23,7 +23,7 @@ func (s *Schema) Subscribe(ctx context.Context, queryString string, operationNam
 	if !s.res.Resolver.IsValid() {
 		return nil, errors.New("schema created without resolver, can not subscribe")
 	}
-	if _, ok := s.schema.EntryPoints["subscription"]; !ok {
+	if _, ok := s.schema.RootOperationTypes["subscription"]; !ok {
 		return nil, errors.New("no subscriptions are offered by the schema")
 	}
 	return s.subscribe(ctx, queryString, operationName, variables, s.res), nil

--- a/types/schema.go
+++ b/types/schema.go
@@ -8,12 +8,12 @@ package types
 //
 // http://spec.graphql.org/draft/#sec-Schema
 type Schema struct {
-	// EntryPoints determines the place in the type system where `query`, `mutation`, and
+	// RootOperationTypes determines the place in the type system where `query`, `mutation`, and
 	// `subscription` operations begin.
 	//
 	// http://spec.graphql.org/draft/#sec-Root-Operation-Types
 	//
-	EntryPoints map[string]NamedType
+	RootOperationTypes map[string]NamedType
 
 	// Types are the fundamental unit of any GraphQL schema.
 	// There are six kinds of named types, and two wrapping types.


### PR DESCRIPTION
Rename entryPoints to RootOperationTypes to align with specification terminology.
see: https://spec.graphql.org/June2018/#sec-Root-Operation-Types