### PR TITLE
Fixed goroutine leak in subscriptions

### DIFF
--- a/subscriptions.go
+++ b/subscriptions.go
@@ -76,10 +76,14 @@ func (s *Schema) subscribe(ctx context.Context, queryString string, operationNam
 	responses := r.Subscribe(ctx, res, op)
 	c := make(chan interface{})
 	go func() {
+	Loop:
 		for resp := range responses {
-			c <- &Response{
-				Data:   resp.Data,
-				Errors: resp.Errors,
+			select {
+			case c <- &Response{Data: resp.Data, Errors: resp.Errors}:
+				continue
+
+			case <-ctx.Done():
+				break Loop
 			}
 		}
 		close(c)


### PR DESCRIPTION
We have goroutine leak here if events will happen in following order:
* In our goroutine we've read a new message from `responses` channel, but didn't send it to `c` channel yet
* Subscriber got disconnected, which forced context to close
* After context was closed, goroutine in `graphql-ws-transport` stopped reading `c` channel (https://github.com/graph-gophers/graphql-transport-ws/blob/master/graphqlws/internal/connection/connection.go#L233-L235)
* Now, back to our goroutine, we're trying to send message to `c` channel. But since that channel is read by no one now, we stuck here forever.

Described situation may seem rare, but in our project with hundreds events per second that leak happened rather often. We tested this fix in production environment and it solved the problem. 

@pavelnikolov 