### PR TITLE
Allow fragment on interface

### DIFF
--- a/graphql_test.go
+++ b/graphql_test.go
@@ -1647,6 +1647,37 @@ func TestFragments(t *testing.T) {
 				}
 			`,
 		},
+		{
+			Schema: starwarsSchema,
+			Query: `
+				query {
+					human(id: "1000") {
+						id
+						mass
+						...characterInfo
+					}
+				}
+				fragment characterInfo on Character {
+					name
+					...on Droid {
+						primaryFunction
+					}
+					...on Human {
+						height
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+					"human": {
+						"id": "1000",
+						"mass": 77,
+						"name": "Luke Skywalker",
+						"height": 1.72
+					}
+				}
+			`,
+		},
 	})
 }
 

--- a/internal/exec/resolvable/meta.go
+++ b/internal/exec/resolvable/meta.go
@@ -23,19 +23,19 @@ func newMeta(s *ast.Schema) *Meta {
 	b := newBuilder(s, nil, false)
 
 	metaSchema := s.Types["__Schema"].(*ast.ObjectTypeDefinition)
-	so, err := b.makeObjectExec(metaSchema.Name, metaSchema.Fields, nil, false, reflect.TypeOf(&introspection.Schema{}))
+	so, err := b.makeObjectExec(metaSchema.Name, metaSchema.Fields, nil, nil, false, reflect.TypeOf(&introspection.Schema{}))
 	if err != nil {
 		panic(err)
 	}
 
 	metaType := s.Types["__Type"].(*ast.ObjectTypeDefinition)
-	t, err := b.makeObjectExec(metaType.Name, metaType.Fields, nil, false, reflect.TypeOf(&introspection.Type{}))
+	t, err := b.makeObjectExec(metaType.Name, metaType.Fields, nil, nil, false, reflect.TypeOf(&introspection.Type{}))
 	if err != nil {
 		panic(err)
 	}
 
 	metaService := s.Types["_Service"].(*ast.ObjectTypeDefinition)
-	sv, err := b.makeObjectExec(metaService.Name, metaService.Fields, nil, false, reflect.TypeOf(&introspection.Service{}))
+	sv, err := b.makeObjectExec(metaService.Name, metaService.Fields, nil, nil, false, reflect.TypeOf(&introspection.Service{}))
 	if err != nil {
 		panic(err)
 	}

--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -211,7 +211,7 @@ func applyFragment(r *Request, s *resolvable.Schema, e *resolvable.Object, frag 
 		}
 		// check if the fragment is on an interface which the current resolvable type implements
 		// see the second test in [TestFragments] in the graphql_test.go file.
-		if _, ok := e.Interfaces[frag.On.Name]; ok {
+		if _, found := e.Interfaces[frag.On.Name]; found {
 			return applyInterfaceFragment(r, s, e, frag)
 		}
 		if ok && len(face.PossibleTypes) > 0 {

--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -209,6 +209,11 @@ func applyFragment(r *Request, s *resolvable.Schema, e *resolvable.Object, frag 
 				Sels:          applySelectionSet(r, s, a.TypeExec.(*resolvable.Object), frag.Selections),
 			}}
 		}
+		// check if the fragment is on an interface which the current resolvable type implements
+		// see the second test in [TestFragments] in the graphql_test.go file.
+		if _, ok := e.Interfaces[frag.On.Name]; ok {
+			return applyInterfaceFragment(r, s, e, frag)
+		}
 		if ok && len(face.PossibleTypes) > 0 {
 			sels := []Selection{}
 			for _, t := range face.PossibleTypes {
@@ -230,6 +235,34 @@ func applyFragment(r *Request, s *resolvable.Schema, e *resolvable.Object, frag 
 		}
 	}
 	return applySelectionSet(r, s, e, frag.Selections)
+}
+
+func applyInterfaceFragment(r *Request, s *resolvable.Schema, e *resolvable.Object, frag *ast.Fragment) []Selection {
+	// if the fragment is on an interface the object type implements, then filter out
+	// selections for any fragments that don't match this type.
+	var sels []ast.Selection
+	for _, sel := range frag.Selections {
+		switch sel := sel.(type) {
+		case *ast.Field:
+			sels = append(sels, sel)
+		case *ast.InlineFragment:
+			if sel.On.Name != e.Name {
+				if _, ok := e.Interfaces[sel.On.Name]; !ok {
+					continue
+				}
+			}
+			sels = append(sels, sel)
+		case *ast.FragmentSpread:
+			f := &r.Doc.Fragments.Get(sel.Name.Name).Fragment
+			if f.On.Name != e.Name {
+				if _, ok := e.Interfaces[f.On.Name]; !ok {
+					continue
+				}
+			}
+			sels = append(sels, sel)
+		}
+	}
+	return applySelectionSet(r, s, e, sels)
 }
 
 func applyField(r *Request, s *resolvable.Schema, e resolvable.Resolvable, sels []ast.Selection) []Selection {


### PR DESCRIPTION
This PR allows fragments on an interface which implements a type.

fixes: #113 
closes: #376 