### PR TITLE
Apollo subgraph example

### DIFF
--- a/example/apollo_federation/subgraph/index.html
+++ b/example/apollo_federation/subgraph/index.html
@@ -1,0 +1,33 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <title>GraphiQL</title>
+    <style>
+      body {
+        height: 100%;
+        margin: 0;
+        width: 100%;
+        overflow: hidden;
+      }
+      #graphiql {
+        height: 100vh;
+      }
+    </style>
+    <script src="https://unpkg.com/react@17/umd/react.development.js" integrity="sha512-Vf2xGDzpqUOEIKO+X2rgTLWPY+65++WPwCHkX2nFMu9IcstumPsf/uKKRd5prX3wOu8Q0GBylRpsDB26R6ExOg==" crossorigin="anonymous"></script>
+    <script src="https://unpkg.com/react-dom@17/umd/react-dom.development.js" integrity="sha512-Wr9OKCTtq1anK0hq5bY3X/AvDI5EflDSAh0mE9gma+4hl+kXdTJPKZ3TwLMBcrgUeoY0s3dq9JjhCQc7vddtFg==" crossorigin="anonymous"></script>
+    <link rel="stylesheet" href="https://unpkg.com/graphiql@2.3.0/graphiql.min.css" />
+  </head>
+  <body>
+    <div id="graphiql">Loading...</div>
+    <script src="https://unpkg.com/graphiql@2.3.0/graphiql.min.js" type="application/javascript"></script>
+    <script>
+      ReactDOM.render(
+        React.createElement(GraphiQL, {
+          fetcher: GraphiQL.createFetcher({url: '/query'}),
+          defaultEditorToolsVisibility: true,
+        }),
+        document.getElementById('graphiql'),
+      );
+    </script>
+  </body>
+</html>

--- a/example/apollo_federation/subgraph/schema.graphql
+++ b/example/apollo_federation/subgraph/schema.graphql
@@ -1,0 +1,58 @@
+type Query {
+    post(id: ID!): Post
+}
+
+type Post @key(fields: "id") {
+    id: ID!
+    title: String!
+}
+
+#
+# Apollo Federation schema
+#
+
+# TODO: generate dynamically
+union _Entity = Post
+
+scalar _Any
+scalar FieldSet
+scalar link__Import
+
+enum link__Purpose {
+    """
+    `SECURITY` features provide metadata necessary to securely resolve fields.
+    """
+    SECURITY
+
+    """
+    `EXECUTIO`N features provide metadata necessary for operation execution.
+    """
+    EXECUTION
+}
+
+type _Service {
+    sdl: String!
+}
+
+extend type Query {
+    _entities(representations: [_Any!]!): [_Entity]!
+    _service: _Service!
+}
+
+directive @external on FIELD_DEFINITION | OBJECT
+directive @requires(fields: FieldSet!) on FIELD_DEFINITION
+directive @provides(fields: FieldSet!) on FIELD_DEFINITION
+directive @key(fields: FieldSet!, resolvable: Boolean = true) repeatable on OBJECT | INTERFACE
+directive @link(url: String!, as: String, for: link__Purpose, import: [link__Import]) repeatable on SCHEMA
+directive @shareable repeatable on OBJECT | FIELD_DEFINITION
+directive @inaccessible on FIELD_DEFINITION | OBJECT | INTERFACE | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @tag(name: String!) repeatable on FIELD_DEFINITION | INTERFACE | OBJECT | UNION | ARGUMENT_DEFINITION | SCALAR | ENUM | ENUM_VALUE | INPUT_OBJECT | INPUT_FIELD_DEFINITION
+directive @override(from: String!) on FIELD_DEFINITION
+directive @composeDirective(name: String!) repeatable on SCHEMA
+directive @interfaceObject on OBJECT
+
+# This definition is required only for libraries that don't support
+# GraphQL's built-in `extend` keyword
+directive @extends on OBJECT | INTERFACE
+
+extend schema @link(url: "https://specs.apollo.dev/federation/v2.0", import: ["@key"])

