### PR TITLE
Fix Flaky Order of Directive Validation

### DIFF
--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -698,7 +698,15 @@ func validateDirectives(c *opContext, loc string, directives ast.DirectiveList) 
 		)
 	}
 
-	for n := range directiveNames {
+	// Iterating in the declared order, rather than using the directiveNames ordering which is random
+	for _, d := range directives {
+		n := d.Name.Name
+
+		ds := directiveNames[n]
+		if len(ds) <= 1 {
+			continue
+		}
+
 		dd, ok := c.schema.Directives[n]
 		if !ok {
 			// Invalid directive will have been flagged already
@@ -706,11 +714,6 @@ func validateDirectives(c *opContext, loc string, directives ast.DirectiveList) 
 		}
 
 		if dd.Repeatable {
-			continue
-		}
-
-		ds := directiveNames[n]
-		if len(ds) <= 1 {
 			continue
 		}
 
@@ -722,6 +725,9 @@ func validateDirectives(c *opContext, loc string, directives ast.DirectiveList) 
 				return fmt.Sprintf("The directive %q can only be used once at this location.", "@"+n)
 			})
 		}
+
+		// drop the name from the set to prevent the same errors being re-added for duplicates
+		delete(directiveNames, n)
 	}
 }
 


### PR DESCRIPTION
Due to the use of a map behind the directiveNames, iterating over them is done in random order. When there are multiple directives that are duplicated, the order of errors can change between runs, and be inconsistent with the expecated result.

This issue is also the case for other types which use a map to validate names, however the other cases currently have no tests validating this condition. To resolve the immediate issue of flaky tests, addressing just the directives case for now. Resolution of other cases should be accompanied by tests exposing the issue.