### PR TITLE
Move GraphQL types to package ast

### DIFF
--- a/ast/argument.go
+++ b/ast/argument.go
@@ -1,4 +1,4 @@
-package types
+package ast
 
 // Argument is a representation of the GraphQL Argument.
 //

--- a/ast/directive.go
+++ b/ast/directive.go
@@ -1,4 +1,4 @@
-package types
+package ast
 
 import "github.com/graph-gophers/graphql-go/errors"
 

--- a/ast/doc.go
+++ b/ast/doc.go
@@ -1,0 +1,9 @@
+/*
+Package ast represents all types from the [GraphQL specification] in code.
+
+The names of the Go types, whenever possible, match 1:1 with the names from
+the specification.
+
+[GraphQL specification]: https://spec.graphql.org
+*/
+package ast

--- a/ast/enum.go
+++ b/ast/enum.go
@@ -1,4 +1,4 @@
-package types
+package ast
 
 import "github.com/graph-gophers/graphql-go/errors"
 

--- a/ast/extension.go
+++ b/ast/extension.go
@@ -1,4 +1,4 @@
-package types
+package ast
 
 import "github.com/graph-gophers/graphql-go/errors"
 

--- a/ast/field.go
+++ b/ast/field.go
@@ -1,4 +1,4 @@
-package types
+package ast
 
 import "github.com/graph-gophers/graphql-go/errors"
 

--- a/ast/fragment.go
+++ b/ast/fragment.go
@@ -1,4 +1,4 @@
-package types
+package ast
 
 import "github.com/graph-gophers/graphql-go/errors"
 

--- a/ast/input.go
+++ b/ast/input.go
@@ -1,4 +1,4 @@
-package types
+package ast
 
 import "github.com/graph-gophers/graphql-go/errors"
 

--- a/ast/interface.go
+++ b/ast/interface.go
@@ -1,4 +1,4 @@
-package types
+package ast
 
 import "github.com/graph-gophers/graphql-go/errors"
 

--- a/ast/object.go
+++ b/ast/object.go
@@ -1,4 +1,4 @@
-package types
+package ast
 
 import "github.com/graph-gophers/graphql-go/errors"
 

--- a/ast/query.go
+++ b/ast/query.go
@@ -1,4 +1,4 @@
-package types
+package ast
 
 import "github.com/graph-gophers/graphql-go/errors"
 

--- a/ast/scalar.go
+++ b/ast/scalar.go
@@ -1,4 +1,4 @@
-package types
+package ast
 
 import "github.com/graph-gophers/graphql-go/errors"
 

--- a/ast/schema.go
+++ b/ast/schema.go
@@ -1,0 +1,41 @@
+package ast
+
+// Schema represents a GraphQL service's collective type system capabilities.
+// A schema is defined in terms of the types and directives it supports as well as the root
+// operation types for each kind of operation: `query`, `mutation`, and `subscription`.
+//
+// For a more formal definition, read the relevant section in the specification:
+//
+// http://spec.graphql.org/draft/#sec-Schema
+type Schema struct {
+	// RootOperationTypes determines the place in the type system where `query`, `mutation`, and
+	// `subscription` operations begin.
+	//
+	// http://spec.graphql.org/draft/#sec-Root-Operation-Types
+	//
+	RootOperationTypes map[string]NamedType
+
+	// Types are the fundamental unit of any GraphQL schema.
+	// There are six kinds of named type definitions in GraphQL, and two wrapping types.
+	//
+	// http://spec.graphql.org/draft/#sec-Types
+	Types map[string]NamedType
+
+	// Directives are used to annotate various parts of a GraphQL document as an indicator that they
+	// should be evaluated differently by a validator, executor, or client tool such as a code
+	// generator.
+	//
+	// http://spec.graphql.org/#sec-Type-System.Directives
+	Directives map[string]*DirectiveDefinition
+
+	EntryPointNames map[string]string
+	Objects         []*ObjectTypeDefinition
+	Unions          []*Union
+	Enums           []*EnumTypeDefinition
+	Extensions      []*Extension
+	SchemaString    string
+}
+
+func (s *Schema) Resolve(name string) Type {
+	return s.Types[name]
+}

