### PR TITLE
Refactor field resolution closer to schema types

### DIFF
--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -1,11 +1,11 @@
 package selected
 
 import (
+	"context"
 	"fmt"
 	"reflect"
 	"sync"
 
-	"github.com/graph-gophers/graphql-go/directives"
 	"github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/internal/exec/packer"
 	"github.com/graph-gophers/graphql-go/internal/exec/resolvable"
@@ -48,13 +48,22 @@ type Selection interface {
 
 type SchemaField struct {
 	resolvable.Field
-	Alias            string
-	Args             map[string]interface{}
-	PackedArgs       reflect.Value
-	PackedDirectives []directives.ResolverInterceptor
-	Sels             []Selection
-	Async            bool
-	FixedResult      reflect.Value
+	Alias       string
+	Args        map[string]interface{}
+	PackedArgs  reflect.Value
+	Sels        []Selection
+	Async       bool
+	FixedResult reflect.Value
+}
+
+func (f *SchemaField) Resolve(ctx context.Context, resolver reflect.Value) (output interface{}, err error) {
+	var args interface{}
+
+	if f.ArgsPacker != nil {
+		args = f.PackedArgs.Interface()
+	}
+
+	return f.Field.Resolve(ctx, resolver, args)
 }
 
 type TypeAssertion struct {
@@ -153,21 +162,14 @@ func applySelectionSet(r *Request, s *resolvable.Schema, e *resolvable.Object, s
 					}
 				}
 
-				packedDirectives, err := packDirectives(fe, r.Vars)
-				if err != nil {
-					r.AddError(errors.Errorf("%s", err))
-					return
-				}
-
 				fieldSels := applyField(r, s, fe.ValueExec, field.SelectionSet)
 				flattenedSels = append(flattenedSels, &SchemaField{
-					Field:            *fe,
-					Alias:            field.Alias.Name,
-					Args:             args,
-					PackedArgs:       packedArgs,
-					PackedDirectives: packedDirectives,
-					Sels:             fieldSels,
-					Async:            fe.HasContext || fe.ArgsPacker != nil || fe.HasError || HasAsyncSel(fieldSels),
+					Field:      *fe,
+					Alias:      field.Alias.Name,
+					Args:       args,
+					PackedArgs: packedArgs,
+					Sels:       fieldSels,
+					Async:      fe.HasContext || fe.ArgsPacker != nil || fe.HasError || HasAsyncSel(fieldSels),
 				})
 			}
 
@@ -190,32 +192,6 @@ func applySelectionSet(r *Request, s *resolvable.Schema, e *resolvable.Object, s
 		}
 	}
 	return
-}
-
-func packDirectives(fe *resolvable.Field, vars map[string]interface{}) ([]directives.ResolverInterceptor, error) {
-	packed := make([]directives.ResolverInterceptor, 0, len(fe.Directives))
-	for _, d := range fe.Directives {
-		dp, ok := fe.DirectivesPackers[d.Name.Name]
-		if !ok {
-			continue // skip directives without packers
-		}
-
-		args := make(map[string]interface{})
-		for _, arg := range d.Arguments {
-			args[arg.Name.Name] = arg.Value.Deserialize(vars)
-		}
-
-		p, err := dp.Pack(args)
-		if err != nil {
-			return nil, err
-		}
-
-		v := p.Interface().(directives.ResolverInterceptor)
-
-		packed = append(packed, v)
-	}
-
-	return packed, nil
 }
 
 func applyFragment(r *Request, s *resolvable.Schema, e *resolvable.Object, frag *types.Fragment) []Selection {

--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -169,7 +169,7 @@ func applySelectionSet(r *Request, s *resolvable.Schema, e *resolvable.Object, s
 					Args:       args,
 					PackedArgs: packedArgs,
 					Sels:       fieldSels,
-					Async:      fe.HasContext || fe.ArgsPacker != nil || fe.HasError || HasAsyncSel(fieldSels),
+					Async:      fe.HasContext || fe.ArgsPacker != nil || len(fe.DirectiveVisitors) > 0 || fe.HasError || HasAsyncSel(fieldSels),
 				})
 			}
 


### PR DESCRIPTION
Much of the work of executing resolvers relates to the resolvable portion of fields, rather than the selection made for the request. With the introduction of directive visitors, these were being recreated for each request, instead of being built once, and re-used.

By pushing the resolution of fields down into the `resolvable.Field`, directives applied to the field definition can be setup just once when the schema is created, and re-used across all requests. Small exceptions to this exist for field types that embed this to provide request specific values (resolver instance and arguments), which get passed along with the call.

The chain of directive visitor functions still needs to be recreated for each resolve call, because the inner resolve function needs to accept the request specific field resolver instance, but other per-request overheads should be removed.