### PR TITLE
Add Validating Directives

### DIFF
--- a/directives/visitor.go
+++ b/directives/visitor.go
@@ -23,3 +23,8 @@ type Resolver interface {
 type ResolverInterceptor interface {
 	Resolve(ctx context.Context, args interface{}, next Resolver) (output interface{}, err error)
 }
+
+// Validator directive which executes before anything is resolved, allowing the request to be rejected.
+type Validator interface {
+	Validate(ctx context.Context, args interface{}) error
+}

--- a/example/directives/authorization/README.md
+++ b/example/directives/authorization/README.md
@@ -80,16 +80,16 @@ $ curl 'http://localhost:8080/query' \
        return "hasRole"
    }
 
-    func (h *HasRoleDirective) Resolve(ctx context.Context, args interface{}, next directives.Resolver) (output interface{}, err error) {
+    func (h *HasRoleDirective) Validate(ctx context.Context, _ interface{}) error {
         u, ok := user.FromContext(ctx)
         if !ok {
-            return nil, fmt.Errorf("user not provided in context")
+            return fmt.Errorf("user not provided in context")
         }
         role := strings.ToLower(h.Role)
         if !u.HasRole(role) {
-            return nil, fmt.Errorf("access denied, %q role required", role)
+            return fmt.Errorf("access denied, %q role required", role)
         }
-        return next.Resolve(ctx, args)
+        return nil
     }
     ```
 

--- a/example/directives/authorization/authorization.go
+++ b/example/directives/authorization/authorization.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/graph-gophers/graphql-go/directives"
 	"github.com/graph-gophers/graphql-go/example/directives/authorization/user"
 )
 
@@ -36,17 +35,17 @@ func (h *HasRoleDirective) ImplementsDirective() string {
 	return "hasRole"
 }
 
-func (h *HasRoleDirective) Resolve(ctx context.Context, args interface{}, next directives.Resolver) (output interface{}, err error) {
+func (h *HasRoleDirective) Validate(ctx context.Context, _ interface{}) error {
 	u, ok := user.FromContext(ctx)
 	if !ok {
-		return nil, fmt.Errorf("user not provided in cotext")
+		return fmt.Errorf("user not provided in cotext")
 	}
 	role := strings.ToLower(h.Role)
 	if !u.HasRole(role) {
-		return nil, fmt.Errorf("access denied, %q role required", role)
+		return fmt.Errorf("access denied, %q role required", role)
 	}
 
-	return next.Resolve(ctx, args)
+	return nil
 }
 
 type Resolver struct{}

--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -54,6 +54,13 @@ func (r *Request) Execute(ctx context.Context, s *resolvable.Schema, op *ast.Ope
 		default:
 			panic("unknown query operation")
 		}
+
+		if errs := validateSelections(ctx, sels, nil, s); errs != nil {
+			r.Errs = errs
+			out.Write([]byte("null"))
+			return
+		}
+
 		r.execSelections(ctx, sels, nil, s, resolver, &out, op.Type == query.Mutation)
 	}()
 
@@ -62,6 +69,11 @@ func (r *Request) Execute(ctx context.Context, s *resolvable.Schema, op *ast.Ope
 	}
 
 	return out.Bytes(), r.Errs
+}
+
+type fieldToValidate struct {
+	field *selected.SchemaField
+	sels  []selected.Selection
 }
 
 type fieldToExec struct {

--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -169,7 +169,7 @@ func applySelectionSet(r *Request, s *resolvable.Schema, e *resolvable.Object, s
 					Args:       args,
 					PackedArgs: packedArgs,
 					Sels:       fieldSels,
-					Async:      fe.HasContext || fe.ArgsPacker != nil || len(fe.DirectiveVisitors) > 0 || fe.HasError || HasAsyncSel(fieldSels),
+					Async:      fe.HasContext || fe.ArgsPacker != nil || len(fe.Visitors.Interceptors) > 0 || fe.HasError || HasAsyncSel(fieldSels),
 				})
 			}
 

--- a/internal/exec/validate.go
+++ b/internal/exec/validate.go
@@ -1,0 +1,105 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/graph-gophers/graphql-go/ast"
+	"github.com/graph-gophers/graphql-go/errors"
+	"github.com/graph-gophers/graphql-go/internal/exec/resolvable"
+	"github.com/graph-gophers/graphql-go/internal/exec/selected"
+)
+
+func collectFieldsToValidate(sels []selected.Selection, s *resolvable.Schema, fields *[]*fieldToValidate, fieldByAlias map[string]*fieldToValidate) {
+	for _, sel := range sels {
+		switch sel := sel.(type) {
+		case *selected.SchemaField:
+			field, ok := fieldByAlias[sel.Alias]
+			if !ok { // validation already checked for conflict (TODO)
+				field = &fieldToValidate{field: sel}
+				fieldByAlias[sel.Alias] = field
+				*fields = append(*fields, field)
+			}
+			field.sels = append(field.sels, sel.Sels...)
+		case *selected.TypenameField:
+			// Ignore __typename, which has no directives
+		case *selected.TypeAssertion:
+			collectFieldsToValidate(sel.Sels, s, fields, fieldByAlias)
+		default:
+			panic(fmt.Sprintf("unexpected selection type %T", sel))
+		}
+	}
+}
+
+func validateFieldSelection(ctx context.Context, s *resolvable.Schema, f *fieldToValidate, path *pathSegment) []*errors.QueryError {
+	if f.field.FixedResult.IsValid() {
+		// Skip fixed result meta fields like __TypeName
+		return nil
+	}
+
+	var args interface{}
+
+	if f.field.ArgsPacker != nil {
+		args = f.field.PackedArgs.Interface()
+	}
+
+	vErrs := f.field.Validate(ctx, args)
+
+	if l := len(vErrs); l > 0 {
+		errs := make([]*errors.QueryError, l)
+
+		for i, err := range vErrs {
+			var ext map[string]interface{}
+			if e, ok := err.(extensionser); ok {
+				ext = e.Extensions()
+			}
+			errs[i] = &errors.QueryError{
+				Err:        err,
+				Message:    err.Error(),
+				Locations:  []errors.Location{f.field.Loc},
+				Path:       path.toSlice(),
+				Extensions: ext,
+			}
+		}
+
+		return errs
+	}
+
+	return validateSelectionSet(ctx, f.sels, f.field.Type, path, s)
+}
+
+func validateSelectionSet(ctx context.Context, sels []selected.Selection, typ ast.Type, path *pathSegment, s *resolvable.Schema) []*errors.QueryError {
+	t, _ := unwrapNonNull(typ)
+
+	switch t.(type) {
+	case *ast.ObjectTypeDefinition, *ast.InterfaceTypeDefinition, *ast.Union:
+		return validateSelections(ctx, sels, path, s)
+	}
+
+	switch t := t.(type) {
+	case *ast.List:
+		return validateList(ctx, sels, t, path, s)
+	case *ast.ScalarTypeDefinition, *ast.EnumTypeDefinition:
+		// Field resolution already validated, don't need to check the value
+	default:
+		panic(fmt.Sprintf("unexpected type %T", t))
+	}
+
+	return nil
+}
+
+func validateSelections(ctx context.Context, sels []selected.Selection, path *pathSegment, s *resolvable.Schema) (errs []*errors.QueryError) {
+	var fields []*fieldToValidate
+	collectFieldsToValidate(sels, s, &fields, make(map[string]*fieldToValidate))
+
+	for _, f := range fields {
+		errs = append(errs, validateFieldSelection(ctx, s, f, &pathSegment{path, f.field.Alias})...)
+	}
+
+	return errs
+}
+
+func validateList(ctx context.Context, sels []selected.Selection, typ *ast.List, path *pathSegment, s *resolvable.Schema) []*errors.QueryError {
+	// For lists, we only need to apply validation once. Nothing has been evaluated, so we have no list, and need to use '0' as the path index
+	return validateSelectionSet(ctx, sels, typ.OfType, &pathSegment{path, 0}, s)
+}


### PR DESCRIPTION
Adding support for directives which are evaluated prior to executing any resolvers. This allows validation to be performed on the request and prevent it from executing any significant work by rejecting the request early.

The most obvious case for this is authorization: based on the requested fields, we can tell whether the request is valid given the current user, and reject the entire request. If that were applied at resolution time, the request would have partially resolved, only to return errors for the specific fields which are not authorized.

fixes: #570 