### PR TITLE
Allow directives without a Go visitor counterpart

### DIFF
--- a/graphql_test.go
+++ b/graphql_test.go
@@ -453,6 +453,27 @@ func TestCustomDirective(t *testing.T) {
 				}
 			`,
 		},
+		{
+			Schema: graphql.MustParseSchema(`
+				# this test ensures that directives without a Go visitor counterpart are allowed
+				directive @awesome on FIELD_DEFINITION
+
+				type Query {
+					hello: String! @awesome
+				}`,
+				&helloResolver{},
+			),
+			Query: `
+				{
+					hello
+				}
+			`,
+			ExpectedResult: `
+				{
+					"hello": "Hello world!"
+				}
+			`,
+		},
 	})
 }
 
@@ -613,23 +634,7 @@ func TestParseSchemaWithInvalidCustomDirectives(t *testing.T) {
 		Args args
 		Want want
 	}{
-		"Missing required directive": {
-			Args: args{
-				Resolver: &helloSnakeResolver1{},
-				Schema: `
-					directive @customDirective on FIELD_DEFINITION
-	
-					schema {
-						query: Query
-					}
-	
-					type Query {
-						hello_html: String! @customDirective
-					}
-				`,
-			},
-			Want: want{Error: `no visitors have been registered for directive "customDirective"`},
-		},
+
 		"Duplicate directive implementations": {
 			Args: args{
 				Directives: []directives.Directive{&customDirectiveVisitor{}, &customInvalidDirective{}},

--- a/internal/exec/resolvable/resolvable.go
+++ b/internal/exec/resolvable/resolvable.go
@@ -283,32 +283,6 @@ func applyDirectives(s *ast.Schema, visitors []directives.Directive) (map[string
 		byName[name] = v
 	}
 
-	for name, def := range s.Directives {
-		// TODO: directives other than FIELD_DEFINITION also need to be supported, and later addition of
-		// capabilities to 'visit' other kinds of directive locations shouldn't break the parsing of existing
-		// schemas that declare those directives, but don't have a visitor for them?
-		var acceptedType bool
-		for _, l := range def.Locations {
-			if l == "FIELD_DEFINITION" {
-				acceptedType = true
-				break
-			}
-		}
-
-		if !acceptedType {
-			continue
-		}
-
-		if _, ok := byName[name]; !ok {
-			if name == "include" || name == "skip" || name == "deprecated" || name == "specifiedBy" {
-				// Special case directives, ignore
-				continue
-			}
-
-			return nil, fmt.Errorf("no visitors have been registered for directive %q", name)
-		}
-	}
-
 	return byName, nil
 }
 


### PR DESCRIPTION
fixes: #588 