### PR TITLE
Support for Setting Defaults on Optional Input Values

### DIFF
--- a/example/starwars/introspect.json
+++ b/example/starwars/introspect.json
@@ -928,17 +928,23 @@
           {
             "args": [
               {
-                "defaultValue": null,
+                "defaultValue": "\"\"",
                 "description": null,
                 "name": "text",
                 "type": {
-                  "kind": "NON_NULL",
-                  "name": null,
-                  "ofType": {
-                    "kind": "SCALAR",
-                    "name": "String",
-                    "ofType": null
-                  }
+                  "kind": "SCALAR",
+                  "name": "String",
+                  "ofType": null
+                }
+              },
+              {
+                "defaultValue": "0",
+                "description": null,
+                "name": "mass",
+                "type": {
+                  "kind": "SCALAR",
+                  "name": "Float",
+                  "ofType": null
                 }
               }
             ],

--- a/example/starwars/starwars.go
+++ b/example/starwars/starwars.go
@@ -21,7 +21,7 @@ var Schema = `
 	type Query {
 		hero(episode: Episode = NEWHOPE): Character
 		reviews(episode: Episode!): [Review]!
-		search(text: String!): [SearchResult]!
+		search(text: String = "", mass: Float = 0): [SearchResult]!
 		character(id: ID!): Character
 		droid(id: ID!): Droid
 		human(id: ID!): Human
@@ -307,20 +307,28 @@ func (r *QueryResolver) Reviews(args struct{ Episode string }) []*reviewResolver
 	return l
 }
 
-func (r *QueryResolver) Search(args struct{ Text string }) []*searchResultResolver {
+func (r *QueryResolver) Search(args struct {
+	Text *string
+	Mass *float64
+}) []*searchResultResolver {
 	var l []*searchResultResolver
+
+	if args.Text == nil || args.Mass == nil {
+		return l
+	}
+
 	for _, h := range humans {
-		if strings.Contains(h.Name, args.Text) {
+		if strings.Contains(h.Name, *args.Text) && float64(h.Mass) >= *args.Mass {
 			l = append(l, &searchResultResolver{&humanResolver{h}})
 		}
 	}
 	for _, d := range droids {
-		if strings.Contains(d.Name, args.Text) {
+		if strings.Contains(d.Name, *args.Text) {
 			l = append(l, &searchResultResolver{&droidResolver{d}})
 		}
 	}
 	for _, s := range starships {
-		if strings.Contains(s.Name, args.Text) {
+		if strings.Contains(s.Name, *args.Text) {
 			l = append(l, &searchResultResolver{&starshipResolver{s}})
 		}
 	}

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -1747,6 +1747,122 @@ func TestArguments(t *testing.T) {
 				}
 			`,
 		},
+		{
+			Schema: starwarsSchema,
+			Query: `
+				{
+					search(text: null) {
+						... on Human {
+							id
+						}
+						... on Droid {
+							name
+						}
+						... on Starship {
+							name
+						}
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+					"search": []
+				}
+			`,
+		},
+		{
+			Schema: starwarsSchema,
+			Query: `
+				{
+					search {
+						... on Human {
+							id
+						}
+						... on Droid {
+							name
+						}
+						... on Starship {
+							name
+						}
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+					"search": [
+						{ "id": "1000" },
+						{ "id": "1001" },
+						{ "id": "1002" },
+						{ "id": "1003" },
+						{ "id": "1004" },
+						{ "name": "C-3PO" },
+						{ "name":"R2-D2" },
+						{ "name": "Millennium Falcon" },
+						{ "name": "X-Wing" },
+						{ "name": "TIE Advanced x1" },
+						{ "name": "Imperial shuttle" }
+					]
+				} `,
+		},
+		{
+			Schema: starwarsSchema,
+			Query: `
+				{
+					search(mass: 1) {
+						... on Human {
+							id
+						}
+						... on Droid {
+							name
+						}
+						... on Starship {
+							name
+						}
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+					"search": [
+						{ "id": "1000" },
+						{ "id": "1001" },
+						{ "id": "1002" },
+						{ "id": "1003" },
+						{ "name": "C-3PO" },
+						{ "name":"R2-D2" },
+						{ "name": "Millennium Falcon" },
+						{ "name": "X-Wing" },
+						{ "name": "TIE Advanced x1" },
+						{ "name": "Imperial shuttle" }
+					]
+				}
+			`,
+		},
+		{
+			Schema: starwarsSchema,
+			Query: `
+				{
+					search(text: "1", mass: 1) {
+						... on Human {
+							id
+						}
+						... on Droid {
+							name
+						}
+						... on Starship {
+							name
+						}
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+					"search": [
+						{ "name": "TIE Advanced x1" }
+					]
+				}
+			`,
+		},
 	})
 }
 


### PR DESCRIPTION
Fix https://github.com/graph-gophers/graphql-go/issues/429 

I have resolved the issue that prevented the inclusion of default values in optional fields. With this change, it's now possible to specify default values for optional fields, and when null is explicitly passed, it is treated as `nil`, not the default value, within the resolver.

In order to implement this change, I modified the packer code. I added a conditional branch for when the type passed to unmarshalInput is `reflect.Pointer`, ensuring it is properly unmarshalled. If this kind of conditional branching is inappropriate according to the design intentions of the packer, please leave a comment.

Also, I've adjusted the `starwars` schema for testing this logic. If this method of testing is deemed inappropriate, please provide feedback.