### PR TITLE
Directives: Allow Argument Validation

### DIFF
--- a/directives/visitor.go
+++ b/directives/visitor.go
@@ -28,3 +28,8 @@ type ResolverInterceptor interface {
 type Validator interface {
 	Validate(ctx context.Context, args interface{}) error
 }
+
+// InputValidator directive which executes before anything is resolved, allowing the request to be rejected.
+type InputValidator interface {
+	ValidateArg(ctx context.Context, value interface{}) error
+}

--- a/directives/visitor.go
+++ b/directives/visitor.go
@@ -10,6 +10,7 @@ import (
 //
 // See the graphql.Directives() Schema Option.
 type Directive interface {
+	AllowLocation(l string) bool
 	ImplementsDirective() string
 }
 
@@ -26,10 +27,5 @@ type ResolverInterceptor interface {
 
 // Validator directive which executes before anything is resolved, allowing the request to be rejected.
 type Validator interface {
-	Validate(ctx context.Context, args interface{}) error
-}
-
-// InputValidator directive which executes before anything is resolved, allowing the request to be rejected.
-type InputValidator interface {
-	ValidateArg(ctx context.Context, value interface{}) error
+	Validate(ctx context.Context, typ, args interface{}) error
 }

--- a/example/directives/authorization/README.md
+++ b/example/directives/authorization/README.md
@@ -80,7 +80,7 @@ $ curl 'http://localhost:8080/query' \
        return "hasRole"
    }
 
-    func (h *HasRoleDirective) Validate(ctx context.Context, _ interface{}) error {
+    func (h *HasRoleDirective) Validate(ctx context.Context, _, _ interface{}) error {
         u, ok := user.FromContext(ctx)
         if !ok {
             return fmt.Errorf("user not provided in context")

--- a/example/directives/authorization/authorization.go
+++ b/example/directives/authorization/authorization.go
@@ -31,11 +31,15 @@ type HasRoleDirective struct {
 	Role string
 }
 
+func (h *HasRoleDirective) AllowLocation(l string) bool {
+	return l == "FIELD_DEFINITION"
+}
+
 func (h *HasRoleDirective) ImplementsDirective() string {
 	return "hasRole"
 }
 
-func (h *HasRoleDirective) Validate(ctx context.Context, _ interface{}) error {
+func (h *HasRoleDirective) Validate(ctx context.Context, _, _ interface{}) error {
 	u, ok := user.FromContext(ctx)
 	if !ok {
 		return fmt.Errorf("user not provided in cotext")

--- a/example_directives_test.go
+++ b/example_directives_test.go
@@ -19,11 +19,15 @@ type HasRoleDirective struct {
 	Role string
 }
 
+func (h *HasRoleDirective) AllowLocation(l string) bool {
+	return l == "FIELD_DEFINITION"
+}
+
 func (h *HasRoleDirective) ImplementsDirective() string {
 	return "hasRole"
 }
 
-func (h *HasRoleDirective) Validate(ctx context.Context, _ interface{}) error {
+func (h *HasRoleDirective) Validate(ctx context.Context, _, _ interface{}) error {
 	if ctx.Value(RoleKey) != h.Role {
 		return fmt.Errorf("access denied, role %q required", h.Role)
 	}
@@ -44,6 +48,10 @@ func (_ *WithNullableArgumentDirective) ImplementsDirective() string {
 }
 
 type UpperDirective struct{}
+
+func (d *UpperDirective) AllowLocation(l string) bool {
+	return l == "FIELD_DEFINITION"
+}
 
 func (d *UpperDirective) ImplementsDirective() string {
 	return "upper"

--- a/example_directives_test.go
+++ b/example_directives_test.go
@@ -39,7 +39,11 @@ type WithNullableArgumentDirective struct {
 	ANullableArgument *string
 }
 
-func (_ *WithNullableArgumentDirective) Validate(_ context.Context, _ interface{}) error {
+func (_ *WithNullableArgumentDirective) AllowLocation(l string) bool {
+	return l == "FIELD_DEFINITION"
+}
+
+func (_ *WithNullableArgumentDirective) Validate(_ context.Context, _, _ interface{}) error {
 	return nil
 }
 

--- a/internal/exec/validate.go
+++ b/internal/exec/validate.go
@@ -43,7 +43,7 @@ func validateFieldSelection(ctx context.Context, s *resolvable.Schema, f *fieldT
 		args = f.field.PackedArgs.Interface()
 	}
 
-	vErrs := f.field.Validate(ctx, args)
+	vErrs := f.field.Validate(ctx, f.field.Args, args)
 
 	if l := len(vErrs); l > 0 {
 		errs := make([]*errors.QueryError, l)

--- a/internal/exec/validate.go
+++ b/internal/exec/validate.go
@@ -43,7 +43,8 @@ func validateFieldSelection(ctx context.Context, s *resolvable.Schema, f *fieldT
 		args = f.field.PackedArgs.Interface()
 	}
 
-	vErrs := f.field.Validate(ctx, f.field.Args, args)
+	vErrs := f.field.ValidateArgs(ctx, f.field.Args)
+	vErrs = append(vErrs, f.field.Validate(ctx, args)...)
 
 	if l := len(vErrs); l > 0 {
 		errs := make([]*errors.QueryError, l)


### PR DESCRIPTION
Proof of concept for implementing directive validation for field arguments. Validation for many cases applies better on the arguments than it does against the field itself.