### PR TITLE
Check for required fields while parsing the schema

### DIFF
--- a/internal/exec/packer/packer.go
+++ b/internal/exec/packer/packer.go
@@ -199,6 +199,12 @@ func (b *Builder) MakeStructPacker(values []*ast.InputValueDefinition, typ refle
 		if sf.PkgPath != "" {
 			return nil, fmt.Errorf("field %q must be exported", sf.Name)
 		}
+		if _, ok := v.Type.(*ast.NonNull); ok {
+			if sf.Type.Kind() == reflect.Ptr {
+				return nil, fmt.Errorf("field %q must be a non-pointer since the parameter is required", sf.Name)
+			}
+		}
+
 		fe.index = sf.Index
 
 		ft := v.Type


### PR DESCRIPTION
fixes: #548 
```go
package main

import (
	"log"
	"net/http"

	graphql "github.com/graph-gophers/graphql-go"
	"github.com/graph-gophers/graphql-go/relay"
)

type query struct{}

func (_ *query) Hello(args struct{ ID *graphql.ID }) string { return "Hello, world!" }

func main() {
	s := `
                type Query {
                        hello(id: ID!): String!
                }
        `
	schema := graphql.MustParseSchema(s, &query{})
	http.Handle("/query", &relay.Handler{Schema: schema})
	log.Fatal(http.ListenAndServe(":8080", nil))
}
```
When running the above, the following error happen, and exit.
```
panic: field "ID" must be a non-pointer since the parameter is required
```