--- a/ast/types.go
+++ b/ast/types.go
@@ -1,4 +1,4 @@
-package types
+package ast
 
 import (
 	"github.com/graph-gophers/graphql-go/errors"

--- a/ast/union.go
+++ b/ast/union.go
@@ -1,4 +1,4 @@
-package types
+package ast
 
 import "github.com/graph-gophers/graphql-go/errors"
 

--- a/ast/value.go
+++ b/ast/value.go
@@ -1,4 +1,4 @@
-package types
+package ast
 
 import (
 	"strconv"

--- a/ast/variable.go
+++ b/ast/variable.go
@@ -1,4 +1,4 @@
-package types
+package ast
 
 import "github.com/graph-gophers/graphql-go/errors"
 

--- a/examples_test.go
+++ b/examples_test.go
@@ -230,9 +230,9 @@ func ExampleRestrictIntrospection() {
 	// }
 }
 
-func ExampleSchema_ASTSchema() {
+func ExampleSchema_AST() {
 	schema := graphql.MustParseSchema(starwars.Schema, nil)
-	ast := schema.ASTSchema()
+	ast := schema.AST()
 
 	for _, e := range ast.Enums {
 		fmt.Printf("Enum %q has the following options:\n", e.Name)
@@ -250,7 +250,7 @@ func ExampleSchema_ASTSchema() {
 	//   - FOOT
 }
 
-func ExampleSchema_ASTSchema_generateEnum() {
+func ExampleSchema_AST_generateEnum() {
 	s := `
 		schema {
 			query: Query
@@ -309,7 +309,7 @@ func (s Season) String() string {
 		graphql.UseStringDescriptions(),
 	}
 	schema := graphql.MustParseSchema(s, nil, opts...)
-	ast := schema.ASTSchema()
+	ast := schema.AST()
 	seasons := ast.Enums[0]
 
 	err = tpl.Execute(os.Stdout, seasons)
@@ -376,7 +376,7 @@ func ExampleUseStringDescriptions() {
 		graphql.UseStringDescriptions(),
 	}
 	schema := graphql.MustParseSchema(s, nil, opts...)
-	ast := schema.ASTSchema()
+	ast := schema.AST()
 
 	post := ast.Objects[1]
 	fmt.Printf("Field descriptions of the %q type:\n", post.TypeName())

--- a/internal/common/directive.go
+++ b/internal/common/directive.go
@@ -1,12 +1,12 @@
 package common
 
-import "github.com/graph-gophers/graphql-go/types"
+import "github.com/graph-gophers/graphql-go/ast"
 
-func ParseDirectives(l *Lexer) types.DirectiveList {
-	var directives types.DirectiveList
+func ParseDirectives(l *Lexer) ast.DirectiveList {
+	var directives ast.DirectiveList
 	for l.Peek() == '@' {
 		l.ConsumeToken('@')
-		d := &types.Directive{}
+		d := &ast.Directive{}
 		d.Name = l.ConsumeIdentWithLoc()
 		d.Name.Loc.Column--
 		if l.Peek() == '(' {

--- a/internal/common/lexer.go
+++ b/internal/common/lexer.go
@@ -7,8 +7,8 @@ import (
 	"strings"
 	"text/scanner"
 
+	"github.com/graph-gophers/graphql-go/ast"
 	"github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/types"
 )
 
 type syntaxError string
@@ -119,11 +119,11 @@ func (l *Lexer) ConsumeIdent() string {
 	return name
 }
 
-func (l *Lexer) ConsumeIdentWithLoc() types.Ident {
+func (l *Lexer) ConsumeIdentWithLoc() ast.Ident {
 	loc := l.Location()
 	name := l.sc.TokenText()
 	l.ConsumeToken(scanner.Ident)
-	return types.Ident{Name: name, Loc: loc}
+	return ast.Ident{Name: name, Loc: loc}
 }
 
 func (l *Lexer) ConsumeKeyword(keyword string) {
@@ -133,8 +133,8 @@ func (l *Lexer) ConsumeKeyword(keyword string) {
 	l.ConsumeWhitespace()
 }
 
-func (l *Lexer) ConsumeLiteral() *types.PrimitiveValue {
-	lit := &types.PrimitiveValue{Type: l.next, Text: l.sc.TokenText()}
+func (l *Lexer) ConsumeLiteral() *ast.PrimitiveValue {
+	lit := &ast.PrimitiveValue{Type: l.next, Text: l.sc.TokenText()}
 	l.ConsumeWhitespace()
 	return lit
 }

--- a/internal/common/literals.go
+++ b/internal/common/literals.go
@@ -3,10 +3,10 @@ package common
 import (
 	"text/scanner"
 
-	"github.com/graph-gophers/graphql-go/types"
+	"github.com/graph-gophers/graphql-go/ast"
 )
 
-func ParseLiteral(l *Lexer, constOnly bool) types.Value {
+func ParseLiteral(l *Lexer, constOnly bool) ast.Value {
 	loc := l.Location()
 	switch l.Peek() {
 	case '$':
@@ -15,12 +15,12 @@ func ParseLiteral(l *Lexer, constOnly bool) types.Value {
 			panic("unreachable")
 		}
 		l.ConsumeToken('$')
-		return &types.Variable{Name: l.ConsumeIdent(), Loc: loc}
+		return &ast.Variable{Name: l.ConsumeIdent(), Loc: loc}
 
 	case scanner.Int, scanner.Float, scanner.String, scanner.Ident:
 		lit := l.ConsumeLiteral()
 		if lit.Type == scanner.Ident && lit.Text == "null" {
-			return &types.NullValue{Loc: loc}
+			return &ast.NullValue{Loc: loc}
 		}
 		lit.Loc = loc
 		return lit
@@ -32,24 +32,24 @@ func ParseLiteral(l *Lexer, constOnly bool) types.Value {
 		return lit
 	case '[':
 		l.ConsumeToken('[')
-		var list []types.Value
+		var list []ast.Value
 		for l.Peek() != ']' {
 			list = append(list, ParseLiteral(l, constOnly))
 		}
 		l.ConsumeToken(']')
-		return &types.ListValue{Values: list, Loc: loc}
+		return &ast.ListValue{Values: list, Loc: loc}
 
 	case '{':
 		l.ConsumeToken('{')
-		var fields []*types.ObjectField
+		var fields []*ast.ObjectField
 		for l.Peek() != '}' {
 			name := l.ConsumeIdentWithLoc()
 			l.ConsumeToken(':')
 			value := ParseLiteral(l, constOnly)
-			fields = append(fields, &types.ObjectField{Name: name, Value: value})
+			fields = append(fields, &ast.ObjectField{Name: name, Value: value})
 		}
 		l.ConsumeToken('}')
-		return &types.ObjectValue{Fields: fields, Loc: loc}
+		return &ast.ObjectValue{Fields: fields, Loc: loc}
 
 	default:
 		l.SyntaxError("invalid value")

--- a/internal/common/types.go
+++ b/internal/common/types.go
@@ -1,31 +1,31 @@
 package common
 
 import (
+	"github.com/graph-gophers/graphql-go/ast"
 	"github.com/graph-gophers/graphql-go/errors"
-	"github.com/graph-gophers/graphql-go/types"
 )
 
-func ParseType(l *Lexer) types.Type {
+func ParseType(l *Lexer) ast.Type {
 	t := parseNullType(l)
 	if l.Peek() == '!' {
 		l.ConsumeToken('!')
-		return &types.NonNull{OfType: t}
+		return &ast.NonNull{OfType: t}
 	}
 	return t
 }
 
-func parseNullType(l *Lexer) types.Type {
+func parseNullType(l *Lexer) ast.Type {
 	if l.Peek() == '[' {
 		l.ConsumeToken('[')
 		ofType := ParseType(l)
 		l.ConsumeToken(']')
-		return &types.List{OfType: ofType}
+		return &ast.List{OfType: ofType}
 	}
 
-	return &types.TypeName{Ident: l.ConsumeIdentWithLoc()}
+	return &ast.TypeName{Ident: l.ConsumeIdentWithLoc()}
 }
 
-type Resolver func(name string) types.Type
+type Resolver func(name string) ast.Type
 
 // ResolveType attempts to resolve a type's name against a resolving function.
 // This function is used when one needs to check if a TypeName exists in the resolver (typically a Schema).
@@ -38,21 +38,21 @@ type Resolver func(name string) types.Type
 //	}
 //
 // ResolveType recursively unwraps List and NonNull types until a NamedType is reached.
-func ResolveType(t types.Type, resolver Resolver) (types.Type, *errors.QueryError) {
+func ResolveType(t ast.Type, resolver Resolver) (ast.Type, *errors.QueryError) {
 	switch t := t.(type) {
-	case *types.List:
+	case *ast.List:
 		ofType, err := ResolveType(t.OfType, resolver)
 		if err != nil {
 			return nil, err
 		}
-		return &types.List{OfType: ofType}, nil
-	case *types.NonNull:
+		return &ast.List{OfType: ofType}, nil
+	case *ast.NonNull:
 		ofType, err := ResolveType(t.OfType, resolver)
 		if err != nil {
 			return nil, err
 		}
-		return &types.NonNull{OfType: ofType}, nil
-	case *types.TypeName:
+		return &ast.NonNull{OfType: ofType}, nil
+	case *ast.TypeName:
 		refT := resolver(t.Name)
 		if refT == nil {
 			err := errors.Errorf("Unknown type %q.", t.Name)

--- a/internal/common/values.go
+++ b/internal/common/values.go
@@ -1,11 +1,11 @@
 package common
 
 import (
-	"github.com/graph-gophers/graphql-go/types"
+	"github.com/graph-gophers/graphql-go/ast"
 )
 
-func ParseInputValue(l *Lexer) *types.InputValueDefinition {
-	p := &types.InputValueDefinition{}
+func ParseInputValue(l *Lexer) *ast.InputValueDefinition {
+	p := &ast.InputValueDefinition{}
 	p.Loc = l.Location()
 	p.Desc = l.DescComment()
 	p.Name = l.ConsumeIdentWithLoc()
@@ -20,15 +20,15 @@ func ParseInputValue(l *Lexer) *types.InputValueDefinition {
 	return p
 }
 
-func ParseArgumentList(l *Lexer) types.ArgumentList {
-	var args types.ArgumentList
+func ParseArgumentList(l *Lexer) ast.ArgumentList {
+	var args ast.ArgumentList
 	l.ConsumeToken('(')
 	for l.Peek() != ')' {
 		name := l.ConsumeIdentWithLoc()
 		l.ConsumeToken(':')
 		value := ParseLiteral(l, false)
 		directives := ParseDirectives(l)
-		args = append(args, &types.Argument{
+		args = append(args, &ast.Argument{
 			Name:       name,
 			Value:      value,
 			Directives: directives,

--- a/internal/exec/resolvable/meta.go
+++ b/internal/exec/resolvable/meta.go
@@ -3,8 +3,8 @@ package resolvable
 import (
 	"reflect"
 
+	"github.com/graph-gophers/graphql-go/ast"
 	"github.com/graph-gophers/graphql-go/introspection"
-	"github.com/graph-gophers/graphql-go/types"
 )
 
 // Meta defines the details of the metadata schema for introspection.
@@ -18,23 +18,23 @@ type Meta struct {
 	Service       *Object
 }
 
-func newMeta(s *types.Schema) *Meta {
+func newMeta(s *ast.Schema) *Meta {
 	var err error
 	b := newBuilder(s, nil, false)
 
-	metaSchema := s.Types["__Schema"].(*types.ObjectTypeDefinition)
+	metaSchema := s.Types["__Schema"].(*ast.ObjectTypeDefinition)
 	so, err := b.makeObjectExec(metaSchema.Name, metaSchema.Fields, nil, false, reflect.TypeOf(&introspection.Schema{}))
 	if err != nil {
 		panic(err)
 	}
 
-	metaType := s.Types["__Type"].(*types.ObjectTypeDefinition)
+	metaType := s.Types["__Type"].(*ast.ObjectTypeDefinition)
 	t, err := b.makeObjectExec(metaType.Name, metaType.Fields, nil, false, reflect.TypeOf(&introspection.Type{}))
 	if err != nil {
 		panic(err)
 	}
 
-	metaService := s.Types["_Service"].(*types.ObjectTypeDefinition)
+	metaService := s.Types["_Service"].(*ast.ObjectTypeDefinition)
 	sv, err := b.makeObjectExec(metaService.Name, metaService.Fields, nil, false, reflect.TypeOf(&introspection.Service{}))
 	if err != nil {
 		panic(err)
@@ -45,15 +45,15 @@ func newMeta(s *types.Schema) *Meta {
 	}
 
 	fieldTypename := Field{
-		FieldDefinition: types.FieldDefinition{
+		FieldDefinition: ast.FieldDefinition{
 			Name: "__typename",
-			Type: &types.NonNull{OfType: s.Types["String"]},
+			Type: &ast.NonNull{OfType: s.Types["String"]},
 		},
 		TraceLabel: "GraphQL field: __typename",
 	}
 
 	fieldSchema := Field{
-		FieldDefinition: types.FieldDefinition{
+		FieldDefinition: ast.FieldDefinition{
 			Name: "__schema",
 			Type: s.Types["__Schema"],
 		},
@@ -61,7 +61,7 @@ func newMeta(s *types.Schema) *Meta {
 	}
 
 	fieldType := Field{
-		FieldDefinition: types.FieldDefinition{
+		FieldDefinition: ast.FieldDefinition{
 			Name: "__type",
 			Type: s.Types["__Type"],
 		},
@@ -69,7 +69,7 @@ func newMeta(s *types.Schema) *Meta {
 	}
 
 	fieldService := Field{
-		FieldDefinition: types.FieldDefinition{
+		FieldDefinition: ast.FieldDefinition{
 			Name: "_service",
 			Type: s.Types["_Service"],
 		},

--- a/internal/exec/subscribe.go
+++ b/internal/exec/subscribe.go
@@ -8,10 +8,10 @@ import (
 	"reflect"
 	"time"
 
+	"github.com/graph-gophers/graphql-go/ast"
 	"github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/internal/exec/resolvable"
 	"github.com/graph-gophers/graphql-go/internal/exec/selected"
-	"github.com/graph-gophers/graphql-go/types"
 )
 
 type Response struct {
@@ -19,7 +19,7 @@ type Response struct {
 	Errors []*errors.QueryError
 }
 
-func (r *Request) Subscribe(ctx context.Context, s *resolvable.Schema, op *types.OperationDefinition) <-chan *Response {
+func (r *Request) Subscribe(ctx context.Context, s *resolvable.Schema, op *ast.OperationDefinition) <-chan *Response {
 	var result reflect.Value
 	var f *fieldToExec
 	var err *errors.QueryError
@@ -70,7 +70,7 @@ func (r *Request) Subscribe(ctx context.Context, s *resolvable.Schema, op *types
 	}
 
 	if err != nil {
-		if _, nonNullChild := f.field.Type.(*types.NonNull); nonNullChild {
+		if _, nonNullChild := f.field.Type.(*ast.NonNull); nonNullChild {
 			return sendAndReturnClosed(&Response{Errors: []*errors.QueryError{err}})
 		}
 		return sendAndReturnClosed(&Response{Data: []byte(fmt.Sprintf(`{"%s":null}`, f.field.Alias)), Errors: []*errors.QueryError{err}})
@@ -141,7 +141,7 @@ func (r *Request) Subscribe(ctx context.Context, s *resolvable.Schema, op *types
 						subR.execSelectionSet(subCtx, f.sels, f.field.Type, &pathSegment{nil, f.field.Alias}, s, resp, &buf)
 
 						propagateChildError := false
-						if _, nonNullChild := f.field.Type.(*types.NonNull); nonNullChild && resolvedToNull(&buf) {
+						if _, nonNullChild := f.field.Type.(*ast.NonNull); nonNullChild && resolvedToNull(&buf) {
 							propagateChildError = true
 						}
 

--- a/internal/schema/meta.go
+++ b/internal/schema/meta.go
@@ -1,7 +1,7 @@
 package schema
 
 import (
-	"github.com/graph-gophers/graphql-go/types"
+	"github.com/graph-gophers/graphql-go/ast"
 )
 
 func init() {
@@ -9,11 +9,10 @@ func init() {
 }
 
 // newMeta initializes an instance of the meta Schema.
-func newMeta() *types.Schema {
-	s := &types.Schema{
-		EntryPointNames: make(map[string]string),
-		Types:           make(map[string]types.NamedType),
-		Directives:      make(map[string]*types.DirectiveDefinition),
+func newMeta() *ast.Schema {
+	s := &ast.Schema{
+		Types:      make(map[string]ast.NamedType),
+		Directives: make(map[string]*ast.DirectiveDefinition),
 	}
 
 	err := Parse(s, metaSrc, false)

--- a/internal/schema/schema_internal_test.go
+++ b/internal/schema/schema_internal_test.go
@@ -4,31 +4,31 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/graph-gophers/graphql-go/ast"
 	"github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/internal/common"
-	"github.com/graph-gophers/graphql-go/types"
 )
 
 func TestParseInterfaceDef(t *testing.T) {
 	type testCase struct {
 		description string
 		definition  string
-		expected    *types.InterfaceTypeDefinition
+		expected    *ast.InterfaceTypeDefinition
 		err         *errors.QueryError
 	}
 
 	tests := []testCase{{
 		description: "Parses simple interface",
 		definition:  "Greeting { field: String }",
-		expected: &types.InterfaceTypeDefinition{
+		expected: &ast.InterfaceTypeDefinition{
 			Name:   "Greeting",
 			Loc:    errors.Location{Line: 1, Column: 1},
-			Fields: types.FieldsDefinition{&types.FieldDefinition{Name: "field"}}},
+			Fields: ast.FieldsDefinition{&ast.FieldDefinition{Name: "field"}}},
 	}}
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			var actual *types.InterfaceTypeDefinition
+			var actual *ast.InterfaceTypeDefinition
 			lex := setup(t, test.definition)
 
 			parse := func() { actual = parseInterfaceDef(lex) }
@@ -46,31 +46,31 @@ func TestParseObjectDef(t *testing.T) {
 	type testCase struct {
 		description string
 		definition  string
-		expected    *types.ObjectTypeDefinition
+		expected    *ast.ObjectTypeDefinition
 		err         *errors.QueryError
 	}
 
 	tests := []testCase{{
 		description: "Parses type inheriting single interface",
 		definition:  "Hello implements World { field: String }",
-		expected:    &types.ObjectTypeDefinition{Name: "Hello", Loc: errors.Location{Line: 1, Column: 1}, InterfaceNames: []string{"World"}},
+		expected:    &ast.ObjectTypeDefinition{Name: "Hello", Loc: errors.Location{Line: 1, Column: 1}, InterfaceNames: []string{"World"}},
 	}, {
 		description: "Parses type inheriting multiple interfaces",
 		definition:  "Hello implements Wo & rld { field: String }",
-		expected:    &types.ObjectTypeDefinition{Name: "Hello", Loc: errors.Location{Line: 1, Column: 1}, InterfaceNames: []string{"Wo", "rld"}},
+		expected:    &ast.ObjectTypeDefinition{Name: "Hello", Loc: errors.Location{Line: 1, Column: 1}, InterfaceNames: []string{"Wo", "rld"}},
 	}, {
 		description: "Parses type inheriting multiple interfaces with leading ampersand",
 		definition:  "Hello implements & Wo & rld { field: String }",
-		expected:    &types.ObjectTypeDefinition{Name: "Hello", Loc: errors.Location{Line: 1, Column: 1}, InterfaceNames: []string{"Wo", "rld"}},
+		expected:    &ast.ObjectTypeDefinition{Name: "Hello", Loc: errors.Location{Line: 1, Column: 1}, InterfaceNames: []string{"Wo", "rld"}},
 	}, {
 		description: "Allows legacy SDL interfaces",
 		definition:  "Hello implements Wo, rld { field: String }",
-		expected:    &types.ObjectTypeDefinition{Name: "Hello", Loc: errors.Location{Line: 1, Column: 1}, InterfaceNames: []string{"Wo", "rld"}},
+		expected:    &ast.ObjectTypeDefinition{Name: "Hello", Loc: errors.Location{Line: 1, Column: 1}, InterfaceNames: []string{"Wo", "rld"}},
 	}}
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			var actual *types.ObjectTypeDefinition
+			var actual *ast.ObjectTypeDefinition
 			lex := setup(t, test.definition)
 
 			parse := func() { actual = parseObjectDef(lex) }
@@ -86,7 +86,7 @@ func TestParseUnionDef(t *testing.T) {
 	type testCase struct {
 		description string
 		definition  string
-		expected    *types.Union
+		expected    *ast.Union
 		err         *errors.QueryError
 	}
 
@@ -94,7 +94,7 @@ func TestParseUnionDef(t *testing.T) {
 		{
 			description: "Parses a union",
 			definition:  "Foo = Bar | Qux | Quux",
-			expected: &types.Union{
+			expected: &ast.Union{
 				Name:      "Foo",
 				TypeNames: []string{"Bar", "Qux", "Quux"},
 				Loc:       errors.Location{Line: 1, Column: 1},
@@ -104,7 +104,7 @@ func TestParseUnionDef(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			var actual *types.Union
+			var actual *ast.Union
 			lex := setup(t, test.definition)
 
 			parse := func() { actual = parseUnionDef(lex) }
@@ -120,7 +120,7 @@ func TestParseEnumDef(t *testing.T) {
 	type testCase struct {
 		description string
 		definition  string
-		expected    *types.EnumTypeDefinition
+		expected    *ast.EnumTypeDefinition
 		err         *errors.QueryError
 	}
 
@@ -128,9 +128,9 @@ func TestParseEnumDef(t *testing.T) {
 		{
 			description: "parses EnumTypeDefinition on single line",
 			definition:  "Foo { BAR QUX }",
-			expected: &types.EnumTypeDefinition{
+			expected: &ast.EnumTypeDefinition{
 				Name: "Foo",
-				EnumValuesDefinition: []*types.EnumValueDefinition{
+				EnumValuesDefinition: []*ast.EnumValueDefinition{
 					{
 						EnumValue: "BAR",
 						Loc:       errors.Location{Line: 1, Column: 7},
@@ -149,9 +149,9 @@ func TestParseEnumDef(t *testing.T) {
 				BAR
 				QUX
 			}`,
-			expected: &types.EnumTypeDefinition{
+			expected: &ast.EnumTypeDefinition{
 				Name: "Foo",
-				EnumValuesDefinition: []*types.EnumValueDefinition{
+				EnumValuesDefinition: []*ast.EnumValueDefinition{
 					{
 						EnumValue: "BAR",
 						Loc:       errors.Location{Line: 2, Column: 5},
@@ -168,7 +168,7 @@ func TestParseEnumDef(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			var actual *types.EnumTypeDefinition
+			var actual *ast.EnumTypeDefinition
 			lex := setup(t, test.definition)
 
 			parse := func() { actual = parseEnumDef(lex) }
@@ -184,7 +184,7 @@ func TestParseDirectiveDef(t *testing.T) {
 	type testCase struct {
 		description string
 		definition  string
-		expected    *types.DirectiveDefinition
+		expected    *ast.DirectiveDefinition
 		err         *errors.QueryError
 	}
 
@@ -192,7 +192,7 @@ func TestParseDirectiveDef(t *testing.T) {
 		{
 			description: "parses DirectiveDefinition",
 			definition:  "@Foo on FIELD",
-			expected: &types.DirectiveDefinition{
+			expected: &ast.DirectiveDefinition{
 				Name:      "Foo",
 				Loc:       errors.Location{Line: 1, Column: 2},
 				Locations: []string{"FIELD"},
@@ -202,7 +202,7 @@ func TestParseDirectiveDef(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			var actual *types.DirectiveDefinition
+			var actual *ast.DirectiveDefinition
 			lex := setup(t, test.definition)
 
 			parse := func() { actual = parseDirectiveDef(lex) }
@@ -218,7 +218,7 @@ func TestParseInputDef(t *testing.T) {
 	type testCase struct {
 		description string
 		definition  string
-		expected    *types.InputObject
+		expected    *ast.InputObject
 		err         *errors.QueryError
 	}
 
@@ -226,7 +226,7 @@ func TestParseInputDef(t *testing.T) {
 		{
 			description: "parses an input object type definition",
 			definition:  "Foo { qux: String }",
-			expected: &types.InputObject{
+			expected: &ast.InputObject{
 				Name:   "Foo",
 				Values: nil,
 				Loc:    errors.Location{Line: 1, Column: 1},
@@ -236,7 +236,7 @@ func TestParseInputDef(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.description, func(t *testing.T) {
-			var actual *types.InputObject
+			var actual *ast.InputObject
 			lex := setup(t, test.definition)
 
 			parse := func() { actual = parseInputDef(lex) }
@@ -248,7 +248,7 @@ func TestParseInputDef(t *testing.T) {
 	}
 }
 
-func compareDirectiveDefinitions(t *testing.T, expected *types.DirectiveDefinition, actual *types.DirectiveDefinition) {
+func compareDirectiveDefinitions(t *testing.T, expected *ast.DirectiveDefinition, actual *ast.DirectiveDefinition) {
 	t.Helper()
 
 	if expected.Name != actual.Name {
@@ -262,7 +262,7 @@ func compareDirectiveDefinitions(t *testing.T, expected *types.DirectiveDefiniti
 	compareLoc(t, "DirectiveDefinition", expected.Loc, actual.Loc)
 }
 
-func compareInputObjectTypeDefinition(t *testing.T, expected, actual *types.InputObject) {
+func compareInputObjectTypeDefinition(t *testing.T, expected, actual *ast.InputObject) {
 	t.Helper()
 
 	if expected.Name != actual.Name {
@@ -272,7 +272,7 @@ func compareInputObjectTypeDefinition(t *testing.T, expected, actual *types.Inpu
 	compareLoc(t, "InputObjectTypeDefinition", expected.Loc, actual.Loc)
 }
 
-func compareEnumTypeDefs(t *testing.T, expected, actual *types.EnumTypeDefinition) {
+func compareEnumTypeDefs(t *testing.T, expected, actual *ast.EnumTypeDefinition) {
 	t.Helper()
 
 	if expected.Name != actual.Name {
@@ -318,7 +318,7 @@ func compareErrors(t *testing.T, expected, actual *errors.QueryError) {
 	}
 }
 
-func compareInterfaces(t *testing.T, expected, actual *types.InterfaceTypeDefinition) {
+func compareInterfaces(t *testing.T, expected, actual *ast.InterfaceTypeDefinition) {
 	t.Helper()
 
 	if expected.Name != actual.Name {
@@ -338,7 +338,7 @@ func compareInterfaces(t *testing.T, expected, actual *types.InterfaceTypeDefini
 	}
 }
 
-func compareUnions(t *testing.T, expected, actual *types.Union) {
+func compareUnions(t *testing.T, expected, actual *ast.Union) {
 	t.Helper()
 
 	if expected.Name != actual.Name {
@@ -350,7 +350,7 @@ func compareUnions(t *testing.T, expected, actual *types.Union) {
 	}
 }
 
-func compareObjects(t *testing.T, expected, actual *types.ObjectTypeDefinition) {
+func compareObjects(t *testing.T, expected, actual *ast.ObjectTypeDefinition) {
 	t.Helper()
 
 	if expected.Name != actual.Name {

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/graph-gophers/graphql-go/ast"
 	"github.com/graph-gophers/graphql-go/internal/schema"
-	"github.com/graph-gophers/graphql-go/types"
 )
 
 func TestParse(t *testing.T) {
@@ -15,14 +15,14 @@ func TestParse(t *testing.T) {
 		sdl                   string
 		useStringDescriptions bool
 		validateError         func(err error) error
-		validateSchema        func(s *types.Schema) error
+		validateSchema        func(s *ast.Schema) error
 	}{
 		{
 			name: "Parses interface definition",
 			sdl:  "interface Greeting { message: String! }",
-			validateSchema: func(s *types.Schema) error {
+			validateSchema: func(s *ast.Schema) error {
 				const typeName = "Greeting"
-				typ, ok := s.Types[typeName].(*types.InterfaceTypeDefinition)
+				typ, ok := s.Types[typeName].(*ast.InterfaceTypeDefinition)
 				if !ok {
 					return fmt.Errorf("interface %q not found", typeName)
 				}
@@ -62,9 +62,9 @@ func TestParse(t *testing.T) {
 				field: String
 			}`,
 			useStringDescriptions: true,
-			validateSchema: func(s *types.Schema) error {
+			validateSchema: func(s *ast.Schema) error {
 				const typeName = "Type"
-				typ, ok := s.Types[typeName].(*types.ObjectTypeDefinition)
+				typ, ok := s.Types[typeName].(*ast.ObjectTypeDefinition)
 				if !ok {
 					return fmt.Errorf("type %q not found", typeName)
 				}
@@ -84,9 +84,9 @@ func TestParse(t *testing.T) {
 				field: String
 			}`,
 			useStringDescriptions: true,
-			validateSchema: func(s *types.Schema) error {
+			validateSchema: func(s *ast.Schema) error {
 				const typeName = "Type"
-				typ, ok := s.Types[typeName].(*types.ObjectTypeDefinition)
+				typ, ok := s.Types[typeName].(*ast.ObjectTypeDefinition)
 				if !ok {
 					return fmt.Errorf("type %q not found", typeName)
 				}
@@ -105,9 +105,9 @@ func TestParse(t *testing.T) {
 				field: String
 			}`,
 			useStringDescriptions: true,
-			validateSchema: func(s *types.Schema) error {
+			validateSchema: func(s *ast.Schema) error {
 				const typeName = "Type"
-				typ, ok := s.Types[typeName].(*types.ObjectTypeDefinition)
+				typ, ok := s.Types[typeName].(*ast.ObjectTypeDefinition)
 				if !ok {
 					return fmt.Errorf("type %q not found", typeName)
 				}
@@ -140,9 +140,9 @@ func TestParse(t *testing.T) {
 				field: String
 			}`,
 			useStringDescriptions: true,
-			validateSchema: func(s *types.Schema) error {
+			validateSchema: func(s *ast.Schema) error {
 				const typeName = "Type"
-				typ, ok := s.Types[typeName].(*types.ObjectTypeDefinition)
+				typ, ok := s.Types[typeName].(*ast.ObjectTypeDefinition)
 				if !ok {
 					return fmt.Errorf("type %q not found", typeName)
 				}
@@ -165,9 +165,9 @@ Second line of the description.
 				field: String
 			}`,
 			useStringDescriptions: true,
-			validateSchema: func(s *types.Schema) error {
+			validateSchema: func(s *ast.Schema) error {
 				const typeName = "Type"
-				typ, ok := s.Types[typeName].(*types.ObjectTypeDefinition)
+				typ, ok := s.Types[typeName].(*ast.ObjectTypeDefinition)
 				if !ok {
 					return fmt.Errorf("type %q not found", typeName)
 				}
@@ -196,9 +196,9 @@ Second line of the description.
                 field: String
             }`,
 			useStringDescriptions: true,
-			validateSchema: func(s *types.Schema) error {
+			validateSchema: func(s *ast.Schema) error {
 				const typeName = "Type"
-				typ, ok := s.Types[typeName].(*types.ObjectTypeDefinition)
+				typ, ok := s.Types[typeName].(*ast.ObjectTypeDefinition)
 				if !ok {
 					return fmt.Errorf("type %q not found", typeName)
 				}
@@ -220,9 +220,9 @@ Second line of the description.
 				field: String
 			}`,
 			useStringDescriptions: true,
-			validateSchema: func(s *types.Schema) error {
+			validateSchema: func(s *ast.Schema) error {
 				const typeName = "Type"
-				typ, ok := s.Types[typeName].(*types.ObjectTypeDefinition)
+				typ, ok := s.Types[typeName].(*ast.ObjectTypeDefinition)
 				if !ok {
 					return fmt.Errorf("type %q not found", typeName)
 				}
@@ -254,7 +254,7 @@ Second line of the description.
 				field: String
 			}`,
 			useStringDescriptions: true,
-			validateSchema: func(s *types.Schema) error {
+			validateSchema: func(s *ast.Schema) error {
 				typ, ok := s.Types["Type"]
 				if !ok {
 					return fmt.Errorf("type %q not found", "Type")
@@ -275,7 +275,7 @@ Second line of the description.
 			type Type { 
 				field: String
 			}`,
-			validateSchema: func(s *types.Schema) error {
+			validateSchema: func(s *ast.Schema) error {
 				typ, ok := s.Types["MyInt"]
 				if !ok {
 					return fmt.Errorf("scalar %q not found", "MyInt")
@@ -303,8 +303,8 @@ Second line of the description.
 				concat(a: String!, b: String!): String!
 			}
 			`,
-			validateSchema: func(s *types.Schema) error {
-				typq, ok := s.Types["Query"].(*types.ObjectTypeDefinition)
+			validateSchema: func(s *ast.Schema) error {
+				typq, ok := s.Types["Query"].(*ast.ObjectTypeDefinition)
 				if !ok {
 					return fmt.Errorf("type %q not found", "Query")
 				}
@@ -316,7 +316,7 @@ Second line of the description.
 					return fmt.Errorf("field %q has an invalid type: %q", "hello", helloField.Type.String())
 				}
 
-				typm, ok := s.Types["Mutation"].(*types.ObjectTypeDefinition)
+				typm, ok := s.Types["Mutation"].(*ast.ObjectTypeDefinition)
 				if !ok {
 					return fmt.Errorf("type %q not found", "Mutation")
 				}
@@ -343,8 +343,8 @@ Second line of the description.
 			extend type Query {
 				world: String!
 			}`,
-			validateSchema: func(s *types.Schema) error {
-				typ, ok := s.Types["Query"].(*types.ObjectTypeDefinition)
+			validateSchema: func(s *ast.Schema) error {
+				typ, ok := s.Types["Query"].(*ast.ObjectTypeDefinition)
 				if !ok {
 					return fmt.Errorf("type %q not found", "Query")
 				}
@@ -383,8 +383,8 @@ Second line of the description.
 				concat(a: String!, b: String!): String!
 			}
 			`,
-			validateSchema: func(s *types.Schema) error {
-				typq, ok := s.Types["Query"].(*types.ObjectTypeDefinition)
+			validateSchema: func(s *ast.Schema) error {
+				typq, ok := s.Types["Query"].(*ast.ObjectTypeDefinition)
 				if !ok {
 					return fmt.Errorf("type %q not found", "Query")
 				}
@@ -396,7 +396,7 @@ Second line of the description.
 					return fmt.Errorf("field %q has an invalid type: %q", "hello", helloField.Type.String())
 				}
 
-				typm, ok := s.Types["Mutation"].(*types.ObjectTypeDefinition)
+				typm, ok := s.Types["Mutation"].(*ast.ObjectTypeDefinition)
 				if !ok {
 					return fmt.Errorf("type %q not found", "Mutation")
 				}
@@ -425,8 +425,8 @@ Second line of the description.
 			extend type Product implements Named {
 				name: String!
 			}`,
-			validateSchema: func(s *types.Schema) error {
-				typ, ok := s.Types["Product"].(*types.ObjectTypeDefinition)
+			validateSchema: func(s *ast.Schema) error {
+				typ, ok := s.Types["Product"].(*ast.ObjectTypeDefinition)
 				if !ok {
 					return fmt.Errorf("type %q not found", "Product")
 				}
@@ -445,7 +445,7 @@ Second line of the description.
 					return fmt.Errorf("field %q has an invalid type: %q", "name", nameField.Type.String())
 				}
 
-				ifc, ok := s.Types["Named"].(*types.InterfaceTypeDefinition)
+				ifc, ok := s.Types["Named"].(*ast.InterfaceTypeDefinition)
 				if !ok {
 					return fmt.Errorf("type %q not found", "Named")
 				}
@@ -474,8 +474,8 @@ Second line of the description.
 			}
 			extend union Item = Coloured
 			`,
-			validateSchema: func(s *types.Schema) error {
-				typ, ok := s.Types["Item"].(*types.Union)
+			validateSchema: func(s *ast.Schema) error {
+				typ, ok := s.Types["Item"].(*ast.Union)
 				if !ok {
 					return fmt.Errorf("type %q not found", "Item")
 				}
@@ -508,8 +508,8 @@ Second line of the description.
 				GBP
 			}
 			`,
-			validateSchema: func(s *types.Schema) error {
-				typ, ok := s.Types["Currencies"].(*types.EnumTypeDefinition)
+			validateSchema: func(s *ast.Schema) error {
+				typ, ok := s.Types["Currencies"].(*ast.EnumTypeDefinition)
 				if !ok {
 					return fmt.Errorf("enum %q not found", "Currencies")
 				}
@@ -609,8 +609,8 @@ Second line of the description.
 			
 			extend union Item = Coloured
 			`,
-			validateSchema: func(s *types.Schema) error {
-				typ, ok := s.Types["Item"].(*types.Union)
+			validateSchema: func(s *ast.Schema) error {
+				typ, ok := s.Types["Item"].(*ast.Union)
 				if !ok {
 					return fmt.Errorf("type %q not found", "Item")
 				}
@@ -646,8 +646,8 @@ Second line of the description.
 				name: String!
 			}
 			`,
-			validateSchema: func(s *types.Schema) error {
-				typ, ok := s.Types["Product"].(*types.InputObject)
+			validateSchema: func(s *ast.Schema) error {
+				typ, ok := s.Types["Product"].(*ast.InputObject)
 				if !ok {
 					return fmt.Errorf("type %q not found", "Product")
 				}
@@ -746,8 +746,8 @@ Second line of the description.
 				category: String!
 			}
 			`,
-			validateSchema: func(s *types.Schema) error {
-				typ, ok := s.Types["Product"].(*types.InterfaceTypeDefinition)
+			validateSchema: func(s *ast.Schema) error {
+				typ, ok := s.Types["Product"].(*ast.InterfaceTypeDefinition)
 				if !ok {
 					return fmt.Errorf("type %q not found", "Product")
 				}
@@ -839,18 +839,18 @@ Second line of the description.
 
 			scalar Mass @repeatabledirective @repeatabledirective
 			`,
-			validateSchema: func(s *types.Schema) error {
-				namedEntityDirectives := s.Types["NamedEntity"].(*types.InterfaceTypeDefinition).Directives
+			validateSchema: func(s *ast.Schema) error {
+				namedEntityDirectives := s.Types["NamedEntity"].(*ast.InterfaceTypeDefinition).Directives
 				if len(namedEntityDirectives) != 1 || namedEntityDirectives[0].Name.Name != "directive" {
 					return fmt.Errorf("missing directive on NamedEntity interface, expected @directive but got %v", namedEntityDirectives)
 				}
 
-				timeDirectives := s.Types["Time"].(*types.ScalarTypeDefinition).Directives
+				timeDirectives := s.Types["Time"].(*ast.ScalarTypeDefinition).Directives
 				if len(timeDirectives) != 1 || timeDirectives[0].Name.Name != "directive" {
 					return fmt.Errorf("missing directive on Time scalar, expected @directive but got %v", timeDirectives)
 				}
 
-				photo := s.Types["Photo"].(*types.ObjectTypeDefinition)
+				photo := s.Types["Photo"].(*ast.ObjectTypeDefinition)
 				photoDirectives := photo.Directives
 				if len(photoDirectives) != 1 || photoDirectives[0].Name.Name != "objectdirective" {
 					return fmt.Errorf("missing directive on Time scalar, expected @objectdirective but got %v", photoDirectives)
@@ -859,17 +859,17 @@ Second line of the description.
 					return fmt.Errorf("expected Photo.id to have 2 directives but got %v", photoDirectives)
 				}
 
-				directionDirectives := s.Types["Direction"].(*types.EnumTypeDefinition).Directives
+				directionDirectives := s.Types["Direction"].(*ast.EnumTypeDefinition).Directives
 				if len(directionDirectives) != 1 || directionDirectives[0].Name.Name != "enumdirective" {
 					return fmt.Errorf("missing directive on Direction enum, expected @enumdirective but got %v", directionDirectives)
 				}
 
-				unionDirectives := s.Types["Union"].(*types.Union).Directives
+				unionDirectives := s.Types["Union"].(*ast.Union).Directives
 				if len(unionDirectives) != 1 || unionDirectives[0].Name.Name != "uniondirective" {
 					return fmt.Errorf("missing directive on Union union, expected @uniondirective but got %v", unionDirectives)
 				}
 
-				massDirectives := s.Types["Mass"].(*types.ScalarTypeDefinition).Directives
+				massDirectives := s.Types["Mass"].(*ast.ScalarTypeDefinition).Directives
 				if len(massDirectives) != 2 || massDirectives[0].Name.Name != "repeatabledirective" || massDirectives[1].Name.Name != "repeatabledirective" {
 					return fmt.Errorf("missing directive on Repeatable scalar, expected @repeatabledirective @repeatabledirective but got %v", massDirectives)
 				}
@@ -882,7 +882,7 @@ Second line of the description.
 			directive @nonrepeatabledirective on SCALAR
 			directive @repeatabledirective repeatable on SCALAR
 			`,
-			validateSchema: func(s *types.Schema) error {
+			validateSchema: func(s *ast.Schema) error {
 				if dir := s.Directives["nonrepeatabledirective"]; dir.Repeatable {
 					return fmt.Errorf("did not expect directive to be repeatable: %v", dir)
 				}
@@ -1016,7 +1016,7 @@ func TestInterfaceImplementsInterface(t *testing.T) {
 		sdl                   string
 		useStringDescriptions bool
 		validateError         func(err error) error
-		validateSchema        func(s *types.Schema) error
+		validateSchema        func(s *ast.Schema) error
 	}{
 		{
 			name: "Parses interface implementing other interface",
@@ -1028,9 +1028,9 @@ func TestInterfaceImplementsInterface(t *testing.T) {
 				field: String!
 			}
 			`,
-			validateSchema: func(s *types.Schema) error {
+			validateSchema: func(s *ast.Schema) error {
 				const implementedInterfaceName = "Bar"
-				typ, ok := s.Types[implementedInterfaceName].(*types.InterfaceTypeDefinition)
+				typ, ok := s.Types[implementedInterfaceName].(*ast.InterfaceTypeDefinition)
 				if !ok {
 					return fmt.Errorf("interface %q not found", implementedInterfaceName)
 				}
@@ -1068,9 +1068,9 @@ func TestInterfaceImplementsInterface(t *testing.T) {
 				field: String!
 			}
 			`,
-			validateSchema: func(s *types.Schema) error {
+			validateSchema: func(s *ast.Schema) error {
 				const implementedInterfaceName = "Baz"
-				typ, ok := s.Types[implementedInterfaceName].(*types.InterfaceTypeDefinition)
+				typ, ok := s.Types[implementedInterfaceName].(*ast.InterfaceTypeDefinition)
 				if !ok {
 					return fmt.Errorf("interface %q not found", implementedInterfaceName)
 				}

--- a/internal/validation/validate_max_depth_test.go
+++ b/internal/validation/validate_max_depth_test.go
@@ -3,9 +3,9 @@ package validation
 import (
 	"testing"
 
+	"github.com/graph-gophers/graphql-go/ast"
 	"github.com/graph-gophers/graphql-go/internal/query"
 	"github.com/graph-gophers/graphql-go/internal/schema"
-	"github.com/graph-gophers/graphql-go/types"
 )
 
 const (
@@ -76,7 +76,7 @@ type maxDepthTestCase struct {
 	expectedErrors []string
 }
 
-func (tc maxDepthTestCase) Run(t *testing.T, s *types.Schema) {
+func (tc maxDepthTestCase) Run(t *testing.T, s *ast.Schema) {
 	t.Run(tc.name, func(t *testing.T) {
 		doc, qErr := query.Parse(tc.query)
 		if qErr != nil {

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -8,11 +8,11 @@ import (
 
 	"encoding/json"
 
+	"github.com/graph-gophers/graphql-go/ast"
 	"github.com/graph-gophers/graphql-go/errors"
 	"github.com/graph-gophers/graphql-go/internal/query"
 	"github.com/graph-gophers/graphql-go/internal/schema"
 	"github.com/graph-gophers/graphql-go/internal/validation"
-	"github.com/graph-gophers/graphql-go/types"
 )
 
 type Test struct {
@@ -38,7 +38,7 @@ func TestValidate(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	schemas := make([]*types.Schema, len(testData.Schemas))
+	schemas := make([]*ast.Schema, len(testData.Schemas))
 	for i, schemaStr := range testData.Schemas {
 		schemas[i] = schema.New()
 		err := schema.Parse(schemas[i], schemaStr, false)

--- a/introspection/introspection.go
+++ b/introspection/introspection.go
@@ -3,15 +3,15 @@ package introspection
 import (
 	"sort"
 
-	"github.com/graph-gophers/graphql-go/types"
+	"github.com/graph-gophers/graphql-go/ast"
 )
 
 type Schema struct {
-	schema *types.Schema
+	schema *ast.Schema
 }
 
 // WrapSchema is only used internally.
-func WrapSchema(schema *types.Schema) *Schema {
+func WrapSchema(schema *ast.Schema) *Schema {
 	return &Schema{schema}
 }
 
@@ -68,11 +68,11 @@ func (r *Schema) SubscriptionType() *Type {
 }
 
 type Type struct {
-	typ types.Type
+	typ ast.Type
 }
 
 // WrapType is only used internally.
-func WrapType(typ types.Type) *Type {
+func WrapType(typ ast.Type) *Type {
 	return &Type{typ}
 }
 
@@ -81,7 +81,7 @@ func (r *Type) Kind() string {
 }
 
 func (r *Type) Name() *string {
-	if named, ok := r.typ.(types.NamedType); ok {
+	if named, ok := r.typ.(ast.NamedType); ok {
 		name := named.TypeName()
 		return &name
 	}
@@ -89,7 +89,7 @@ func (r *Type) Name() *string {
 }
 
 func (r *Type) Description() *string {
-	if named, ok := r.typ.(types.NamedType); ok {
+	if named, ok := r.typ.(ast.NamedType); ok {
 		desc := named.Description()
 		if desc == "" {
 			return nil
@@ -100,11 +100,11 @@ func (r *Type) Description() *string {
 }
 
 func (r *Type) Fields(args *struct{ IncludeDeprecated bool }) *[]*Field {
-	var fields types.FieldsDefinition
+	var fields ast.FieldsDefinition
 	switch t := r.typ.(type) {
-	case *types.ObjectTypeDefinition:
+	case *ast.ObjectTypeDefinition:
 		fields = t.Fields
-	case *types.InterfaceTypeDefinition:
+	case *ast.InterfaceTypeDefinition:
 		fields = t.Fields
 	default:
 		return nil
@@ -120,7 +120,7 @@ func (r *Type) Fields(args *struct{ IncludeDeprecated bool }) *[]*Field {
 }
 
 func (r *Type) Interfaces() *[]*Type {
-	t, ok := r.typ.(*types.ObjectTypeDefinition)
+	t, ok := r.typ.(*ast.ObjectTypeDefinition)
 	if !ok {
 		return nil
 	}
@@ -133,11 +133,11 @@ func (r *Type) Interfaces() *[]*Type {
 }
 
 func (r *Type) PossibleTypes() *[]*Type {
-	var possibleTypes []*types.ObjectTypeDefinition
+	var possibleTypes []*ast.ObjectTypeDefinition
 	switch t := r.typ.(type) {
-	case *types.InterfaceTypeDefinition:
+	case *ast.InterfaceTypeDefinition:
 		possibleTypes = t.PossibleTypes
-	case *types.Union:
+	case *ast.Union:
 		possibleTypes = t.UnionMemberTypes
 	default:
 		return nil
@@ -151,7 +151,7 @@ func (r *Type) PossibleTypes() *[]*Type {
 }
 
 func (r *Type) EnumValues(args *struct{ IncludeDeprecated bool }) *[]*EnumValue {
-	t, ok := r.typ.(*types.EnumTypeDefinition)
+	t, ok := r.typ.(*ast.EnumTypeDefinition)
 	if !ok {
 		return nil
 	}
@@ -166,7 +166,7 @@ func (r *Type) EnumValues(args *struct{ IncludeDeprecated bool }) *[]*EnumValue 
 }
 
 func (r *Type) InputFields() *[]*InputValue {
-	t, ok := r.typ.(*types.InputObject)
+	t, ok := r.typ.(*ast.InputObject)
 	if !ok {
 		return nil
 	}
@@ -180,9 +180,9 @@ func (r *Type) InputFields() *[]*InputValue {
 
 func (r *Type) OfType() *Type {
 	switch t := r.typ.(type) {
-	case *types.List:
+	case *ast.List:
 		return &Type{t.OfType}
-	case *types.NonNull:
+	case *ast.NonNull:
 		return &Type{t.OfType}
 	default:
 		return nil
@@ -191,7 +191,7 @@ func (r *Type) OfType() *Type {
 
 func (r *Type) SpecifiedByURL() *string {
 	switch t := r.typ.(type) {
-	case *types.ScalarTypeDefinition:
+	case *ast.ScalarTypeDefinition:
 		if d := t.Directives.Get("specifiedBy"); d != nil {
 			arg := d.Arguments.MustGet("url")
 			url := arg.Deserialize(nil).(string)
@@ -204,7 +204,7 @@ func (r *Type) SpecifiedByURL() *string {
 }
 
 type Field struct {
-	field *types.FieldDefinition
+	field *ast.FieldDefinition
 }
 
 func (r *Field) Name() string {
@@ -244,7 +244,7 @@ func (r *Field) DeprecationReason() *string {
 }
 
 type InputValue struct {
-	value *types.InputValueDefinition
+	value *ast.InputValueDefinition
 }
 
 func (r *InputValue) Name() string {
@@ -271,7 +271,7 @@ func (r *InputValue) DefaultValue() *string {
 }
 
 type EnumValue struct {
-	value *types.EnumValueDefinition
+	value *ast.EnumValueDefinition
 }
 
 func (r *EnumValue) Name() string {
@@ -299,7 +299,7 @@ func (r *EnumValue) DeprecationReason() *string {
 }
 
 type Directive struct {
-	directive *types.DirectiveDefinition
+	directive *ast.DirectiveDefinition
 }
 
 func (r *Directive) Name() string {
@@ -326,11 +326,11 @@ func (r *Directive) Args() []*InputValue {
 }
 
 type Service struct {
-	schema *types.Schema
+	schema *ast.Schema
 }
 
 // WrapService is only used internally.
-func WrapService(schema *types.Schema) *Service {
+func WrapService(schema *ast.Schema) *Service {
 	return &Service{schema}
 }
 

--- a/types/doc.go
+++ b/types/doc.go
@@ -1,7 +1,0 @@
-/*
-Package types represents all types from the GraphQL specification in code.
-
-The names of the Go types, whenever possible, match 1:1 with the names from
-the specification.
-*/
-package types

--- a/types/schema.go
+++ b/types/schema.go
@@ -1,41 +1,145 @@
+/*
+Package types represents all types from the GraphQL specification in code.
+
+The names of the Go types, whenever possible, match 1:1 with the names from
+the specification.
+
+Deprecated: Use package [ast] instead. This package will be deleted in future versions of the library.
+*/
 package types
 
-// Schema represents a GraphQL service's collective type system capabilities.
-// A schema is defined in terms of the types and directives it supports as well as the root
-// operation types for each kind of operation: `query`, `mutation`, and `subscription`.
+import "github.com/graph-gophers/graphql-go/ast"
+
+// Schema is here for backwards compatibility.
 //
-// For a more formal definition, read the relevant section in the specification:
-//
-// http://spec.graphql.org/draft/#sec-Schema
-type Schema struct {
-	// RootOperationTypes determines the place in the type system where `query`, `mutation`, and
-	// `subscription` operations begin.
-	//
-	// http://spec.graphql.org/draft/#sec-Root-Operation-Types
-	//
-	RootOperationTypes map[string]NamedType
+// Deprecated: use [ast.Schema] instead.
+type Schema = ast.Schema
 
-	// Types are the fundamental unit of any GraphQL schema.
-	// There are six kinds of named types, and two wrapping types.
-	//
-	// http://spec.graphql.org/draft/#sec-Types
-	Types map[string]NamedType
+// Deprecated: use [ast.Argument] instead.
+type Argument = ast.Argument
 
-	// Directives are used to annotate various parts of a GraphQL document as an indicator that they
-	// should be evaluated differently by a validator, executor, or client tool such as a code
-	// generator.
-	//
-	// http://spec.graphql.org/#sec-Type-System.Directives
-	Directives map[string]*DirectiveDefinition
+// Deprecated: use [ast.ArgumentList] instead.
+type ArgumentList = ast.ArgumentList
 
-	EntryPointNames map[string]string
-	Objects         []*ObjectTypeDefinition
-	Unions          []*Union
-	Enums           []*EnumTypeDefinition
-	Extensions      []*Extension
-	SchemaString    string
-}
+// Deprecated: use [ast.ArgumentsDefinition] instead.
+type ArgumentsDefinition = ast.ArgumentsDefinition
 
-func (s *Schema) Resolve(name string) Type {
-	return s.Types[name]
-}
+// Deprecated: use [ast.Directive] instead.
+type Directive = ast.Directive
+
+// Deprecated: use [ast.DirectiveDefinition] instead.
+type DirectiveDefinition = ast.DirectiveDefinition
+
+// Deprecated: use [ast.DirectiveList] instead.
+type DirectiveList = ast.DirectiveList
+
+// Deprecated: use [ast.EnumTypeDefinition] instead.
+type EnumTypeDefinition = ast.EnumTypeDefinition
+
+// Deprecated: use [ast.EnumValueDefinition] instead.
+type EnumValueDefinition = ast.EnumValueDefinition
+
+// Deprecated: use [ast.Extension] instead.
+type Extension = ast.Extension
+
+// Deprecated: use [ast.FieldDefinition] instead.
+type FieldDefinition = ast.FieldDefinition
+
+// Deprecated: use [ast.FieldsDefinition] instead.
+type FieldsDefinition = ast.FieldsDefinition
+
+// Deprecated: use [ast.Fragment] instead.
+type Fragment = ast.Fragment
+
+// Deprecated: use [ast.InlineFragment] instead.
+type InlineFragment = ast.InlineFragment
+
+// Deprecated: use [ast.FragmentDefinition] instead.
+type FragmentDefinition = ast.FragmentDefinition
+
+// Deprecated: use [ast.FragmentSpread] instead.
+type FragmentSpread = ast.FragmentSpread
+
+// Deprecated: use [ast.FragmentList] instead.
+type FragmentList = ast.FragmentList
+
+// Deprecated: use [ast.InputValueDefinition] instead.
+type InputValueDefinition = ast.InputValueDefinition
+
+// Deprecated: use [ast.InputValueDefinitionList] instead.
+type InputValueDefinitionList = ast.InputValueDefinitionList
+
+// Deprecated: use [ast.InputObject] instead.
+type InputObject = ast.InputObject
+
+// Deprecated: use [ast.InterfaceTypeDefinition] instead.
+type InterfaceTypeDefinition = ast.InterfaceTypeDefinition
+
+// Deprecated: use [ast.ObjectTypeDefinition] instead.
+type ObjectTypeDefinition = ast.ObjectTypeDefinition
+
+// Deprecated: use [ast.ExecutableDefinition] instead.
+type ExecutableDefinition = ast.ExecutableDefinition
+
+// Deprecated: use [ast.OperationDefinition] instead.
+type OperationDefinition = ast.OperationDefinition
+
+// Deprecated: use [ast.OperationType] instead.
+type OperationType = ast.OperationType
+
+// Deprecated: use [ast.Selection] instead.
+type Selection = ast.Selection
+
+// Deprecated: use [ast.SelectionSet] instead.
+type SelectionSet = ast.SelectionSet
+
+// Deprecated: use [ast.Field] instead.
+type Field = ast.Field
+
+// Deprecated: use [ast.OperationList] instead.
+type OperationList = ast.OperationList
+
+// Deprecated: use [ast.ScalarTypeDefinition] instead.
+type ScalarTypeDefinition = ast.ScalarTypeDefinition
+
+// Deprecated: use [ast.TypeName] instead.
+type TypeName = ast.TypeName
+
+// Deprecated: use [ast.NamedType] instead.
+type NamedType = ast.NamedType
+
+// Deprecated: use [ast.Ident] instead.
+type Ident = ast.Ident
+
+// Deprecated: use [ast.Type] instead.
+type Type = ast.Type
+
+// Deprecated: use [ast.List] instead.
+type List = ast.List
+
+// Deprecated: use [ast.NonNull] instead.
+type NonNull = ast.NonNull
+
+// Deprecated: use [ast.Union] instead.
+type Union = ast.Union
+
+// Deprecated: use [ast.Value] instead.
+type Value = ast.Value
+
+// Deprecated: use [ast.PrimitiveValue] instead.
+type PrimitiveValue = ast.PrimitiveValue
+
+// Deprecated: use [ast.ListValue] instead.
+type ListValue = ast.ListValue
+
+// Deprecated: use [ast.ObjectValue] instead.
+type ObjectValue = ast.ObjectValue
+
+// Deprecated: use [ast.ObjectField] instead.
+type ObjectField = ast.ObjectField
+
+// Deprecated: use [ast.NullValue] instead.
+type NullValue = ast.NullValue
+
+// Deprecated: use [ast.Variable] instead.
+type Variable = ast.Variable


### PR DESCRIPTION
Use the `ast` package for GraphQL types because it describes better the types it contains. Also, it would be better when using the types from other packages. For example, `ast.ExecutableDefinition` gives more context than `types.ExecutableDefinition`.

fixes: #582