### PR TITLE
Add graphql reflect tag

### DIFF
--- a/examples_test.go
+++ b/examples_test.go
@@ -433,3 +433,59 @@ func ExampleUseStringDescriptions() {
 	//   field: "title", description: ""
 	//   field: "tags", description: "Tags of the post."
 }
+
+// ExampleFieldTag demonstrates the use of the graphql field tag.
+func Example_resolverFieldTag() {
+	type resolver struct {
+		Hello           string
+		HelloUnderscore string `graphql:"_hello"`
+		HelloLower      string `graphql:"hello"`
+		HelloTitle      string `graphql:"Hello"`
+		HelloUpper      string `graphql:"HELLO"`
+	}
+
+	sdl := `
+	type Query {
+		_hello: String!
+		hello: String!
+		Hello: String!
+		HELLO: String!
+	}`
+
+	r := &resolver{
+		Hello:           "This field is not used during query execution!",
+		HelloLower:      "Hello, graphql!",
+		HelloTitle:      "Hello, GraphQL!",
+		HelloUnderscore: "Hello, _!",
+		HelloUpper:      "Hello, GRAPHQL!",
+	}
+
+	query := `
+	{
+		_hello
+		hello
+		Hello
+		HELLO
+	}
+	`
+
+	schema := graphql.MustParseSchema(sdl, r, graphql.UseFieldResolvers())
+	res := schema.Exec(context.Background(), query, "", nil)
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	err := enc.Encode(res)
+	if err != nil {
+		panic(err)
+	}
+
+	// output:
+	// {
+	//   "data": {
+	//     "_hello": "Hello, _!",
+	//     "hello": "Hello, graphql!",
+	//     "Hello": "Hello, GraphQL!",
+	//     "HELLO": "Hello, GRAPHQL!"
+	//   }
+	// }
+}

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -5637,6 +5637,23 @@ func TestSchemaExtension(t *testing.T) {
 
 func TestGraphqlNames(t *testing.T) {
 	t.Parallel()
+
+	sdl1 := `
+	type Query {
+		hello: String!
+	}
+	`
+	type invalidResolver1 struct {
+		Field1 string `graphql:"hello"`
+		Field2 string `graphql:"hello"`
+	}
+
+	wantErr := fmt.Errorf(`*graphql_test.invalidResolver1 does not resolve "Query": ambiguous field "hello"`)
+	_, err := graphql.ParseSchema(sdl1, &invalidResolver1{}, graphql.UseFieldResolvers())
+	if err == nil || err.Error() != wantErr.Error() {
+		t.Fatalf("want err %q, got %q", wantErr, err)
+	}
+
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
 			Schema: graphql.MustParseSchema(`

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -5648,7 +5648,7 @@ func TestGraphqlNames(t *testing.T) {
 		Field2 string `graphql:"hello"`
 	}
 
-	wantErr := fmt.Errorf(`*graphql_test.invalidResolver1 does not resolve "Query": ambiguous field "hello"`)
+	wantErr := fmt.Errorf(`*graphql_test.invalidResolver1 does not resolve "Query": multiple fields have a graphql reflect tag "hello"`)
 	_, err := graphql.ParseSchema(sdl1, &invalidResolver1{}, graphql.UseFieldResolvers())
 	if err == nil || err.Error() != wantErr.Error() {
 		t.Fatalf("want err %q, got %q", wantErr, err)

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -5635,36 +5635,34 @@ func TestSchemaExtension(t *testing.T) {
 	}
 }
 
-type helloTagResolver struct {
-	// Hello           string
-	HelloUnderscore string `graphql:"_hello"`
-	HelloLower      string `graphql:"hello"`
-	HelloTitle      string `graphql:"Hello"`
-	HelloUpper      string `graphql:"HELLO"`
-}
-
 func TestGraphqlNames(t *testing.T) {
 	t.Parallel()
-
-	sdl := `
-	type Query {
-		_hello: String!
-		hello: String!
-		Hello: String!
-		HELLO: String!
-	}`
-
-	resolverTags := &helloTagResolver{
-		// Hello:           "Unused field!",
-		HelloLower:      "Hello, graphql!",
-		HelloTitle:      "Hello, GraphQL!",
-		HelloUnderscore: "Hello, _!",
-		HelloUpper:      "Hello, GRAPHQL!",
-	}
-
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
-			Schema: graphql.MustParseSchema(sdl, resolverTags, graphql.UseFieldResolvers()),
+			Schema: graphql.MustParseSchema(`
+				type Query {
+					_hello: String!
+					hello: String!
+					Hello: String!
+					HELLO: String!
+				}`,
+				func() interface{} {
+					type helloTagResolver struct {
+						Hello           string
+						HelloUnderscore string `graphql:"_hello"`
+						HelloLower      string `graphql:"hello"`
+						HelloTitle      string `graphql:"Hello"`
+						HelloUpper      string `graphql:"HELLO"`
+					}
+					return &helloTagResolver{
+						Hello:           "This field will not be used during query execution!",
+						HelloLower:      "Hello, graphql!",
+						HelloTitle:      "Hello, GraphQL!",
+						HelloUnderscore: "Hello, _!",
+						HelloUpper:      "Hello, GRAPHQL!",
+					}
+				}(),
+				graphql.UseFieldResolvers()),
 			Query: `
 				{
 					_hello

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -2529,7 +2529,7 @@ func TestInlineFragments(t *testing.T) {
 		},
 
 		{
-			Schema: socialSchema,
+			Schema: graphql.MustParseSchema(social.Schema, &social.Resolver{}, graphql.UseFieldResolvers()),
 			Query: `
 				query {
 					admin(id: "0x01") {
@@ -5633,4 +5633,54 @@ func TestSchemaExtension(t *testing.T) {
 	if name != "awesome" {
 		t.Fatalf(`expected an "awesome" schema directive, got %q`, dirs[0].Name.Name)
 	}
+}
+
+type helloTagResolver struct {
+	// Hello           string
+	HelloUnderscore string `graphql:"_hello"`
+	HelloLower      string `graphql:"hello"`
+	HelloTitle      string `graphql:"Hello"`
+	HelloUpper      string `graphql:"HELLO"`
+}
+
+func TestGraphqlNames(t *testing.T) {
+	t.Parallel()
+
+	sdl := `
+	type Query {
+		_hello: String!
+		hello: String!
+		Hello: String!
+		HELLO: String!
+	}`
+
+	resolverTags := &helloTagResolver{
+		// Hello:           "Unused field!",
+		HelloLower:      "Hello, graphql!",
+		HelloTitle:      "Hello, GraphQL!",
+		HelloUnderscore: "Hello, _!",
+		HelloUpper:      "Hello, GRAPHQL!",
+	}
+
+	gqltesting.RunTests(t, []*gqltesting.Test{
+		{
+			Schema: graphql.MustParseSchema(sdl, resolverTags, graphql.UseFieldResolvers()),
+			Query: `
+				{
+					_hello
+					hello
+					Hello
+					HELLO
+				}
+			`,
+			ExpectedResult: `
+				{
+					"_hello": "Hello, _!",
+				    "hello": "Hello, graphql!",
+				    "Hello": "Hello, GraphQL!",
+				    "HELLO": "Hello, GRAPHQL!"
+				}
+			`,
+		},
+	})
 }

--- a/internal/exec/resolvable/resolvable.go
+++ b/internal/exec/resolvable/resolvable.go
@@ -444,15 +444,19 @@ func (b *execBuilder) makeObjectExec(typeName string, fields ast.FieldsDefinitio
 
 	Fields := make(map[string]*Field)
 	rt := unwrapPtr(resolverType)
-	fieldsCount := fieldCount(rt, map[string]int{})
+	fieldsCount, fieldTagsCount := fieldCount(rt, map[string]int{}, map[string]int{})
 	for _, f := range fields {
 		var fieldIndex []int
 		methodIndex := findMethod(resolverType, f.Name)
 		if b.useFieldResolvers && methodIndex == -1 {
-			if fieldsCount[strings.ToLower(stripUnderscore(f.Name))] > 1 {
+			// If a resolver field is ambiguous thrown an error unless there is exactly one field with the given graphql
+			// reflect tag. In that case use the field with the reflect tag.
+			if fieldsCount[strings.ToLower(stripUnderscore(f.Name))] > 1 && fieldTagsCount[f.Name] != 1 {
 				return nil, fmt.Errorf("%s does not resolve %q: ambiguous field %q", resolverType, typeName, f.Name)
+			} else if fieldTagsCount[f.Name] > 1 {
+				return nil, fmt.Errorf("%s does not resolve %q: multiple fields have a graphql reflect tag %q", resolverType, typeName, f.Name)
 			}
-			fieldIndex = findField(rt, f.Name, []int{})
+			fieldIndex = findField(rt, f.Name, []int{}, fieldTagsCount)
 		}
 		if methodIndex == -1 && len(fieldIndex) == 0 {
 			var hint string
@@ -660,21 +664,27 @@ func findMethod(t reflect.Type, name string) int {
 	return -1
 }
 
-func findField(t reflect.Type, name string, index []int) []int {
+func findField(t reflect.Type, name string, index []int, matchingTagsCount map[string]int) []int {
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
 
 		if field.Type.Kind() == reflect.Struct && field.Anonymous {
-			newIndex := findField(field.Type, name, []int{i})
+			newIndex := findField(field.Type, name, []int{i}, matchingTagsCount)
 			if len(newIndex) > 1 {
 				return append(index, newIndex...)
 			}
 		}
 
 		if gt, ok := field.Tag.Lookup("graphql"); ok {
-			if strings.EqualFold(name, gt) {
+			if name == gt {
 				return append(index, i)
 			}
+		}
+
+		// The current field's tag didn't match, however, if the tag of another field matches,
+		// then skip the name matching until we find the desired field with the correct tag.
+		if matchingTagsCount[name] > 0 {
+			continue
 		}
 
 		if strings.EqualFold(stripUnderscore(name), stripUnderscore(field.Name)) {
@@ -687,31 +697,39 @@ func findField(t reflect.Type, name string, index []int) []int {
 
 // fieldCount helps resolve ambiguity when more than one embedded struct contains fields with the same name.
 // or when a field has a `graphql` reflect tag with the same name as some other field causing name collision.
-func fieldCount(t reflect.Type, count map[string]int) map[string]int {
+func fieldCount(t reflect.Type, count, tagsCount map[string]int) (map[string]int, map[string]int) {
 	if t.Kind() != reflect.Struct {
-		return nil
+		return nil, nil
 	}
 
 	for i := 0; i < t.NumField(); i++ {
 		field := t.Field(i)
-		var fieldName string
-		if gt, ok := field.Tag.Lookup("graphql"); ok && gt != "" {
+		var fieldName, gt string
+		var hasTag bool
+		if gt, hasTag = field.Tag.Lookup("graphql"); hasTag && gt != "" {
 			fieldName = gt
 		} else {
 			fieldName = strings.ToLower(stripUnderscore(field.Name))
 		}
 
 		if field.Type.Kind() == reflect.Struct && field.Anonymous {
-			count = fieldCount(field.Type, count)
+			count, tagsCount = fieldCount(field.Type, count, tagsCount)
 		} else {
 			if _, ok := count[fieldName]; !ok {
 				count[fieldName] = 0
 			}
 			count[fieldName]++
+			if !hasTag {
+				continue
+			}
+			if _, ok := count[gt]; !ok {
+				tagsCount[gt] = 0
+			}
+			tagsCount[gt]++
 		}
 	}
 
-	return count
+	return count, tagsCount
 }
 
 func unwrapNonNull(t ast.Type) (ast.Type, bool) {

--- a/internal/exec/resolvable/resolvable.go
+++ b/internal/exec/resolvable/resolvable.go
@@ -451,10 +451,10 @@ func (b *execBuilder) makeObjectExec(typeName string, fields ast.FieldsDefinitio
 		if b.useFieldResolvers && methodIndex == -1 {
 			// If a resolver field is ambiguous thrown an error unless there is exactly one field with the given graphql
 			// reflect tag. In that case use the field with the reflect tag.
-			if fieldsCount[strings.ToLower(stripUnderscore(f.Name))] > 1 && fieldTagsCount[f.Name] != 1 {
-				return nil, fmt.Errorf("%s does not resolve %q: ambiguous field %q", resolverType, typeName, f.Name)
-			} else if fieldTagsCount[f.Name] > 1 {
+			if fieldTagsCount[f.Name] > 1 {
 				return nil, fmt.Errorf("%s does not resolve %q: multiple fields have a graphql reflect tag %q", resolverType, typeName, f.Name)
+			} else if fieldsCount[strings.ToLower(stripUnderscore(f.Name))] > 1 && fieldTagsCount[f.Name] != 1 {
+				return nil, fmt.Errorf("%s does not resolve %q: ambiguous field %q", resolverType, typeName, f.Name)
 			}
 			fieldIndex = findField(rt, f.Name, []int{}, fieldTagsCount)
 		}

--- a/introspection_test.go
+++ b/introspection_test.go
@@ -11,8 +11,6 @@ import (
 	"github.com/graph-gophers/graphql-go/example/starwars"
 )
 
-var socialSchema = graphql.MustParseSchema(social.Schema, &social.Resolver{}, graphql.UseFieldResolvers())
-
 func TestSchema_ToJSON(t *testing.T) {
 	t.Parallel()
 
@@ -29,7 +27,7 @@ func TestSchema_ToJSON(t *testing.T) {
 	}{
 		{
 			Name: "Social Schema",
-			Args: args{Schema: socialSchema},
+			Args: args{Schema: graphql.MustParseSchema(social.Schema, &social.Resolver{}, graphql.UseFieldResolvers())},
 			Want: want{JSON: mustReadFile("example/social/introspect.json")},
 		},
 		{


### PR DESCRIPTION
This PR allows fields to have a `graphql` reflect tag in order to override the name of the field they resolve. This in turn would allow for field resolvers which are case-sensitive. Currently the library matches fields using case-insensitive matching and the `_` char is insignificant. This violates the official GraphQL spec which states that names should be case-sensitive and the `_` is significant.

With this change, similar to the `json` reflect tag, users can set a `graphql` tag in order to override the name. For example:
```go
type resolver struct {
    Hello string `graphql:"hello"`
}
```
or 
```go
type resolver struct {
    Greeting string `graphql:"hello"`
}
```
The above would allow the users to override the name and use a case-sensitive matching. Both of the above resolvers would resolve a schema like this:
```graphql
type Query {
    hello: String!
}
```

fixes: #593 