### PR TITLE
Separate resolvers for each operation

### DIFF
--- a/example/starwars/starwars.go
+++ b/example/starwars/starwars.go
@@ -286,14 +286,20 @@ var reviews = make(map[string][]*review)
 
 type Resolver struct{}
 
-func (r *Resolver) Hero(args struct{ Episode string }) *characterResolver {
+func (*Resolver) Query() *QueryResolver {
+	return &QueryResolver{}
+}
+
+type QueryResolver struct{}
+
+func (r *QueryResolver) Hero(args struct{ Episode string }) *characterResolver {
 	if args.Episode == "EMPIRE" {
 		return &characterResolver{&humanResolver{humanData["1000"]}}
 	}
 	return &characterResolver{&droidResolver{droidData["2001"]}}
 }
 
-func (r *Resolver) Reviews(args struct{ Episode string }) []*reviewResolver {
+func (r *QueryResolver) Reviews(args struct{ Episode string }) []*reviewResolver {
 	var l []*reviewResolver
 	for _, review := range reviews[args.Episode] {
 		l = append(l, &reviewResolver{review})
@@ -301,7 +307,7 @@ func (r *Resolver) Reviews(args struct{ Episode string }) []*reviewResolver {
 	return l
 }
 
-func (r *Resolver) Search(args struct{ Text string }) []*searchResultResolver {
+func (r *QueryResolver) Search(args struct{ Text string }) []*searchResultResolver {
 	var l []*searchResultResolver
 	for _, h := range humans {
 		if strings.Contains(h.Name, args.Text) {
@@ -321,7 +327,7 @@ func (r *Resolver) Search(args struct{ Text string }) []*searchResultResolver {
 	return l
 }
 
-func (r *Resolver) Character(args struct{ ID graphql.ID }) *characterResolver {
+func (r *QueryResolver) Character(args struct{ ID graphql.ID }) *characterResolver {
 	if h := humanData[args.ID]; h != nil {
 		return &characterResolver{&humanResolver{h}}
 	}
@@ -331,28 +337,34 @@ func (r *Resolver) Character(args struct{ ID graphql.ID }) *characterResolver {
 	return nil
 }
 
-func (r *Resolver) Human(args struct{ ID graphql.ID }) *humanResolver {
+func (r *QueryResolver) Human(args struct{ ID graphql.ID }) *humanResolver {
 	if h := humanData[args.ID]; h != nil {
 		return &humanResolver{h}
 	}
 	return nil
 }
 
-func (r *Resolver) Droid(args struct{ ID graphql.ID }) *droidResolver {
+func (r *QueryResolver) Droid(args struct{ ID graphql.ID }) *droidResolver {
 	if d := droidData[args.ID]; d != nil {
 		return &droidResolver{d}
 	}
 	return nil
 }
 
-func (r *Resolver) Starship(args struct{ ID graphql.ID }) *starshipResolver {
+func (r *QueryResolver) Starship(args struct{ ID graphql.ID }) *starshipResolver {
 	if s := starshipData[args.ID]; s != nil {
 		return &starshipResolver{s}
 	}
 	return nil
 }
 
-func (r *Resolver) CreateReview(args *struct {
+func (*Resolver) Mutation() *MutationResolver {
+	return &MutationResolver{}
+}
+
+type MutationResolver struct{}
+
+func (r *MutationResolver) CreateReview(args *struct {
 	Episode string
 	Review  *reviewInput
 }) *reviewResolver {

--- a/graphql.go
+++ b/graphql.go
@@ -221,7 +221,7 @@ func (s *Schema) ValidateWithVariables(queryString string, variables map[string]
 // without a resolver. If the context get cancelled, no further resolvers will be called and a
 // the context error will be returned as soon as possible (not immediately).
 func (s *Schema) Exec(ctx context.Context, queryString string, operationName string, variables map[string]interface{}) *Response {
-	if !s.res.Resolver.IsValid() {
+	if !s.res.QueryResolver.IsValid() {
 		panic("schema created without resolver, can not exec")
 	}
 	return s.exec(ctx, queryString, operationName, variables, s.res)

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -45,7 +45,18 @@ func (r *Request) Execute(ctx context.Context, s *resolvable.Schema, op *types.O
 	func() {
 		defer r.handlePanic(ctx)
 		sels := selected.ApplyOperation(&r.Request, s, op)
-		r.execSelections(ctx, sels, nil, s, s.Resolver, &out, op.Type == query.Mutation)
+		var resolver reflect.Value
+		switch op.Type {
+		case query.Query:
+			resolver = s.QueryResolver
+		case query.Mutation:
+			resolver = s.MutationResolver
+		case query.Subscription:
+			resolver = s.SubscriptionResolver
+		default:
+			panic("unknown query operation")
+		}
+		r.execSelections(ctx, sels, nil, s, resolver, &out, op.Type == query.Mutation)
 	}()
 
 	if err := ctx.Err(); err != nil {

--- a/internal/exec/subscribe.go
+++ b/internal/exec/subscribe.go
@@ -28,7 +28,7 @@ func (r *Request) Subscribe(ctx context.Context, s *resolvable.Schema, op *types
 
 		sels := selected.ApplyOperation(&r.Request, s, op)
 		var fields []*fieldToExec
-		collectFieldsToResolve(sels, s, s.Resolver, &fields, make(map[string]*fieldToExec))
+		collectFieldsToResolve(sels, s, s.SubscriptionResolver, &fields, make(map[string]*fieldToExec))
 
 		// TODO: move this check into validation.Validate
 		if len(fields) != 1 {

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -20,7 +20,7 @@ import (
 // further resolvers will be called. The context error will be returned as soon
 // as possible (not immediately).
 func (s *Schema) Subscribe(ctx context.Context, queryString string, operationName string, variables map[string]interface{}) (<-chan interface{}, error) {
-	if !s.res.Resolver.IsValid() {
+	if !s.res.SubscriptionResolver.IsValid() {
 		return nil, errors.New("schema created without resolver, can not subscribe")
 	}
 	if _, ok := s.schema.RootOperationTypes["subscription"]; !ok {


### PR DESCRIPTION
This PR allows having fields in the schema with the same name in different operations. For example, consider the schema below:
```graphql
schema {
	query: Query
	mutation: Mutation
	subscription: Subscription
}

type Query {
	hello: String!
}

type Mutation {
	hello: String!
}

type Subscription {
	hello: HelloEvent!
}

type HelloEvent {
	msg: String!
}
```
Before this PR it was not possible to have more than one operation with the same field name. This PR resolves the problem in a backwards compatible way.
Continuation from #182 
Fixes #145
Fixes #562 