### PR TITLE
refactored execFieldSelection to return multiple errors on the same path if err instance of `interface { Unwrap() []error }`

### DIFF
--- a/internal/exec/selected/selected.go
+++ b/internal/exec/selected/selected.go
@@ -23,9 +23,9 @@ type Request struct {
 	AllowIntrospection bool
 }
 
-func (r *Request) AddError(err *errors.QueryError) {
+func (r *Request) AddError(errs ...*errors.QueryError) {
 	r.Mu.Lock()
-	r.Errs = append(r.Errs, err)
+	r.Errs = append(r.Errs, errs...)
 	r.Mu.Unlock()
 }
 


### PR DESCRIPTION
I opened this discussion, [but thou](https://github.com/graph-gophers/graphql-go/discussions/623), but thought it might be useful to provide the code change being proposed.  This allows joined errors to be returned as:

```
{
  "errors": [
    {
      "message": "You cannot do this because of X.",
      "path": [
        "field"
      ],
      "extensions": {
        "code": "failed_x"
      }
    },
    {
      "message": "You cannot do this because of Y.",
      "path": [
        "field"
      ],
      "extensions": {
        "code": "failed_y"
      }
    },
    {
      "message": "You cannot do this because of Z.",
      "path": [
        "field"
      ],
      "extensions": {
        "code": "failed_z"
      }
    }
  ],
  "data": {
    "field": null
  }
}
```

rather than being using extensions and a more nested:

```
{
  "errors": [
    {
      "message": "failed_x: You cannot do this because of X., failed_y: You cannot do this because of Y., failed_z: You cannot do this because of Z.",
      "path": [
        "field"
      ],
      "extensions": {
        "details": [
          {
            "code": "failed_x",
            "message": "You cannot do this because of X."
          },
          {
            "code": "failed_y",
            "message": "You cannot do this because of Y."
          },
          {
            "code": "failed_z",
            "message": "You cannot do this because of Z."
          }
        ]
      }
    }
  ],
  "data": {
    "field": null
  }
}
```