### PR TITLE
Supporting two new fields for __InputValue

### DIFF
--- a/example/social/introspect.json
+++ b/example/social/introspect.json
@@ -1052,6 +1052,34 @@
               "name": "String",
               "ofType": null
             }
+          },
+          {
+            "args": [],
+            "deprecationReason": null,
+            "description": null,
+            "isDeprecated": false,
+            "name": "isDeprecated",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            }
+          },
+          {
+            "args": [],
+            "deprecationReason": null,
+            "description": null,
+            "isDeprecated": false,
+            "name": "deprecationReason",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            }
           }
         ],
         "inputFields": null,

--- a/example/starwars/introspect.json
+++ b/example/starwars/introspect.json
@@ -1694,6 +1694,34 @@
               "name": "String",
               "ofType": null
             }
+          },
+          {
+            "args": [],
+            "deprecationReason": null,
+            "description": null,
+            "isDeprecated": false,
+            "name": "isDeprecated",
+            "type": {
+              "kind": "NON_NULL",
+              "name": null,
+              "ofType": {
+                "kind": "SCALAR",
+                "name": "Boolean",
+                "ofType": null
+              }
+            }
+          },
+          {
+            "args": [],
+            "deprecationReason": null,
+            "description": null,
+            "isDeprecated": false,
+            "name": "deprecationReason",
+            "type": {
+              "kind": "SCALAR",
+              "name": "String",
+              "ofType": null
+            }
           }
         ],
         "inputFields": null,

--- a/internal/schema/meta.go
+++ b/internal/schema/meta.go
@@ -148,6 +148,8 @@ var metaSrc = `
 		type: __Type!
 		# A GraphQL-formatted string representing the default value for this input value.
 		defaultValue: String
+		isDeprecated: Boolean!
+		deprecationReason: String
 	}
 
 	# A GraphQL Schema defines the capabilities of a GraphQL server. It exposes all

--- a/introspection/introspection.go
+++ b/introspection/introspection.go
@@ -270,6 +270,19 @@ func (r *InputValue) DefaultValue() *string {
 	return &s
 }
 
+func (r *InputValue) IsDeprecated() bool {
+	return r.value.Directives.Get("deprecated") != nil
+}
+
+func (r *InputValue) DeprecationReason() *string {
+	d := r.value.Directives.Get("deprecated")
+	if d == nil {
+		return nil
+	}
+	reason := d.Arguments.MustGet("reason").Deserialize(nil).(string)
+	return &reason
+}
+
 type EnumValue struct {
 	value *ast.EnumValueDefinition
 }


### PR DESCRIPTION
2 new fields were added in the new version of the specification for InputValue.
[spec](https://spec.graphql.org/draft/#sec-The-__InputValue-Type)

For example, Apollo client for Kotlin is already requesting these fields: https://github.com/apollographql/apollo-kotlin/blob/v3.7.5/libraries/apollo-tooling/src/main/kotlin/com/apollographql/apollo3/tooling/SchemaDownloader.kt#L260 