--- a/example/apollo_federation/subgraph/server.go
+++ b/example/apollo_federation/subgraph/server.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	_ "embed"
+	"encoding/json"
+	"fmt"
+	"log"
+	"net/http"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/relay"
+)
+
+//go:embed index.html
+var page []byte
+
+//go:embed schema.graphql
+var sdl string
+
+type entitiesFunc func(args struct{ Representations []Any }) ([]*Entity, error)
+
+type resolver struct {
+	posts map[graphql.ID]Post
+
+	Entities entitiesFunc   `graphql:"_entities"`
+	Service  func() Service `graphql:"_service"`
+}
+
+func (r *resolver) Post(args struct{ ID graphql.ID }) (*Post, error) {
+	p, ok := r.posts[args.ID]
+	if !ok {
+		return nil, fmt.Errorf("post with id %q not found", args.ID)
+	}
+	return &p, nil
+}
+
+type Post struct {
+	ID    graphql.ID `json:"id"`
+	Title string     `json:"title"`
+}
+
+type Any struct {
+	TypeName string `json:"__typename"`
+	Keys     map[string]interface{}
+}
+
+func (a *Any) UnmarshalJSON(d []byte) error {
+	m := map[string]interface{}{}
+	err := json.Unmarshal(d, &m)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal keys: %w", err)
+	}
+	delete(m, "__typename") // remove duplicate key
+	(*a).Keys = m
+
+	var temp struct {
+		T string `json:"__typename"`
+	}
+	err = json.Unmarshal(d, &temp)
+	if err != nil {
+		return fmt.Errorf("failed to unmarshal typename: %w", err)
+	}
+	a.TypeName = temp.T
+	return nil
+}
+
+func (Any) ImplementsGraphQLType(name string) bool {
+	return name == "_Any"
+}
+
+func (a *Any) UnmarshalGraphQL(input interface{}) error {
+	var data []byte
+	switch val := input.(type) {
+	case string:
+		v := fmt.Sprint(val) // this line turns all the `\"` into `"`
+		data = []byte(v)
+	default:
+		return fmt.Errorf("want string input, got %T", input)
+	}
+
+	return json.Unmarshal(data, a)
+}
+
+func entities(posts map[graphql.ID]Post) entitiesFunc {
+	return func(args struct{ Representations []Any }) ([]*Entity, error) {
+		var res []*Entity
+		for _, rep := range args.Representations {
+			switch rep.TypeName {
+			case "Post":
+				val, found := rep.Keys["id"]
+				if !found {
+					return nil, fmt.Errorf("required key id was not provided")
+				}
+				id, ok := val.(string)
+				if !ok {
+					return nil, fmt.Errorf("expected a string, got %T", val)
+				}
+				p, ok := posts[graphql.ID(id)]
+				if !ok {
+					return nil, fmt.Errorf("post with id %q, not found", id)
+				}
+				res = append(res, &Entity{entity: &p})
+
+			default:
+				return nil, fmt.Errorf("unexpected representation type %q", rep.TypeName)
+			}
+		}
+
+		return res, nil
+	}
+}
+
+type Entity struct {
+	entity interface{}
+}
+
+func (e *Entity) ToPost() (*Post, bool) {
+	p, ok := e.entity.(*Post)
+	return p, ok
+}
+
+func service(s string) func() Service {
+	return func() Service {
+		return Service{SDL: s}
+	}
+}
+
+type Service struct {
+	SDL string
+}
+
+func main() {
+	// If you want to generate dynamically all the entities which have the `key` directive
+	//
+	//   s := graphql.MustParseSchema(sdl, nil)
+	//   ast := s.AST()
+	//   var ent []string
+	//   for _, o := range ast.Objects {
+	//       for _, d := range o.Directives {
+	//           if d.Name.Name == "key" {
+	//               ent = append(ent, o.Name)
+	//               break
+	//           }
+	//       }
+	//   }
+	//
+	// ent contains all the type names.
+
+	posts := map[graphql.ID]Post{
+		graphql.ID("1"): {ID: graphql.ID("1"), Title: "Title 1"},
+		graphql.ID("2"): {ID: graphql.ID("2"), Title: "Title 2"},
+		graphql.ID("3"): {ID: graphql.ID("3"), Title: "Title 3"},
+	}
+
+	r := &resolver{
+		posts:    posts,
+		Entities: entities(posts),
+		Service:  service(sdl),
+	}
+	opts := []graphql.SchemaOpt{graphql.UseStringDescriptions(), graphql.UseFieldResolvers()}
+	schema := graphql.MustParseSchema(sdl, r, opts...)
+	http.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) { w.Write(page) })
+	http.Handle("/query", &relay.Handler{Schema: schema})
+
+	log.Fatal(http.ListenAndServe(":8080", nil))
+}


### PR DESCRIPTION
fixes: #602 
fixes: #528 

In order to test:
1. Pull the `master` branch
2. Run `cd example/apollo_federation/subgraph`
3. Run `go run server.go`
4. Test with a query like this:
   ```graphql
    query subgraph{
      post(id: "3") {
        id
        title
      }
      _entities(representations: ["{\"__typename\": \"Post\", \"id\": \"3\"}"]) {
        __typename
        ... on Post {
          id
          title
        }
      }
      _service {
        sdl
      }
    }
   ```


<img width="1728" alt="Screenshot 2023-03-02 at 14 16 47" src="https://user-images.githubusercontent.com/441740/222426646-4079dda0-c89b-4daf-bc10-a1d4749fac73.png">