### PR TITLE
Support treating Zero Values as Null

### DIFF
--- a/internal/exec/exec.go
+++ b/internal/exec/exec.go
@@ -266,10 +266,16 @@ func (r *Request) execSelectionSet(ctx context.Context, sels []selected.Selectio
 		// function to resolve the field returned null or because an error occurred),
 		// add an error to the "errors" list in the response.
 		if nonNull {
-			err := errors.Errorf("graphql: got nil for non-null %q", t)
+			err := errors.Errorf("got nil for non-null %q", t)
 			err.Path = path.toSlice()
 			r.AddError(err)
 		}
+		out.WriteString("null")
+		return
+	}
+
+	// Nullable zero values = null
+	if s.AllowNullableZeroValues() && !nonNull && reflect.DeepEqual(resolver.Interface(), reflect.Zero(resolver.Type()).Interface()) {
 		out.WriteString("null")
 		return
 	}

--- a/internal/exec/resolvable/meta.go
+++ b/internal/exec/resolvable/meta.go
@@ -16,11 +16,17 @@ type Meta struct {
 	Schema        *Object
 	Type          *Object
 	Service       *Object
+
+	allowNullableZeroValues bool
 }
 
-func newMeta(s *ast.Schema) *Meta {
+func (m *Meta) AllowNullableZeroValues() bool {
+	return m.allowNullableZeroValues
+}
+
+func newMeta(s *ast.Schema, allowNullableZeroValues bool) *Meta {
 	var err error
-	b := newBuilder(s, nil, false)
+	b := newBuilder(s, nil, false, allowNullableZeroValues)
 
 	metaSchema := s.Types["__Schema"].(*ast.ObjectTypeDefinition)
 	so, err := b.makeObjectExec(metaSchema.Name, metaSchema.Fields, nil, nil, false, reflect.TypeOf(&introspection.Schema{}))
@@ -68,5 +74,7 @@ func newMeta(s *ast.Schema) *Meta {
 		FieldType:     fieldType,
 		Schema:        so,
 		Type:          t,
+
+		allowNullableZeroValues: allowNullableZeroValues,
 	}
 }

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -458,7 +458,6 @@ func parseObjectDef(l *common.Lexer) *ast.ObjectTypeDefinition {
 	l.ConsumeToken('}')
 
 	return object
-
 }
 
 func parseInterfaceDef(l *common.Lexer) *ast.InterfaceTypeDefinition {
@@ -528,6 +527,7 @@ func parseEnumDef(l *common.Lexer) *ast.EnumTypeDefinition {
 	l.ConsumeToken('}')
 	return enum
 }
+
 func parseDirectiveDef(l *common.Lexer) *ast.DirectiveDefinition {
 	l.ConsumeToken('@')
 	loc := l.Location()


### PR DESCRIPTION
This PR adds optional support for treating zero values as null. We primarily use this to allow us to seamlessly return Protobuf generated types from our resolvers, avoiding the need to implement schema-conforming translation types for output. This saves us a tremendous amount of boilerplate.

We have been running with this fork in production for quite some time (over 4 years!), which I have been shepherding and keeping up to date all this time ([see here](https://github.com/graph-gophers/graphql-go/compare/master...digits:graphql-go:digits) for our working branch).

If users do not specify `AllowNullableZeroValues`, the default is to preserve existing behavior.