### PR TITLE
Fix incorrect validation of zero float value

### DIFF
--- a/internal/validation/testdata/tests.json
+++ b/internal/validation/testdata/tests.json
@@ -1526,6 +1526,13 @@
       ]
     },
     {
+      "name": "Validate: Default Float variable set to zero",
+      "rule": "DefaultValuesOfCorrectType",
+      "schema": 0,
+      "query": "\n      query Foo($a: Float = 0.0) {\n       field(a: $a)\n     }\n     ",
+      "errors": []
+    },
+    {
       "name": "Validate: No invalid default Float variable values/value out of range",
       "rule": "DefaultValuesOfCorrectType",
       "schema": 0,

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -895,7 +895,7 @@ func validateBuiltInScalar(v string, n string) bool {
 		return f >= math.MinInt32 && f <= math.MaxInt32
 	case "Float":
 		f, fe := strconv.ParseFloat(v, 64)
-		return fe == nil && f >= math.SmallestNonzeroFloat64 && f <= math.MaxFloat64
+		return fe == nil && f <= math.MaxFloat64
 	case "String":
 		vl := len(v)
 		return vl >= 2 && v[0] == '"' && v[vl-1] == '"'


### PR DESCRIPTION
Float value of 0.0 is valid. Removed the incorrect
if condition. Added a test.

Fixes https://github.com/graph-gophers/graphql-go/issues/546
