### PR TITLE
Refactor Validation Tests JSON

### DIFF
--- a/internal/validation/testdata/export.ts
+++ b/internal/validation/testdata/export.ts
@@ -1,4 +1,5 @@
 import * as fs from 'node:fs';
+import { createHash } from 'crypto';
 import { printSchema } from 'graphql/src/utilities/printSchema.js';
 import { schemas, testCases } from 'graphql/src/validation/__tests__/harness.js';
 
@@ -36,10 +37,31 @@ import 'graphql/src/validation/__tests__/VariablesAreInputTypesRule-test.js';
 // require('graphql/src/validation/__tests__/VariablesDefaultValueAllowed-test');
 import 'graphql/src/validation/__tests__/VariablesInAllowedPositionRule-test.js';
 
-let output = JSON.stringify({
-	schemas: schemas().map(s => printSchema(s)),
-	tests: testCases(),
-}, null, 2)
+// Schema index in the source array can be unstable, as its dependent on the order they are used in the registered test
+// files. The SHA256 of the schema will change if there are any changes to the content, but is a better reference than
+// the schema indexes all changing when a new schema is inserted.
+let s = schemas().map(s => {
+  const sdl = printSchema(s)
+  const id = createHash('sha256').update(sdl).digest('base64');
+  const v: { id: string; sdl: string; } = {id: id, sdl: sdl};
+  return v;
+});
+
+const tests = testCases().map(c => {
+  const schema = s[c.schema];
+  return {
+    name: c.name,
+	  rule: c.rule,
+	  schema: schema.id,
+	  query: c.query,
+	  errors: c.errors,
+  }
+});
+
+// Order based on the schema string to provide semi-stable ordering
+s = s.sort((a, b) => a.sdl.localeCompare(b.sdl));
+
+let output = JSON.stringify({schemas: s, tests: tests}, null, 2)
 output = output.replace(/ Did you mean to use an inline fragment on [^?]*\?/g, '');
 // Ignore suggested types in errors, which graphql-go does not currently produce.
 output = output.replace(/ Did you mean \\"[A-Z].*\"\?/g, '');

--- a/internal/validation/testdata/tests.json
+++ b/internal/validation/testdata/tests.json
@@ -1,62 +1,89 @@
 {
   "schemas": [
-    "interface Pet {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\nunion CatOrDog = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\ntype Query {\n  human: Human\n}",
-    "schema {\n  query: QueryRoot\n}\n\ndirective @onField on FIELD\n\ninterface Mammal {\n  mother: Mammal\n  father: Mammal\n}\n\ninterface Pet {\n  name(surname: Boolean): String\n}\n\ninterface Canine implements Mammal {\n  name(surname: Boolean): String\n  mother: Canine\n  father: Canine\n}\n\nenum DogCommand {\n  SIT\n  HEEL\n  DOWN\n}\n\ntype Dog implements Pet & Mammal & Canine {\n  name(surname: Boolean): String\n  nickname: String\n  barkVolume: Int\n  barks: Boolean\n  doesKnowCommand(dogCommand: DogCommand): Boolean\n  isHouseTrained(atOtherHomes: Boolean = true): Boolean\n  isAtLocation(x: Int, y: Int): Boolean\n  mother: Dog\n  father: Dog\n}\n\ntype Cat implements Pet {\n  name(surname: Boolean): String\n  nickname: String\n  meows: Boolean\n  meowsVolume: Int\n  furColor: FurColor\n}\n\nunion CatOrDog = Cat | Dog\n\ntype Human {\n  name(surname: Boolean): String\n  pets: [Pet]\n  relatives: [Human]!\n}\n\nenum FurColor {\n  BROWN\n  BLACK\n  TAN\n  SPOTTED\n  NO_FUR\n  UNKNOWN\n}\n\ninput ComplexInput {\n  requiredField: Boolean!\n  nonNullField: Boolean! = false\n  intField: Int\n  stringField: String\n  booleanField: Boolean\n  stringListField: [String]\n}\n\ninput OneOfInput @oneOf {\n  stringField: String\n  intField: Int\n}\n\ntype ComplicatedArgs {\n  intArgField(intArg: Int): String\n  nonNullIntArgField(nonNullIntArg: Int!): String\n  stringArgField(stringArg: String): String\n  booleanArgField(booleanArg: Boolean): String\n  enumArgField(enumArg: FurColor): String\n  floatArgField(floatArg: Float): String\n  idArgField(idArg: ID): String\n  stringListArgField(stringListArg: [String]): String\n  stringListNonNullArgField(stringListNonNullArg: [String!]): String\n  complexArgField(complexArg: ComplexInput): String\n  oneOfArgField(oneOfArg: OneOfInput): String\n  multipleReqs(req1: Int!, req2: Int!): String\n  nonNullFieldWithDefault(arg: Int! = 0): String\n  multipleOpts(opt1: Int = 0, opt2: Int = 0): String\n  multipleOptAndReq(req1: Int!, req2: Int!, opt1: Int = 0, opt2: Int = 0): String\n}\n\ntype QueryRoot {\n  human(id: ID): Human\n  dog: Dog\n  cat: Cat\n  pet: Pet\n  catOrDog: CatOrDog\n  complicatedArgs: ComplicatedArgs\n}",
-    "directive @onQuery on QUERY\n\ndirective @onMutation on MUTATION\n\ndirective @onSubscription on SUBSCRIPTION\n\ndirective @onField on FIELD\n\ndirective @onFragmentDefinition on FRAGMENT_DEFINITION\n\ndirective @onFragmentSpread on FRAGMENT_SPREAD\n\ndirective @onInlineFragment on INLINE_FRAGMENT\n\ndirective @onVariableDefinition on VARIABLE_DEFINITION\n\ntype Query {\n  dummy: String\n}",
-    "type Query {\n  foo: String\n}",
-    "type Query {\n  someField(a: String, b: String): String\n}",
-    "input SomeInput {\n  a: String\n  b: String\n}\n\ntype Query {\n  someField(arg: SomeInput): String\n}",
-    "interface SomeBox {\n  deepBox: SomeBox\n  unrelatedField: String\n}\n\ntype StringBox implements SomeBox {\n  scalar: String\n  deepBox: StringBox\n  unrelatedField: String\n  listStringBox: [StringBox]\n  stringBox: StringBox\n  intBox: IntBox\n}\n\ntype IntBox implements SomeBox {\n  scalar: Int\n  deepBox: IntBox\n  unrelatedField: String\n  listStringBox: [StringBox]\n  stringBox: StringBox\n  intBox: IntBox\n}\n\ninterface NonNullStringBox1 {\n  scalar: String!\n}\n\ntype NonNullStringBox1Impl implements SomeBox & NonNullStringBox1 {\n  scalar: String!\n  unrelatedField: String\n  deepBox: SomeBox\n}\n\ninterface NonNullStringBox2 {\n  scalar: String!\n}\n\ntype NonNullStringBox2Impl implements SomeBox & NonNullStringBox2 {\n  scalar: String!\n  unrelatedField: String\n  deepBox: SomeBox\n}\n\ntype Connection {\n  edges: [Edge]\n}\n\ntype Edge {\n  node: Node\n}\n\ntype Node {\n  id: ID\n  name: String\n}\n\ntype Query {\n  someBox: SomeBox\n  connection: Connection\n}",
-    "type Foo {\n  constructor: String\n}\n\ntype Query {\n  foo: Foo\n}",
-    "schema {\n  query: QueryRoot\n}\n\ndirective @onField on FIELD\n\ndirective @directive on FIELD | FRAGMENT_DEFINITION\n\ndirective @directiveA on FIELD | FRAGMENT_DEFINITION\n\ndirective @directiveB on FIELD | FRAGMENT_DEFINITION\n\ndirective @repeatable repeatable on FIELD | FRAGMENT_DEFINITION\n\ninterface Mammal {\n  mother: Mammal\n  father: Mammal\n}\n\ninterface Pet {\n  name(surname: Boolean): String\n}\n\ninterface Canine implements Mammal {\n  name(surname: Boolean): String\n  mother: Canine\n  father: Canine\n}\n\nenum DogCommand {\n  SIT\n  HEEL\n  DOWN\n}\n\ntype Dog implements Pet & Mammal & Canine {\n  name(surname: Boolean): String\n  nickname: String\n  barkVolume: Int\n  barks: Boolean\n  doesKnowCommand(dogCommand: DogCommand): Boolean\n  isHouseTrained(atOtherHomes: Boolean = true): Boolean\n  isAtLocation(x: Int, y: Int): Boolean\n  mother: Dog\n  father: Dog\n}\n\ntype Cat implements Pet {\n  name(surname: Boolean): String\n  nickname: String\n  meows: Boolean\n  meowsVolume: Int\n  furColor: FurColor\n}\n\nunion CatOrDog = Cat | Dog\n\ntype Human {\n  name(surname: Boolean): String\n  pets: [Pet]\n  relatives: [Human]!\n}\n\nenum FurColor {\n  BROWN\n  BLACK\n  TAN\n  SPOTTED\n  NO_FUR\n  UNKNOWN\n}\n\ninput ComplexInput {\n  requiredField: Boolean!\n  nonNullField: Boolean! = false\n  intField: Int\n  stringField: String\n  booleanField: Boolean\n  stringListField: [String]\n}\n\ninput OneOfInput @oneOf {\n  stringField: String\n  intField: Int\n}\n\ntype ComplicatedArgs {\n  intArgField(intArg: Int): String\n  nonNullIntArgField(nonNullIntArg: Int!): String\n  stringArgField(stringArg: String): String\n  booleanArgField(booleanArg: Boolean): String\n  enumArgField(enumArg: FurColor): String\n  floatArgField(floatArg: Float): String\n  idArgField(idArg: ID): String\n  stringListArgField(stringListArg: [String]): String\n  stringListNonNullArgField(stringListNonNullArg: [String!]): String\n  complexArgField(complexArg: ComplexInput): String\n  oneOfArgField(oneOfArg: OneOfInput): String\n  multipleReqs(req1: Int!, req2: Int!): String\n  nonNullFieldWithDefault(arg: Int! = 0): String\n  multipleOpts(opt1: Int = 0, opt2: Int = 0): String\n  multipleOptAndReq(req1: Int!, req2: Int!, opt1: Int = 0, opt2: Int = 0): String\n}\n\ntype QueryRoot {\n  human(id: ID): Human\n  dog: Dog\n  cat: Cat\n  pet: Pet\n  catOrDog: CatOrDog\n  complicatedArgs: ComplicatedArgs\n}"
+    {
+      "id": "7vlHtoKB6yn7Yw66xpvtAb0M4Wjj5LmzeSTymz2zE5w=",
+      "sdl": "directive @onQuery on QUERY\n\ndirective @onMutation on MUTATION\n\ndirective @onSubscription on SUBSCRIPTION\n\ndirective @onField on FIELD\n\ndirective @onFragmentDefinition on FRAGMENT_DEFINITION\n\ndirective @onFragmentSpread on FRAGMENT_SPREAD\n\ndirective @onInlineFragment on INLINE_FRAGMENT\n\ndirective @onVariableDefinition on VARIABLE_DEFINITION\n\ntype Query {\n  dummy: String\n}"
+    },
+    {
+      "id": "FPFhio7mA1zxXhXd/8NCpbdwBrysWfBkn36GZ1uvDAA=",
+      "sdl": "input SomeInput {\n  a: String\n  b: String\n}\n\ntype Query {\n  someField(arg: SomeInput): String\n}"
+    },
+    {
+      "id": "QCY6hMOsxyATcac05rKqjKSVL1T9s4WCW+M3bkNLnbk=",
+      "sdl": "interface Pet {\n  name: String\n}\n\ntype Dog implements Pet {\n  name: String\n  nickname: String\n  barkVolume: Int\n}\n\ntype Cat implements Pet {\n  name: String\n  nickname: String\n  meowVolume: Int\n}\n\nunion CatOrDog = Cat | Dog\n\ntype Human {\n  name: String\n  pets: [Pet]\n}\n\ntype Query {\n  human: Human\n}"
+    },
+    {
+      "id": "lI0vTN4faZpDsH78EAqnHxgWvSXnGiiQrLUtNc+zVJw=",
+      "sdl": "interface SomeBox {\n  deepBox: SomeBox\n  unrelatedField: String\n}\n\ntype StringBox implements SomeBox {\n  scalar: String\n  deepBox: StringBox\n  unrelatedField: String\n  listStringBox: [StringBox]\n  stringBox: StringBox\n  intBox: IntBox\n}\n\ntype IntBox implements SomeBox {\n  scalar: Int\n  deepBox: IntBox\n  unrelatedField: String\n  listStringBox: [StringBox]\n  stringBox: StringBox\n  intBox: IntBox\n}\n\ninterface NonNullStringBox1 {\n  scalar: String!\n}\n\ntype NonNullStringBox1Impl implements SomeBox & NonNullStringBox1 {\n  scalar: String!\n  unrelatedField: String\n  deepBox: SomeBox\n}\n\ninterface NonNullStringBox2 {\n  scalar: String!\n}\n\ntype NonNullStringBox2Impl implements SomeBox & NonNullStringBox2 {\n  scalar: String!\n  unrelatedField: String\n  deepBox: SomeBox\n}\n\ntype Connection {\n  edges: [Edge]\n}\n\ntype Edge {\n  node: Node\n}\n\ntype Node {\n  id: ID\n  name: String\n}\n\ntype Query {\n  someBox: SomeBox\n  connection: Connection\n}"
+    },
+    {
+      "id": "JcQm34rC4nzCQ4Cn4QDjItvRRlqLNNgWJlR58cdBrQc=",
+      "sdl": "schema {\n  query: QueryRoot\n}\n\ndirective @onField on FIELD\n\ndirective @directive on FIELD | FRAGMENT_DEFINITION\n\ndirective @directiveA on FIELD | FRAGMENT_DEFINITION\n\ndirective @directiveB on FIELD | FRAGMENT_DEFINITION\n\ndirective @repeatable repeatable on FIELD | FRAGMENT_DEFINITION\n\ninterface Mammal {\n  mother: Mammal\n  father: Mammal\n}\n\ninterface Pet {\n  name(surname: Boolean): String\n}\n\ninterface Canine implements Mammal {\n  name(surname: Boolean): String\n  mother: Canine\n  father: Canine\n}\n\nenum DogCommand {\n  SIT\n  HEEL\n  DOWN\n}\n\ntype Dog implements Pet & Mammal & Canine {\n  name(surname: Boolean): String\n  nickname: String\n  barkVolume: Int\n  barks: Boolean\n  doesKnowCommand(dogCommand: DogCommand): Boolean\n  isHouseTrained(atOtherHomes: Boolean = true): Boolean\n  isAtLocation(x: Int, y: Int): Boolean\n  mother: Dog\n  father: Dog\n}\n\ntype Cat implements Pet {\n  name(surname: Boolean): String\n  nickname: String\n  meows: Boolean\n  meowsVolume: Int\n  furColor: FurColor\n}\n\nunion CatOrDog = Cat | Dog\n\ntype Human {\n  name(surname: Boolean): String\n  pets: [Pet]\n  relatives: [Human]!\n}\n\nenum FurColor {\n  BROWN\n  BLACK\n  TAN\n  SPOTTED\n  NO_FUR\n  UNKNOWN\n}\n\ninput ComplexInput {\n  requiredField: Boolean!\n  nonNullField: Boolean! = false\n  intField: Int\n  stringField: String\n  booleanField: Boolean\n  stringListField: [String]\n}\n\ninput OneOfInput @oneOf {\n  stringField: String\n  intField: Int\n}\n\ntype ComplicatedArgs {\n  intArgField(intArg: Int): String\n  nonNullIntArgField(nonNullIntArg: Int!): String\n  stringArgField(stringArg: String): String\n  booleanArgField(booleanArg: Boolean): String\n  enumArgField(enumArg: FurColor): String\n  floatArgField(floatArg: Float): String\n  idArgField(idArg: ID): String\n  stringListArgField(stringListArg: [String]): String\n  stringListNonNullArgField(stringListNonNullArg: [String!]): String\n  complexArgField(complexArg: ComplexInput): String\n  oneOfArgField(oneOfArg: OneOfInput): String\n  multipleReqs(req1: Int!, req2: Int!): String\n  nonNullFieldWithDefault(arg: Int! = 0): String\n  multipleOpts(opt1: Int = 0, opt2: Int = 0): String\n  multipleOptAndReq(req1: Int!, req2: Int!, opt1: Int = 0, opt2: Int = 0): String\n}\n\ntype QueryRoot {\n  human(id: ID): Human\n  dog: Dog\n  cat: Cat\n  pet: Pet\n  catOrDog: CatOrDog\n  complicatedArgs: ComplicatedArgs\n}"
+    },
+    {
+      "id": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
+      "sdl": "schema {\n  query: QueryRoot\n}\n\ndirective @onField on FIELD\n\ninterface Mammal {\n  mother: Mammal\n  father: Mammal\n}\n\ninterface Pet {\n  name(surname: Boolean): String\n}\n\ninterface Canine implements Mammal {\n  name(surname: Boolean): String\n  mother: Canine\n  father: Canine\n}\n\nenum DogCommand {\n  SIT\n  HEEL\n  DOWN\n}\n\ntype Dog implements Pet & Mammal & Canine {\n  name(surname: Boolean): String\n  nickname: String\n  barkVolume: Int\n  barks: Boolean\n  doesKnowCommand(dogCommand: DogCommand): Boolean\n  isHouseTrained(atOtherHomes: Boolean = true): Boolean\n  isAtLocation(x: Int, y: Int): Boolean\n  mother: Dog\n  father: Dog\n}\n\ntype Cat implements Pet {\n  name(surname: Boolean): String\n  nickname: String\n  meows: Boolean\n  meowsVolume: Int\n  furColor: FurColor\n}\n\nunion CatOrDog = Cat | Dog\n\ntype Human {\n  name(surname: Boolean): String\n  pets: [Pet]\n  relatives: [Human]!\n}\n\nenum FurColor {\n  BROWN\n  BLACK\n  TAN\n  SPOTTED\n  NO_FUR\n  UNKNOWN\n}\n\ninput ComplexInput {\n  requiredField: Boolean!\n  nonNullField: Boolean! = false\n  intField: Int\n  stringField: String\n  booleanField: Boolean\n  stringListField: [String]\n}\n\ninput OneOfInput @oneOf {\n  stringField: String\n  intField: Int\n}\n\ntype ComplicatedArgs {\n  intArgField(intArg: Int): String\n  nonNullIntArgField(nonNullIntArg: Int!): String\n  stringArgField(stringArg: String): String\n  booleanArgField(booleanArg: Boolean): String\n  enumArgField(enumArg: FurColor): String\n  floatArgField(floatArg: Float): String\n  idArgField(idArg: ID): String\n  stringListArgField(stringListArg: [String]): String\n  stringListNonNullArgField(stringListNonNullArg: [String!]): String\n  complexArgField(complexArg: ComplexInput): String\n  oneOfArgField(oneOfArg: OneOfInput): String\n  multipleReqs(req1: Int!, req2: Int!): String\n  nonNullFieldWithDefault(arg: Int! = 0): String\n  multipleOpts(opt1: Int = 0, opt2: Int = 0): String\n  multipleOptAndReq(req1: Int!, req2: Int!, opt1: Int = 0, opt2: Int = 0): String\n}\n\ntype QueryRoot {\n  human(id: ID): Human\n  dog: Dog\n  cat: Cat\n  pet: Pet\n  catOrDog: CatOrDog\n  complicatedArgs: ComplicatedArgs\n}"
+    },
+    {
+      "id": "kxqeANW6SwgMzv7OfoER7Pehb0UyllcRPcBPGckVxRc=",
+      "sdl": "type Foo {\n  constructor: String\n}\n\ntype Query {\n  foo: Foo\n}"
+    },
+    {
+      "id": "oECbw4BIP7gX1R+fCGRDCcqbO2FV/Uf0MhhE0EDAWIw=",
+      "sdl": "type Query {\n  foo: String\n}"
+    },
+    {
+      "id": "6+inK6Z824FQA4uBaUhxFXmMhc79+vKbamUi32/NtdQ=",
+      "sdl": "type Query {\n  someField(a: String, b: String): String\n}"
+    }
   ],
   "tests": [
     {
       "name": "Validate: Fields on correct type/Object field selection",
       "rule": "FieldsOnCorrectTypeRule",
-      "schema": 0,
+      "schema": "QCY6hMOsxyATcac05rKqjKSVL1T9s4WCW+M3bkNLnbk=",
       "query": "\n      fragment objectFieldSelection on Dog {\n        __typename\n        name\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Fields on correct type/Aliased object field selection",
       "rule": "FieldsOnCorrectTypeRule",
-      "schema": 0,
+      "schema": "QCY6hMOsxyATcac05rKqjKSVL1T9s4WCW+M3bkNLnbk=",
       "query": "\n      fragment aliasedObjectFieldSelection on Dog {\n        tn : __typename\n        otherName : name\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Fields on correct type/Interface field selection",
       "rule": "FieldsOnCorrectTypeRule",
-      "schema": 0,
+      "schema": "QCY6hMOsxyATcac05rKqjKSVL1T9s4WCW+M3bkNLnbk=",
       "query": "\n      fragment interfaceFieldSelection on Pet {\n        __typename\n        name\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Fields on correct type/Aliased interface field selection",
       "rule": "FieldsOnCorrectTypeRule",
-      "schema": 0,
+      "schema": "QCY6hMOsxyATcac05rKqjKSVL1T9s4WCW+M3bkNLnbk=",
       "query": "\n      fragment interfaceFieldSelection on Pet {\n        otherName : name\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Fields on correct type/Lying alias selection",
       "rule": "FieldsOnCorrectTypeRule",
-      "schema": 0,
+      "schema": "QCY6hMOsxyATcac05rKqjKSVL1T9s4WCW+M3bkNLnbk=",
       "query": "\n      fragment lyingAliasSelection on Dog {\n        name : nickname\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Fields on correct type/Ignores fields on unknown type",
       "rule": "FieldsOnCorrectTypeRule",
-      "schema": 0,
+      "schema": "QCY6hMOsxyATcac05rKqjKSVL1T9s4WCW+M3bkNLnbk=",
       "query": "\n      fragment unknownSelection on UnknownType {\n        unknownField\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Fields on correct type/reports errors when type is known again",
       "rule": "FieldsOnCorrectTypeRule",
-      "schema": 0,
+      "schema": "QCY6hMOsxyATcac05rKqjKSVL1T9s4WCW+M3bkNLnbk=",
       "query": "\n      fragment typeKnownAgain on Pet {\n        unknown_pet_field {\n          ... on Cat {\n            unknown_cat_field\n          }\n        }\n      }\n    ",
       "errors": [
         {
@@ -82,7 +109,7 @@
     {
       "name": "Validate: Fields on correct type/Field not defined on fragment",
       "rule": "FieldsOnCorrectTypeRule",
-      "schema": 0,
+      "schema": "QCY6hMOsxyATcac05rKqjKSVL1T9s4WCW+M3bkNLnbk=",
       "query": "\n      fragment fieldNotDefined on Dog {\n        meowVolume\n      }\n    ",
       "errors": [
         {
@@ -99,7 +126,7 @@
     {
       "name": "Validate: Fields on correct type/Ignores deeply unknown field",
       "rule": "FieldsOnCorrectTypeRule",
-      "schema": 0,
+      "schema": "QCY6hMOsxyATcac05rKqjKSVL1T9s4WCW+M3bkNLnbk=",
       "query": "\n      fragment deepFieldNotDefined on Dog {\n        unknown_field {\n          deeper_unknown_field\n        }\n      }\n    ",
       "errors": [
         {
@@ -116,7 +143,7 @@
     {
       "name": "Validate: Fields on correct type/Sub-field not defined",
       "rule": "FieldsOnCorrectTypeRule",
-      "schema": 0,
+      "schema": "QCY6hMOsxyATcac05rKqjKSVL1T9s4WCW+M3bkNLnbk=",
       "query": "\n      fragment subFieldNotDefined on Human {\n        pets {\n          unknown_field\n        }\n      }\n    ",
       "errors": [
         {
@@ -133,7 +160,7 @@
     {
       "name": "Validate: Fields on correct type/Field not defined on inline fragment",
       "rule": "FieldsOnCorrectTypeRule",
-      "schema": 0,
+      "schema": "QCY6hMOsxyATcac05rKqjKSVL1T9s4WCW+M3bkNLnbk=",
       "query": "\n      fragment fieldNotDefined on Pet {\n        ... on Dog {\n          meowVolume\n        }\n      }\n    ",
       "errors": [
         {
@@ -150,7 +177,7 @@
     {
       "name": "Validate: Fields on correct type/Aliased field target not defined",
       "rule": "FieldsOnCorrectTypeRule",
-      "schema": 0,
+      "schema": "QCY6hMOsxyATcac05rKqjKSVL1T9s4WCW+M3bkNLnbk=",
       "query": "\n      fragment aliasedFieldTargetNotDefined on Dog {\n        volume : mooVolume\n      }\n    ",
       "errors": [
         {
@@ -167,7 +194,7 @@
     {
       "name": "Validate: Fields on correct type/Aliased lying field target not defined",
       "rule": "FieldsOnCorrectTypeRule",
-      "schema": 0,
+      "schema": "QCY6hMOsxyATcac05rKqjKSVL1T9s4WCW+M3bkNLnbk=",
       "query": "\n      fragment aliasedLyingFieldTargetNotDefined on Dog {\n        barkVolume : kawVolume\n      }\n    ",
       "errors": [
         {
@@ -184,7 +211,7 @@
     {
       "name": "Validate: Fields on correct type/Not defined on interface",
       "rule": "FieldsOnCorrectTypeRule",
-      "schema": 0,
+      "schema": "QCY6hMOsxyATcac05rKqjKSVL1T9s4WCW+M3bkNLnbk=",
       "query": "\n      fragment notDefinedOnInterface on Pet {\n        tailLength\n      }\n    ",
       "errors": [
         {
@@ -201,7 +228,7 @@
     {
       "name": "Validate: Fields on correct type/Defined on implementors but not on interface",
       "rule": "FieldsOnCorrectTypeRule",
-      "schema": 0,
+      "schema": "QCY6hMOsxyATcac05rKqjKSVL1T9s4WCW+M3bkNLnbk=",
       "query": "\n      fragment definedOnImplementorsButNotInterface on Pet {\n        nickname\n      }\n    ",
       "errors": [
         {
@@ -218,14 +245,14 @@
     {
       "name": "Validate: Fields on correct type/Meta field selection on union",
       "rule": "FieldsOnCorrectTypeRule",
-      "schema": 0,
+      "schema": "QCY6hMOsxyATcac05rKqjKSVL1T9s4WCW+M3bkNLnbk=",
       "query": "\n      fragment directFieldSelectionOnUnion on CatOrDog {\n        __typename\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Fields on correct type/Direct field selection on union",
       "rule": "FieldsOnCorrectTypeRule",
-      "schema": 0,
+      "schema": "QCY6hMOsxyATcac05rKqjKSVL1T9s4WCW+M3bkNLnbk=",
       "query": "\n      fragment directFieldSelectionOnUnion on CatOrDog {\n        directField\n      }\n    ",
       "errors": [
         {
@@ -242,7 +269,7 @@
     {
       "name": "Validate: Fields on correct type/Defined on implementors queried on union",
       "rule": "FieldsOnCorrectTypeRule",
-      "schema": 0,
+      "schema": "QCY6hMOsxyATcac05rKqjKSVL1T9s4WCW+M3bkNLnbk=",
       "query": "\n      fragment definedOnImplementorsQueriedOnUnion on CatOrDog {\n        name\n      }\n    ",
       "errors": [
         {
@@ -259,56 +286,56 @@
     {
       "name": "Validate: Fields on correct type/valid field in inline fragment",
       "rule": "FieldsOnCorrectTypeRule",
-      "schema": 0,
+      "schema": "QCY6hMOsxyATcac05rKqjKSVL1T9s4WCW+M3bkNLnbk=",
       "query": "\n      fragment objectFieldSelection on Pet {\n        ... on Dog {\n          name\n        }\n        ... {\n          name\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Fragments on composite types/object is valid fragment type",
       "rule": "FragmentsOnCompositeTypesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment validFragment on Dog {\n        barks\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Fragments on composite types/interface is valid fragment type",
       "rule": "FragmentsOnCompositeTypesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment validFragment on Pet {\n        name\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Fragments on composite types/object is valid inline fragment type",
       "rule": "FragmentsOnCompositeTypesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment validFragment on Pet {\n        ... on Dog {\n          barks\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Fragments on composite types/interface is valid inline fragment type",
       "rule": "FragmentsOnCompositeTypesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment validFragment on Mammal {\n        ... on Canine {\n          name\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Fragments on composite types/inline fragment without type is valid",
       "rule": "FragmentsOnCompositeTypesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment validFragment on Pet {\n        ... {\n          name\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Fragments on composite types/union is valid fragment type",
       "rule": "FragmentsOnCompositeTypesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment validFragment on CatOrDog {\n        __typename\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Fragments on composite types/scalar is invalid fragment type",
       "rule": "FragmentsOnCompositeTypesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment scalarFragment on Boolean {\n        bad\n      }\n    ",
       "errors": [
         {
@@ -325,7 +352,7 @@
     {
       "name": "Validate: Fragments on composite types/enum is invalid fragment type",
       "rule": "FragmentsOnCompositeTypesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment scalarFragment on FurColor {\n        bad\n      }\n    ",
       "errors": [
         {
@@ -342,7 +369,7 @@
     {
       "name": "Validate: Fragments on composite types/input object is invalid fragment type",
       "rule": "FragmentsOnCompositeTypesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment inputFragment on ComplexInput {\n        stringField\n      }\n    ",
       "errors": [
         {
@@ -359,7 +386,7 @@
     {
       "name": "Validate: Fragments on composite types/scalar is invalid inline fragment type",
       "rule": "FragmentsOnCompositeTypesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment invalidFragment on Pet {\n        ... on String {\n          barks\n        }\n      }\n    ",
       "errors": [
         {
@@ -376,21 +403,21 @@
     {
       "name": "Validate: Known directives/with no directives",
       "rule": "KnownDirectivesRule",
-      "schema": 2,
+      "schema": "7vlHtoKB6yn7Yw66xpvtAb0M4Wjj5LmzeSTymz2zE5w=",
       "query": "\n      query Foo {\n        name\n        ...Frag\n      }\n\n      fragment Frag on Dog {\n        name\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Known directives/with standard directives",
       "rule": "KnownDirectivesRule",
-      "schema": 2,
+      "schema": "7vlHtoKB6yn7Yw66xpvtAb0M4Wjj5LmzeSTymz2zE5w=",
       "query": "\n      {\n        human @skip(if: false) {\n          name\n          pets {\n            ... on Dog @include(if: true) {\n              name\n            }\n          }\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Known directives/with unknown directive",
       "rule": "KnownDirectivesRule",
-      "schema": 2,
+      "schema": "7vlHtoKB6yn7Yw66xpvtAb0M4Wjj5LmzeSTymz2zE5w=",
       "query": "\n      {\n        human @unknown(directive: \"value\") {\n          name\n        }\n      }\n    ",
       "errors": [
         {
@@ -407,7 +434,7 @@
     {
       "name": "Validate: Known directives/with many unknown directives",
       "rule": "KnownDirectivesRule",
-      "schema": 2,
+      "schema": "7vlHtoKB6yn7Yw66xpvtAb0M4Wjj5LmzeSTymz2zE5w=",
       "query": "\n      {\n        __typename @unknown\n        human @unknown {\n          name\n          pets @unknown {\n            name\n          }\n        }\n      }\n    ",
       "errors": [
         {
@@ -442,14 +469,14 @@
     {
       "name": "Validate: Known directives/with well placed directives",
       "rule": "KnownDirectivesRule",
-      "schema": 2,
+      "schema": "7vlHtoKB6yn7Yw66xpvtAb0M4Wjj5LmzeSTymz2zE5w=",
       "query": "\n      query ($var: Boolean @onVariableDefinition) @onQuery {\n        human @onField {\n          ...Frag @onFragmentSpread\n          ... @onInlineFragment {\n            name @onField\n          }\n        }\n      }\n\n      mutation @onMutation {\n        someField @onField\n      }\n\n      subscription @onSubscription {\n        someField @onField\n      }\n\n      fragment Frag on Human @onFragmentDefinition {\n        name @onField\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Known directives/with misplaced directives",
       "rule": "KnownDirectivesRule",
-      "schema": 2,
+      "schema": "7vlHtoKB6yn7Yw66xpvtAb0M4Wjj5LmzeSTymz2zE5w=",
       "query": "\n      query ($var: Boolean @onQuery) @onMutation {\n        human @onQuery {\n          ...Frag @onQuery\n          ... @onQuery {\n            name @onQuery\n          }\n        }\n      }\n\n      mutation @onQuery {\n        someField @onQuery\n      }\n\n      subscription @onQuery {\n        someField @onQuery\n      }\n\n      fragment Frag on Human @onQuery {\n        name @onQuery\n      }\n    ",
       "errors": [
         {
@@ -565,14 +592,14 @@
     {
       "name": "Validate: Known fragment names/known fragment names are valid",
       "rule": "KnownFragmentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        human(id: 4) {\n          ...HumanFields1\n          ... on Human {\n            ...HumanFields2\n          }\n          ... {\n            name\n          }\n        }\n      }\n      fragment HumanFields1 on Human {\n        name\n        ...HumanFields3\n      }\n      fragment HumanFields2 on Human {\n        name\n      }\n      fragment HumanFields3 on Human {\n        name\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Known fragment names/unknown fragment names are invalid",
       "rule": "KnownFragmentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        human(id: 4) {\n          ...UnknownFragment1\n          ... on Human {\n            ...UnknownFragment2\n          }\n        }\n      }\n      fragment HumanFields on Human {\n        name\n        ...UnknownFragment3\n      }\n    ",
       "errors": [
         {
@@ -607,14 +634,14 @@
     {
       "name": "Validate: Known type names/known type names are valid",
       "rule": "KnownTypeNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo(\n        $var: String\n        $required: [Int!]!\n        $introspectionType: __EnumValue\n      ) {\n        user(id: 4) {\n          pets { ... on Pet { name }, ...PetFields, ... { name } }\n        }\n      }\n\n      fragment PetFields on Pet {\n        name\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Known type names/unknown type names are invalid",
       "rule": "KnownTypeNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($var: [JumbledUpLetters!]!) {\n        user(id: 4) {\n          name\n          pets { ... on Badger { name }, ...PetFields }\n        }\n      }\n      fragment PetFields on Peat {\n        name\n      }\n    ",
       "errors": [
         {
@@ -649,7 +676,7 @@
     {
       "name": "Validate: Known type names/references to standard scalars that are missing in schema",
       "rule": "KnownTypeNamesRule",
-      "schema": 3,
+      "schema": "oECbw4BIP7gX1R+fCGRDCcqbO2FV/Uf0MhhE0EDAWIw=",
       "query": "\n      query ($id: ID, $float: Float, $int: Int) {\n        __typename\n      }\n    ",
       "errors": [
         {
@@ -684,35 +711,35 @@
     {
       "name": "Validate: Anonymous operation must be alone/no operations",
       "rule": "LoneAnonymousOperationRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment fragA on Type {\n        field\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Anonymous operation must be alone/one anon operation",
       "rule": "LoneAnonymousOperationRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Anonymous operation must be alone/multiple named operations",
       "rule": "LoneAnonymousOperationRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo {\n        field\n      }\n\n      query Bar {\n        field\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Anonymous operation must be alone/anon operation with fragment",
       "rule": "LoneAnonymousOperationRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        ...Foo\n      }\n      fragment Foo on Type {\n        field\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Anonymous operation must be alone/multiple anon operations",
       "rule": "LoneAnonymousOperationRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        fieldA\n      }\n      {\n        fieldB\n      }\n    ",
       "errors": [
         {
@@ -738,7 +765,7 @@
     {
       "name": "Validate: Anonymous operation must be alone/anon operation with a mutation",
       "rule": "LoneAnonymousOperationRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        fieldA\n      }\n      mutation Foo {\n        fieldB\n      }\n    ",
       "errors": [
         {
@@ -755,7 +782,7 @@
     {
       "name": "Validate: Anonymous operation must be alone/anon operation with a subscription",
       "rule": "LoneAnonymousOperationRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        fieldA\n      }\n      subscription Foo {\n        fieldB\n      }\n    ",
       "errors": [
         {
@@ -772,42 +799,42 @@
     {
       "name": "Validate: No circular fragment spreads/single reference is valid",
       "rule": "NoFragmentCyclesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment fragA on Dog { ...fragB }\n      fragment fragB on Dog { name }\n    ",
       "errors": []
     },
     {
       "name": "Validate: No circular fragment spreads/spreading twice is not circular",
       "rule": "NoFragmentCyclesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment fragA on Dog { ...fragB, ...fragB }\n      fragment fragB on Dog { name }\n    ",
       "errors": []
     },
     {
       "name": "Validate: No circular fragment spreads/spreading twice indirectly is not circular",
       "rule": "NoFragmentCyclesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment fragA on Dog { ...fragB, ...fragC }\n      fragment fragB on Dog { ...fragC }\n      fragment fragC on Dog { name }\n    ",
       "errors": []
     },
     {
       "name": "Validate: No circular fragment spreads/double spread within abstract types",
       "rule": "NoFragmentCyclesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment nameFragment on Pet {\n        ... on Dog { name }\n        ... on Cat { name }\n      }\n\n      fragment spreadsInAnon on Pet {\n        ... on Dog { ...nameFragment }\n        ... on Cat { ...nameFragment }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: No circular fragment spreads/does not false positive on unknown fragment",
       "rule": "NoFragmentCyclesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment nameFragment on Pet {\n        ...UnknownFragment\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: No circular fragment spreads/spreading recursively within field fails",
       "rule": "NoFragmentCyclesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment fragA on Human { relatives { ...fragA } },\n    ",
       "errors": [
         {
@@ -824,7 +851,7 @@
     {
       "name": "Validate: No circular fragment spreads/no spreading itself directly",
       "rule": "NoFragmentCyclesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment fragA on Dog { ...fragA }\n    ",
       "errors": [
         {
@@ -841,7 +868,7 @@
     {
       "name": "Validate: No circular fragment spreads/no spreading itself directly within inline fragment",
       "rule": "NoFragmentCyclesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment fragA on Pet {\n        ... on Dog {\n          ...fragA\n        }\n      }\n    ",
       "errors": [
         {
@@ -858,7 +885,7 @@
     {
       "name": "Validate: No circular fragment spreads/no spreading itself indirectly",
       "rule": "NoFragmentCyclesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment fragA on Dog { ...fragB }\n      fragment fragB on Dog { ...fragA }\n    ",
       "errors": [
         {
@@ -879,7 +906,7 @@
     {
       "name": "Validate: No circular fragment spreads/no spreading itself indirectly reports opposite order",
       "rule": "NoFragmentCyclesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment fragB on Dog { ...fragA }\n      fragment fragA on Dog { ...fragB }\n    ",
       "errors": [
         {
@@ -900,7 +927,7 @@
     {
       "name": "Validate: No circular fragment spreads/no spreading itself indirectly within inline fragment",
       "rule": "NoFragmentCyclesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment fragA on Pet {\n        ... on Dog {\n          ...fragB\n        }\n      }\n      fragment fragB on Pet {\n        ... on Dog {\n          ...fragA\n        }\n      }\n    ",
       "errors": [
         {
@@ -921,7 +948,7 @@
     {
       "name": "Validate: No circular fragment spreads/no spreading itself deeply",
       "rule": "NoFragmentCyclesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment fragA on Dog { ...fragB }\n      fragment fragB on Dog { ...fragC }\n      fragment fragC on Dog { ...fragO }\n      fragment fragX on Dog { ...fragY }\n      fragment fragY on Dog { ...fragZ }\n      fragment fragZ on Dog { ...fragO }\n      fragment fragO on Dog { ...fragP }\n      fragment fragP on Dog { ...fragA, ...fragX }\n    ",
       "errors": [
         {
@@ -979,7 +1006,7 @@
     {
       "name": "Validate: No circular fragment spreads/no spreading itself deeply two paths",
       "rule": "NoFragmentCyclesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment fragA on Dog { ...fragB, ...fragC }\n      fragment fragB on Dog { ...fragA }\n      fragment fragC on Dog { ...fragA }\n    ",
       "errors": [
         {
@@ -1013,7 +1040,7 @@
     {
       "name": "Validate: No circular fragment spreads/no spreading itself deeply two paths -- alt traverse order",
       "rule": "NoFragmentCyclesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment fragA on Dog { ...fragC }\n      fragment fragB on Dog { ...fragC }\n      fragment fragC on Dog { ...fragA, ...fragB }\n    ",
       "errors": [
         {
@@ -1047,7 +1074,7 @@
     {
       "name": "Validate: No circular fragment spreads/no spreading itself deeply and immediately",
       "rule": "NoFragmentCyclesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment fragA on Dog { ...fragB }\n      fragment fragB on Dog { ...fragB, ...fragC }\n      fragment fragC on Dog { ...fragA, ...fragB }\n    ",
       "errors": [
         {
@@ -1094,56 +1121,56 @@
     {
       "name": "Validate: No undefined variables/all variables defined",
       "rule": "NoUndefinedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($a: String, $b: String, $c: String) {\n        field(a: $a, b: $b, c: $c)\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: No undefined variables/all variables deeply defined",
       "rule": "NoUndefinedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($a: String, $b: String, $c: String) {\n        field(a: $a) {\n          field(b: $b) {\n            field(c: $c)\n          }\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: No undefined variables/all variables deeply in inline fragments defined",
       "rule": "NoUndefinedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($a: String, $b: String, $c: String) {\n        ... on Type {\n          field(a: $a) {\n            field(b: $b) {\n              ... on Type {\n                field(c: $c)\n              }\n            }\n          }\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: No undefined variables/all variables in fragments deeply defined",
       "rule": "NoUndefinedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($a: String, $b: String, $c: String) {\n        ...FragA\n      }\n      fragment FragA on Type {\n        field(a: $a) {\n          ...FragB\n        }\n      }\n      fragment FragB on Type {\n        field(b: $b) {\n          ...FragC\n        }\n      }\n      fragment FragC on Type {\n        field(c: $c)\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: No undefined variables/variable within single fragment defined in multiple operations",
       "rule": "NoUndefinedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($a: String) {\n        ...FragA\n      }\n      query Bar($a: String) {\n        ...FragA\n      }\n      fragment FragA on Type {\n        field(a: $a)\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: No undefined variables/variable within fragments defined in operations",
       "rule": "NoUndefinedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($a: String) {\n        ...FragA\n      }\n      query Bar($b: String) {\n        ...FragB\n      }\n      fragment FragA on Type {\n        field(a: $a)\n      }\n      fragment FragB on Type {\n        field(b: $b)\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: No undefined variables/variable within recursive fragment defined",
       "rule": "NoUndefinedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($a: String) {\n        ...FragA\n      }\n      fragment FragA on Type {\n        field(a: $a) {\n          ...FragA\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: No undefined variables/variable not defined",
       "rule": "NoUndefinedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($a: String, $b: String, $c: String) {\n        field(a: $a, b: $b, c: $c, d: $d)\n      }\n    ",
       "errors": [
         {
@@ -1164,7 +1191,7 @@
     {
       "name": "Validate: No undefined variables/variable not defined by un-named query",
       "rule": "NoUndefinedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field(a: $a)\n      }\n    ",
       "errors": [
         {
@@ -1185,7 +1212,7 @@
     {
       "name": "Validate: No undefined variables/multiple variables not defined",
       "rule": "NoUndefinedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($b: String) {\n        field(a: $a, b: $b, c: $c)\n      }\n    ",
       "errors": [
         {
@@ -1219,7 +1246,7 @@
     {
       "name": "Validate: No undefined variables/variable in fragment not defined by un-named query",
       "rule": "NoUndefinedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        ...FragA\n      }\n      fragment FragA on Type {\n        field(a: $a)\n      }\n    ",
       "errors": [
         {
@@ -1240,7 +1267,7 @@
     {
       "name": "Validate: No undefined variables/variable in fragment not defined by operation",
       "rule": "NoUndefinedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($a: String, $b: String) {\n        ...FragA\n      }\n      fragment FragA on Type {\n        field(a: $a) {\n          ...FragB\n        }\n      }\n      fragment FragB on Type {\n        field(b: $b) {\n          ...FragC\n        }\n      }\n      fragment FragC on Type {\n        field(c: $c)\n      }\n    ",
       "errors": [
         {
@@ -1261,7 +1288,7 @@
     {
       "name": "Validate: No undefined variables/multiple variables in fragments not defined",
       "rule": "NoUndefinedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($b: String) {\n        ...FragA\n      }\n      fragment FragA on Type {\n        field(a: $a) {\n          ...FragB\n        }\n      }\n      fragment FragB on Type {\n        field(b: $b) {\n          ...FragC\n        }\n      }\n      fragment FragC on Type {\n        field(c: $c)\n      }\n    ",
       "errors": [
         {
@@ -1295,7 +1322,7 @@
     {
       "name": "Validate: No undefined variables/single variable in fragment not defined by multiple operations",
       "rule": "NoUndefinedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($a: String) {\n        ...FragAB\n      }\n      query Bar($a: String) {\n        ...FragAB\n      }\n      fragment FragAB on Type {\n        field(a: $a, b: $b)\n      }\n    ",
       "errors": [
         {
@@ -1329,7 +1356,7 @@
     {
       "name": "Validate: No undefined variables/variables in fragment not defined by multiple operations",
       "rule": "NoUndefinedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($b: String) {\n        ...FragAB\n      }\n      query Bar($a: String) {\n        ...FragAB\n      }\n      fragment FragAB on Type {\n        field(a: $a, b: $b)\n      }\n    ",
       "errors": [
         {
@@ -1363,7 +1390,7 @@
     {
       "name": "Validate: No undefined variables/variable in fragment used by other operation",
       "rule": "NoUndefinedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($b: String) {\n        ...FragA\n      }\n      query Bar($a: String) {\n        ...FragB\n      }\n      fragment FragA on Type {\n        field(a: $a)\n      }\n      fragment FragB on Type {\n        field(b: $b)\n      }\n    ",
       "errors": [
         {
@@ -1397,7 +1424,7 @@
     {
       "name": "Validate: No undefined variables/multiple undefined variables produce multiple errors",
       "rule": "NoUndefinedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($b: String) {\n        ...FragAB\n      }\n      query Bar($a: String) {\n        ...FragAB\n      }\n      fragment FragAB on Type {\n        field1(a: $a, b: $b)\n        ...FragC\n        field3(a: $a, b: $b)\n      }\n      fragment FragC on Type {\n        field2(c: $c)\n      }\n    ",
       "errors": [
         {
@@ -1483,21 +1510,21 @@
     {
       "name": "Validate: No unused fragments/all fragment names are used",
       "rule": "NoUnusedFragmentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        human(id: 4) {\n          ...HumanFields1\n          ... on Human {\n            ...HumanFields2\n          }\n        }\n      }\n      fragment HumanFields1 on Human {\n        name\n        ...HumanFields3\n      }\n      fragment HumanFields2 on Human {\n        name\n      }\n      fragment HumanFields3 on Human {\n        name\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: No unused fragments/all fragment names are used by multiple operations",
       "rule": "NoUnusedFragmentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo {\n        human(id: 4) {\n          ...HumanFields1\n        }\n      }\n      query Bar {\n        human(id: 4) {\n          ...HumanFields2\n        }\n      }\n      fragment HumanFields1 on Human {\n        name\n        ...HumanFields3\n      }\n      fragment HumanFields2 on Human {\n        name\n      }\n      fragment HumanFields3 on Human {\n        name\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: No unused fragments/contains unknown fragments",
       "rule": "NoUnusedFragmentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo {\n        human(id: 4) {\n          ...HumanFields1\n        }\n      }\n      query Bar {\n        human(id: 4) {\n          ...HumanFields2\n        }\n      }\n      fragment HumanFields1 on Human {\n        name\n        ...HumanFields3\n      }\n      fragment HumanFields2 on Human {\n        name\n      }\n      fragment HumanFields3 on Human {\n        name\n      }\n      fragment Unused1 on Human {\n        name\n      }\n      fragment Unused2 on Human {\n        name\n      }\n    ",
       "errors": [
         {
@@ -1523,7 +1550,7 @@
     {
       "name": "Validate: No unused fragments/contains unknown fragments with ref cycle",
       "rule": "NoUnusedFragmentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo {\n        human(id: 4) {\n          ...HumanFields1\n        }\n      }\n      query Bar {\n        human(id: 4) {\n          ...HumanFields2\n        }\n      }\n      fragment HumanFields1 on Human {\n        name\n        ...HumanFields3\n      }\n      fragment HumanFields2 on Human {\n        name\n      }\n      fragment HumanFields3 on Human {\n        name\n      }\n      fragment Unused1 on Human {\n        name\n        ...Unused2\n      }\n      fragment Unused2 on Human {\n        name\n        ...Unused1\n      }\n    ",
       "errors": [
         {
@@ -1549,7 +1576,7 @@
     {
       "name": "Validate: No unused fragments/contains unknown and undef fragments",
       "rule": "NoUnusedFragmentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo {\n        human(id: 4) {\n          ...bar\n        }\n      }\n      fragment foo on Human {\n        name\n      }\n    ",
       "errors": [
         {
@@ -1566,49 +1593,49 @@
     {
       "name": "Validate: No unused variables/uses all variables",
       "rule": "NoUnusedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query ($a: String, $b: String, $c: String) {\n        field(a: $a, b: $b, c: $c)\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: No unused variables/uses all variables deeply",
       "rule": "NoUnusedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($a: String, $b: String, $c: String) {\n        field(a: $a) {\n          field(b: $b) {\n            field(c: $c)\n          }\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: No unused variables/uses all variables deeply in inline fragments",
       "rule": "NoUnusedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($a: String, $b: String, $c: String) {\n        ... on Type {\n          field(a: $a) {\n            field(b: $b) {\n              ... on Type {\n                field(c: $c)\n              }\n            }\n          }\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: No unused variables/uses all variables in fragments",
       "rule": "NoUnusedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($a: String, $b: String, $c: String) {\n        ...FragA\n      }\n      fragment FragA on Type {\n        field(a: $a) {\n          ...FragB\n        }\n      }\n      fragment FragB on Type {\n        field(b: $b) {\n          ...FragC\n        }\n      }\n      fragment FragC on Type {\n        field(c: $c)\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: No unused variables/variable used by fragment in multiple operations",
       "rule": "NoUnusedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($a: String) {\n        ...FragA\n      }\n      query Bar($b: String) {\n        ...FragB\n      }\n      fragment FragA on Type {\n        field(a: $a)\n      }\n      fragment FragB on Type {\n        field(b: $b)\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: No unused variables/variable used by recursive fragment",
       "rule": "NoUnusedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($a: String) {\n        ...FragA\n      }\n      fragment FragA on Type {\n        field(a: $a) {\n          ...FragA\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: No unused variables/variable not used",
       "rule": "NoUnusedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query ($a: String, $b: String, $c: String) {\n        field(a: $a, b: $b)\n      }\n    ",
       "errors": [
         {
@@ -1625,7 +1652,7 @@
     {
       "name": "Validate: No unused variables/multiple variables not used",
       "rule": "NoUnusedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($a: String, $b: String, $c: String) {\n        field(b: $b)\n      }\n    ",
       "errors": [
         {
@@ -1651,7 +1678,7 @@
     {
       "name": "Validate: No unused variables/variable not used in fragments",
       "rule": "NoUnusedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($a: String, $b: String, $c: String) {\n        ...FragA\n      }\n      fragment FragA on Type {\n        field(a: $a) {\n          ...FragB\n        }\n      }\n      fragment FragB on Type {\n        field(b: $b) {\n          ...FragC\n        }\n      }\n      fragment FragC on Type {\n        field\n      }\n    ",
       "errors": [
         {
@@ -1668,7 +1695,7 @@
     {
       "name": "Validate: No unused variables/multiple variables not used in fragments",
       "rule": "NoUnusedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($a: String, $b: String, $c: String) {\n        ...FragA\n      }\n      fragment FragA on Type {\n        field {\n          ...FragB\n        }\n      }\n      fragment FragB on Type {\n        field(b: $b) {\n          ...FragC\n        }\n      }\n      fragment FragC on Type {\n        field\n      }\n    ",
       "errors": [
         {
@@ -1694,7 +1721,7 @@
     {
       "name": "Validate: No unused variables/variable not used by unreferenced fragment",
       "rule": "NoUnusedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($b: String) {\n        ...FragA\n      }\n      fragment FragA on Type {\n        field(a: $a)\n      }\n      fragment FragB on Type {\n        field(b: $b)\n      }\n    ",
       "errors": [
         {
@@ -1711,7 +1738,7 @@
     {
       "name": "Validate: No unused variables/variable not used by fragment used by other operation",
       "rule": "NoUnusedVariablesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($b: String) {\n        ...FragA\n      }\n      query Bar($a: String) {\n        ...FragB\n      }\n      fragment FragA on Type {\n        field(a: $a)\n      }\n      fragment FragB on Type {\n        field(b: $b)\n      }\n    ",
       "errors": [
         {
@@ -1737,63 +1764,63 @@
     {
       "name": "Validate: Overlapping fields can be merged/unique fields",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment uniqueFields on Dog {\n        name\n        nickname\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/identical fields",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment mergeIdenticalFields on Dog {\n        name\n        name\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/identical fields with identical args",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment mergeIdenticalFieldsWithIdenticalArgs on Dog {\n        doesKnowCommand(dogCommand: SIT)\n        doesKnowCommand(dogCommand: SIT)\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/identical fields with identical directives",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment mergeSameFieldsWithSameDirectives on Dog {\n        name @include(if: true)\n        name @include(if: true)\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/different args with different aliases",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment differentArgsWithDifferentAliases on Dog {\n        knowsSit: doesKnowCommand(dogCommand: SIT)\n        knowsDown: doesKnowCommand(dogCommand: DOWN)\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/different directives with different aliases",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment differentDirectivesWithDifferentAliases on Dog {\n        nameIfTrue: name @include(if: true)\n        nameIfFalse: name @include(if: false)\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/different skip/include directives accepted",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment differentDirectivesWithDifferentAliases on Dog {\n        name @include(if: true)\n        name @include(if: false)\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/Same stream directives supported",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment differentDirectivesWithDifferentAliases on Dog {\n        name @stream(label: \"streamLabel\", initialCount: 1)\n        name @stream(label: \"streamLabel\", initialCount: 1)\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/different stream directive label",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment conflictingArgs on Dog {\n        name @stream(label: \"streamLabel\", initialCount: 1)\n        name @stream(label: \"anotherLabel\", initialCount: 1)\n      }\n    ",
       "errors": [
         {
@@ -1814,7 +1841,7 @@
     {
       "name": "Validate: Overlapping fields can be merged/different stream directive initialCount",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment conflictingArgs on Dog {\n        name @stream(label: \"streamLabel\", initialCount: 1)\n        name @stream(label: \"streamLabel\", initialCount: 2)\n      }\n    ",
       "errors": [
         {
@@ -1835,7 +1862,7 @@
     {
       "name": "Validate: Overlapping fields can be merged/different stream directive first missing args",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment conflictingArgs on Dog {\n        name @stream\n        name @stream(label: \"streamLabel\", initialCount: 1)\n      }\n    ",
       "errors": [
         {
@@ -1856,7 +1883,7 @@
     {
       "name": "Validate: Overlapping fields can be merged/different stream directive second missing args",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment conflictingArgs on Dog {\n        name @stream(label: \"streamLabel\", initialCount: 1)\n        name @stream\n      }\n    ",
       "errors": [
         {
@@ -1877,7 +1904,7 @@
     {
       "name": "Validate: Overlapping fields can be merged/different stream directive extra argument",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment conflictingArgs on Dog {\n        name @stream(label: \"streamLabel\", initialCount: 1)\n        name @stream(label: \"streamLabel\", initialCount: 1, extraArg: true)\n      }\n    ",
       "errors": [
         {
@@ -1898,7 +1925,7 @@
     {
       "name": "Validate: Overlapping fields can be merged/mix of stream and no stream",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment conflictingArgs on Dog {\n        name @stream\n        name\n      }\n    ",
       "errors": [
         {
@@ -1919,14 +1946,14 @@
     {
       "name": "Validate: Overlapping fields can be merged/different stream directive both missing args",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment conflictingArgs on Dog {\n        name @stream\n        name @stream\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/Same aliases with different field targets",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment sameAliasesWithDifferentFieldTargets on Dog {\n        fido: name\n        fido: nickname\n      }\n    ",
       "errors": [
         {
@@ -1947,14 +1974,14 @@
     {
       "name": "Validate: Overlapping fields can be merged/Same aliases allowed on non-overlapping fields",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment sameAliasesWithDifferentFieldTargets on Pet {\n        ... on Dog {\n          name\n        }\n        ... on Cat {\n          name: nickname\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/Alias masking direct field access",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment aliasMaskingDirectFieldAccess on Dog {\n        name: nickname\n        name\n      }\n    ",
       "errors": [
         {
@@ -1975,7 +2002,7 @@
     {
       "name": "Validate: Overlapping fields can be merged/different args, second adds an argument",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment conflictingArgs on Dog {\n        doesKnowCommand\n        doesKnowCommand(dogCommand: HEEL)\n      }\n    ",
       "errors": [
         {
@@ -1996,7 +2023,7 @@
     {
       "name": "Validate: Overlapping fields can be merged/different args, second missing an argument",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment conflictingArgs on Dog {\n        doesKnowCommand(dogCommand: SIT)\n        doesKnowCommand\n      }\n    ",
       "errors": [
         {
@@ -2017,7 +2044,7 @@
     {
       "name": "Validate: Overlapping fields can be merged/conflicting arg values",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment conflictingArgs on Dog {\n        doesKnowCommand(dogCommand: SIT)\n        doesKnowCommand(dogCommand: HEEL)\n      }\n    ",
       "errors": [
         {
@@ -2038,7 +2065,7 @@
     {
       "name": "Validate: Overlapping fields can be merged/conflicting arg names",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment conflictingArgs on Dog {\n        isAtLocation(x: 0)\n        isAtLocation(y: 0)\n      }\n    ",
       "errors": [
         {
@@ -2059,28 +2086,28 @@
     {
       "name": "Validate: Overlapping fields can be merged/allows different args where no conflict is possible",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment conflictingArgs on Pet {\n        ... on Dog {\n          name(surname: true)\n        }\n        ... on Cat {\n          name\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/allows different order of args",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 4,
+      "schema": "6+inK6Z824FQA4uBaUhxFXmMhc79+vKbamUi32/NtdQ=",
       "query": "\n        {\n          someField(a: null, b: null)\n          someField(b: null, a: null)\n        }\n      ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/allows different order of input object fields in arg values",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 5,
+      "schema": "FPFhio7mA1zxXhXd/8NCpbdwBrysWfBkn36GZ1uvDAA=",
       "query": "\n        {\n          someField(arg: { a: null, b: null })\n          someField(arg: { b: null, a: null })\n        }\n      ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/encounters conflict in fragments",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        ...A\n        ...B\n      }\n      fragment A on Type {\n        x: a\n      }\n      fragment B on Type {\n        x: b\n      }\n    ",
       "errors": [
         {
@@ -2101,7 +2128,7 @@
     {
       "name": "Validate: Overlapping fields can be merged/reports each conflict once",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        f1 {\n          ...A\n          ...B\n        }\n        f2 {\n          ...B\n          ...A\n        }\n        f3 {\n          ...A\n          ...B\n          x: c\n        }\n      }\n      fragment A on Type {\n        x: a\n      }\n      fragment B on Type {\n        x: b\n      }\n    ",
       "errors": [
         {
@@ -2148,7 +2175,7 @@
     {
       "name": "Validate: Overlapping fields can be merged/deep conflict",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field {\n          x: a\n        },\n        field {\n          x: b\n        }\n      }\n    ",
       "errors": [
         {
@@ -2177,7 +2204,7 @@
     {
       "name": "Validate: Overlapping fields can be merged/deep conflict with multiple issues",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field {\n          x: a\n          y: c\n        },\n        field {\n          x: b\n          y: d\n        }\n      }\n    ",
       "errors": [
         {
@@ -2214,7 +2241,7 @@
     {
       "name": "Validate: Overlapping fields can be merged/very deep conflict",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field {\n          deepField {\n            x: a\n          }\n        },\n        field {\n          deepField {\n            x: b\n          }\n        }\n      }\n    ",
       "errors": [
         {
@@ -2251,7 +2278,7 @@
     {
       "name": "Validate: Overlapping fields can be merged/reports deep conflict to nearest common ancestor",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field {\n          deepField {\n            x: a\n          }\n          deepField {\n            x: b\n          }\n        },\n        field {\n          deepField {\n            y\n          }\n        }\n      }\n    ",
       "errors": [
         {
@@ -2280,7 +2307,7 @@
     {
       "name": "Validate: Overlapping fields can be merged/reports deep conflict to nearest common ancestor in fragments",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field {\n          ...F\n        }\n        field {\n          ...F\n        }\n      }\n      fragment F on T {\n        deepField {\n          deeperField {\n            x: a\n          }\n          deeperField {\n            x: b\n          }\n        },\n        deepField {\n          deeperField {\n            y\n          }\n        }\n      }\n    ",
       "errors": [
         {
@@ -2309,7 +2336,7 @@
     {
       "name": "Validate: Overlapping fields can be merged/reports deep conflict in nested fragments",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field {\n          ...F\n        }\n        field {\n          ...I\n        }\n      }\n      fragment F on T {\n        x: a\n        ...G\n      }\n      fragment G on T {\n        y: c\n      }\n      fragment I on T {\n        y: d\n        ...J\n      }\n      fragment J on T {\n        x: b\n      }\n    ",
       "errors": [
         {
@@ -2346,14 +2373,14 @@
     {
       "name": "Validate: Overlapping fields can be merged/ignores unknown fragments",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field\n        ...Unknown\n        ...Known\n      }\n\n      fragment Known on T {\n        field\n        ...OtherUnknown\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/return types must be unambiguous/conflicting return types which potentially overlap",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 6,
+      "schema": "lI0vTN4faZpDsH78EAqnHxgWvSXnGiiQrLUtNc+zVJw=",
       "query": "\n          {\n            someBox {\n              ...on IntBox {\n                scalar\n              }\n              ...on NonNullStringBox1 {\n                scalar\n              }\n            }\n          }\n        ",
       "errors": [
         {
@@ -2374,14 +2401,14 @@
     {
       "name": "Validate: Overlapping fields can be merged/return types must be unambiguous/compatible return shapes on different return types",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 6,
+      "schema": "lI0vTN4faZpDsH78EAqnHxgWvSXnGiiQrLUtNc+zVJw=",
       "query": "\n          {\n            someBox {\n              ... on SomeBox {\n                deepBox {\n                  unrelatedField\n                }\n              }\n              ... on StringBox {\n                deepBox {\n                  unrelatedField\n                }\n              }\n            }\n          }\n        ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/return types must be unambiguous/disallows differing return types despite no overlap",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 6,
+      "schema": "lI0vTN4faZpDsH78EAqnHxgWvSXnGiiQrLUtNc+zVJw=",
       "query": "\n          {\n            someBox {\n              ... on IntBox {\n                scalar\n              }\n              ... on StringBox {\n                scalar\n              }\n            }\n          }\n        ",
       "errors": [
         {
@@ -2402,7 +2429,7 @@
     {
       "name": "Validate: Overlapping fields can be merged/return types must be unambiguous/disallows differing return type nullability despite no overlap",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 6,
+      "schema": "lI0vTN4faZpDsH78EAqnHxgWvSXnGiiQrLUtNc+zVJw=",
       "query": "\n          {\n            someBox {\n              ... on NonNullStringBox1 {\n                scalar\n              }\n              ... on StringBox {\n                scalar\n              }\n            }\n          }\n        ",
       "errors": [
         {
@@ -2423,7 +2450,7 @@
     {
       "name": "Validate: Overlapping fields can be merged/return types must be unambiguous/disallows differing return type list despite no overlap",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 6,
+      "schema": "lI0vTN4faZpDsH78EAqnHxgWvSXnGiiQrLUtNc+zVJw=",
       "query": "\n          {\n            someBox {\n              ... on IntBox {\n                box: listStringBox {\n                  scalar\n                }\n              }\n              ... on StringBox {\n                box: stringBox {\n                  scalar\n                }\n              }\n            }\n          }\n        ",
       "errors": [
         {
@@ -2444,7 +2471,7 @@
     {
       "name": "Validate: Overlapping fields can be merged/return types must be unambiguous/disallows differing return type list despite no overlap",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 6,
+      "schema": "lI0vTN4faZpDsH78EAqnHxgWvSXnGiiQrLUtNc+zVJw=",
       "query": "\n          {\n            someBox {\n              ... on IntBox {\n                box: stringBox {\n                  scalar\n                }\n              }\n              ... on StringBox {\n                box: listStringBox {\n                  scalar\n                }\n              }\n            }\n          }\n        ",
       "errors": [
         {
@@ -2465,7 +2492,7 @@
     {
       "name": "Validate: Overlapping fields can be merged/return types must be unambiguous/disallows differing deep return types despite no overlap",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 6,
+      "schema": "lI0vTN4faZpDsH78EAqnHxgWvSXnGiiQrLUtNc+zVJw=",
       "query": "\n          {\n            someBox {\n              ... on IntBox {\n                box: stringBox {\n                  scalar\n                }\n              }\n              ... on StringBox {\n                box: intBox {\n                  scalar\n                }\n              }\n            }\n          }\n        ",
       "errors": [
         {
@@ -2494,28 +2521,28 @@
     {
       "name": "Validate: Overlapping fields can be merged/return types must be unambiguous/allows non-conflicting overlapping types",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 6,
+      "schema": "lI0vTN4faZpDsH78EAqnHxgWvSXnGiiQrLUtNc+zVJw=",
       "query": "\n          {\n            someBox {\n              ... on IntBox {\n                scalar: unrelatedField\n              }\n              ... on StringBox {\n                scalar\n              }\n            }\n          }\n        ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/return types must be unambiguous/same wrapped scalar return types",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 6,
+      "schema": "lI0vTN4faZpDsH78EAqnHxgWvSXnGiiQrLUtNc+zVJw=",
       "query": "\n          {\n            someBox {\n              ...on NonNullStringBox1 {\n                scalar\n              }\n              ...on NonNullStringBox2 {\n                scalar\n              }\n            }\n          }\n        ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/return types must be unambiguous/allows inline fragments without type condition",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 6,
+      "schema": "lI0vTN4faZpDsH78EAqnHxgWvSXnGiiQrLUtNc+zVJw=",
       "query": "\n          {\n            a\n            ... {\n              a\n            }\n          }\n        ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/return types must be unambiguous/compares deep types including list",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 6,
+      "schema": "lI0vTN4faZpDsH78EAqnHxgWvSXnGiiQrLUtNc+zVJw=",
       "query": "\n          {\n            connection {\n              ...edgeID\n              edges {\n                node {\n                  id: name\n                }\n              }\n            }\n          }\n\n          fragment edgeID on Connection {\n            edges {\n              node {\n                id\n              }\n            }\n          }\n        ",
       "errors": [
         {
@@ -2552,42 +2579,42 @@
     {
       "name": "Validate: Overlapping fields can be merged/return types must be unambiguous/ignores unknown types",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 6,
+      "schema": "lI0vTN4faZpDsH78EAqnHxgWvSXnGiiQrLUtNc+zVJw=",
       "query": "\n          {\n            someBox {\n              ...on UnknownType {\n                scalar\n              }\n              ...on NonNullStringBox2 {\n                scalar\n              }\n            }\n          }\n        ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/return types must be unambiguous/works for field names that are JS keywords",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 7,
+      "schema": "kxqeANW6SwgMzv7OfoER7Pehb0UyllcRPcBPGckVxRc=",
       "query": "\n          {\n            foo {\n              constructor\n            }\n          }\n        ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/does not infinite loop on recursive fragment",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        ...fragA\n      }\n\n      fragment fragA on Human { name, relatives { name, ...fragA } }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/does not infinite loop on immediately recursive fragment",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        ...fragA\n      }\n\n      fragment fragA on Human { name, ...fragA }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/does not infinite loop on recursive fragment with a field named after fragment",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        ...fragA\n        fragA\n      }\n\n      fragment fragA on Query { ...fragA }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/finds invalid cases even with field named after fragment",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        fragA\n        ...fragA\n      }\n\n      fragment fragA on Type {\n        fragA: b\n      }\n    ",
       "errors": [
         {
@@ -2608,14 +2635,14 @@
     {
       "name": "Validate: Overlapping fields can be merged/does not infinite loop on transitively recursive fragment",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        ...fragA\n        fragB\n      }\n\n      fragment fragA on Human { name, ...fragB }\n      fragment fragB on Human { name, ...fragC }\n      fragment fragC on Human { name, ...fragA }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Overlapping fields can be merged/finds invalid case even with immediately recursive fragment",
       "rule": "OverlappingFieldsCanBeMergedRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment sameAliasesWithDifferentFieldTargets on Dog {\n        ...sameAliasesWithDifferentFieldTargets\n        fido: name\n        fido: nickname\n      }\n    ",
       "errors": [
         {
@@ -2636,91 +2663,91 @@
     {
       "name": "Validate: Provided required arguments/ignores unknown arguments",
       "rule": "ProvidedRequiredArgumentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        dog {\n          isHouseTrained(unknownArgument: true)\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Provided required arguments/Valid non-nullable value/Arg on optional arg",
       "rule": "ProvidedRequiredArgumentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n        {\n          dog {\n            isHouseTrained(atOtherHomes: true)\n          }\n        }\n      ",
       "errors": []
     },
     {
       "name": "Validate: Provided required arguments/Valid non-nullable value/No Arg on optional arg",
       "rule": "ProvidedRequiredArgumentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n        {\n          dog {\n            isHouseTrained\n          }\n        }\n      ",
       "errors": []
     },
     {
       "name": "Validate: Provided required arguments/Valid non-nullable value/No arg on non-null field with default",
       "rule": "ProvidedRequiredArgumentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n        {\n          complicatedArgs {\n            nonNullFieldWithDefault\n          }\n        }\n      ",
       "errors": []
     },
     {
       "name": "Validate: Provided required arguments/Valid non-nullable value/Multiple args",
       "rule": "ProvidedRequiredArgumentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n        {\n          complicatedArgs {\n            multipleReqs(req1: 1, req2: 2)\n          }\n        }\n      ",
       "errors": []
     },
     {
       "name": "Validate: Provided required arguments/Valid non-nullable value/Multiple args reverse order",
       "rule": "ProvidedRequiredArgumentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n        {\n          complicatedArgs {\n            multipleReqs(req2: 2, req1: 1)\n          }\n        }\n      ",
       "errors": []
     },
     {
       "name": "Validate: Provided required arguments/Valid non-nullable value/No args on multiple optional",
       "rule": "ProvidedRequiredArgumentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n        {\n          complicatedArgs {\n            multipleOpts\n          }\n        }\n      ",
       "errors": []
     },
     {
       "name": "Validate: Provided required arguments/Valid non-nullable value/One arg on multiple optional",
       "rule": "ProvidedRequiredArgumentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n        {\n          complicatedArgs {\n            multipleOpts(opt1: 1)\n          }\n        }\n      ",
       "errors": []
     },
     {
       "name": "Validate: Provided required arguments/Valid non-nullable value/Second arg on multiple optional",
       "rule": "ProvidedRequiredArgumentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n        {\n          complicatedArgs {\n            multipleOpts(opt2: 1)\n          }\n        }\n      ",
       "errors": []
     },
     {
       "name": "Validate: Provided required arguments/Valid non-nullable value/Multiple required args on mixedList",
       "rule": "ProvidedRequiredArgumentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n        {\n          complicatedArgs {\n            multipleOptAndReq(req1: 3, req2: 4)\n          }\n        }\n      ",
       "errors": []
     },
     {
       "name": "Validate: Provided required arguments/Valid non-nullable value/Multiple required and one optional arg on mixedList",
       "rule": "ProvidedRequiredArgumentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n        {\n          complicatedArgs {\n            multipleOptAndReq(req1: 3, req2: 4, opt1: 5)\n          }\n        }\n      ",
       "errors": []
     },
     {
       "name": "Validate: Provided required arguments/Valid non-nullable value/All required and optional args on mixedList",
       "rule": "ProvidedRequiredArgumentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n        {\n          complicatedArgs {\n            multipleOptAndReq(req1: 3, req2: 4, opt1: 5, opt2: 6)\n          }\n        }\n      ",
       "errors": []
     },
     {
       "name": "Validate: Provided required arguments/Invalid non-nullable value/Missing one non-nullable argument",
       "rule": "ProvidedRequiredArgumentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n        {\n          complicatedArgs {\n            multipleReqs(req2: 2)\n          }\n        }\n      ",
       "errors": [
         {
@@ -2737,7 +2764,7 @@
     {
       "name": "Validate: Provided required arguments/Invalid non-nullable value/Missing multiple non-nullable arguments",
       "rule": "ProvidedRequiredArgumentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n        {\n          complicatedArgs {\n            multipleReqs\n          }\n        }\n      ",
       "errors": [
         {
@@ -2763,7 +2790,7 @@
     {
       "name": "Validate: Provided required arguments/Invalid non-nullable value/Incorrect value and missing argument",
       "rule": "ProvidedRequiredArgumentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n        {\n          complicatedArgs {\n            multipleReqs(req1: \"one\")\n          }\n        }\n      ",
       "errors": [
         {
@@ -2780,21 +2807,21 @@
     {
       "name": "Validate: Provided required arguments/Directive arguments/ignores unknown directives",
       "rule": "ProvidedRequiredArgumentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n        {\n          dog @unknown\n        }\n      ",
       "errors": []
     },
     {
       "name": "Validate: Provided required arguments/Directive arguments/with directives of valid types",
       "rule": "ProvidedRequiredArgumentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n        {\n          dog @include(if: true) {\n            name\n          }\n          human @skip(if: false) {\n            name\n          }\n        }\n      ",
       "errors": []
     },
     {
       "name": "Validate: Provided required arguments/Directive arguments/with directive with missing types",
       "rule": "ProvidedRequiredArgumentsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n        {\n          dog @include {\n            name @skip\n          }\n        }\n      ",
       "errors": [
         {
@@ -2820,14 +2847,14 @@
     {
       "name": "Validate: Scalar leafs/valid scalar selection",
       "rule": "ScalarLeafsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment scalarSelection on Dog {\n        barks\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Scalar leafs/object type missing selection",
       "rule": "ScalarLeafsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query directQueryOnObjectWithoutSubFields {\n        human\n      }\n    ",
       "errors": [
         {
@@ -2844,7 +2871,7 @@
     {
       "name": "Validate: Scalar leafs/interface type missing selection",
       "rule": "ScalarLeafsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        human { pets }\n      }\n    ",
       "errors": [
         {
@@ -2861,14 +2888,14 @@
     {
       "name": "Validate: Scalar leafs/valid scalar selection with args",
       "rule": "ScalarLeafsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment scalarSelectionWithArgs on Dog {\n        doesKnowCommand(dogCommand: SIT)\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Scalar leafs/scalar selection not allowed on Boolean",
       "rule": "ScalarLeafsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment scalarSelectionsNotAllowedOnBoolean on Dog {\n        barks { sinceWhen }\n      }\n    ",
       "errors": [
         {
@@ -2885,7 +2912,7 @@
     {
       "name": "Validate: Scalar leafs/scalar selection not allowed on Enum",
       "rule": "ScalarLeafsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment scalarSelectionsNotAllowedOnEnum on Cat {\n        furColor { inHexDec }\n      }\n    ",
       "errors": [
         {
@@ -2902,7 +2929,7 @@
     {
       "name": "Validate: Scalar leafs/scalar selection not allowed with args",
       "rule": "ScalarLeafsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment scalarSelectionsNotAllowedWithArgs on Dog {\n        doesKnowCommand(dogCommand: SIT) { sinceWhen }\n      }\n    ",
       "errors": [
         {
@@ -2919,7 +2946,7 @@
     {
       "name": "Validate: Scalar leafs/Scalar selection not allowed with directives",
       "rule": "ScalarLeafsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment scalarSelectionsNotAllowedWithDirectives on Dog {\n        name @include(if: true) { isAlsoHumanName }\n      }\n    ",
       "errors": [
         {
@@ -2936,7 +2963,7 @@
     {
       "name": "Validate: Scalar leafs/Scalar selection not allowed with directives and args",
       "rule": "ScalarLeafsRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment scalarSelectionsNotAllowedWithDirectivesAndArgs on Dog {\n        doesKnowCommand(dogCommand: SIT) @include(if: true) { sinceWhen }\n      }\n    ",
       "errors": [
         {
@@ -2953,70 +2980,70 @@
     {
       "name": "Validate: Unique argument names/no arguments on field",
       "rule": "UniqueArgumentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique argument names/no arguments on directive",
       "rule": "UniqueArgumentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field @directive\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique argument names/argument on field",
       "rule": "UniqueArgumentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field(arg: \"value\")\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique argument names/argument on directive",
       "rule": "UniqueArgumentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field @directive(arg: \"value\")\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique argument names/same argument on two fields",
       "rule": "UniqueArgumentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        one: field(arg: \"value\")\n        two: field(arg: \"value\")\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique argument names/same argument on field and directive",
       "rule": "UniqueArgumentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field(arg: \"value\") @directive(arg: \"value\")\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique argument names/same argument on two directives",
       "rule": "UniqueArgumentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field @directive1(arg: \"value\") @directive2(arg: \"value\")\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique argument names/multiple field arguments",
       "rule": "UniqueArgumentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field(arg1: \"value\", arg2: \"value\", arg3: \"value\")\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique argument names/multiple directive arguments",
       "rule": "UniqueArgumentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field @directive(arg1: \"value\", arg2: \"value\", arg3: \"value\")\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique argument names/duplicate field arguments",
       "rule": "UniqueArgumentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field(arg1: \"value\", arg1: \"value\")\n      }\n    ",
       "errors": [
         {
@@ -3037,7 +3064,7 @@
     {
       "name": "Validate: Unique argument names/many duplicate field arguments",
       "rule": "UniqueArgumentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field(arg1: \"value\", arg1: \"value\", arg1: \"value\")\n      }\n    ",
       "errors": [
         {
@@ -3062,7 +3089,7 @@
     {
       "name": "Validate: Unique argument names/duplicate directive arguments",
       "rule": "UniqueArgumentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field @directive(arg1: \"value\", arg1: \"value\")\n      }\n    ",
       "errors": [
         {
@@ -3083,7 +3110,7 @@
     {
       "name": "Validate: Unique argument names/many duplicate directive arguments",
       "rule": "UniqueArgumentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field @directive(arg1: \"value\", arg1: \"value\", arg1: \"value\")\n      }\n    ",
       "errors": [
         {
@@ -3108,56 +3135,56 @@
     {
       "name": "Validate: Directives Are Unique Per Location/no directives",
       "rule": "UniqueDirectivesPerLocationRule",
-      "schema": 8,
+      "schema": "JcQm34rC4nzCQ4Cn4QDjItvRRlqLNNgWJlR58cdBrQc=",
       "query": "\n      fragment Test on Type {\n        field\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Directives Are Unique Per Location/unique directives in different locations",
       "rule": "UniqueDirectivesPerLocationRule",
-      "schema": 8,
+      "schema": "JcQm34rC4nzCQ4Cn4QDjItvRRlqLNNgWJlR58cdBrQc=",
       "query": "\n      fragment Test on Type @directiveA {\n        field @directiveB\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Directives Are Unique Per Location/unique directives in same locations",
       "rule": "UniqueDirectivesPerLocationRule",
-      "schema": 8,
+      "schema": "JcQm34rC4nzCQ4Cn4QDjItvRRlqLNNgWJlR58cdBrQc=",
       "query": "\n      fragment Test on Type @directiveA @directiveB {\n        field @directiveA @directiveB\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Directives Are Unique Per Location/same directives in different locations",
       "rule": "UniqueDirectivesPerLocationRule",
-      "schema": 8,
+      "schema": "JcQm34rC4nzCQ4Cn4QDjItvRRlqLNNgWJlR58cdBrQc=",
       "query": "\n      fragment Test on Type @directiveA {\n        field @directiveA\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Directives Are Unique Per Location/same directives in similar locations",
       "rule": "UniqueDirectivesPerLocationRule",
-      "schema": 8,
+      "schema": "JcQm34rC4nzCQ4Cn4QDjItvRRlqLNNgWJlR58cdBrQc=",
       "query": "\n      fragment Test on Type {\n        field @directive\n        field @directive\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Directives Are Unique Per Location/repeatable directives in same location",
       "rule": "UniqueDirectivesPerLocationRule",
-      "schema": 8,
+      "schema": "JcQm34rC4nzCQ4Cn4QDjItvRRlqLNNgWJlR58cdBrQc=",
       "query": "\n      fragment Test on Type @repeatable @repeatable {\n        field @repeatable @repeatable\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Directives Are Unique Per Location/unknown directives must be ignored",
       "rule": "UniqueDirectivesPerLocationRule",
-      "schema": 8,
+      "schema": "JcQm34rC4nzCQ4Cn4QDjItvRRlqLNNgWJlR58cdBrQc=",
       "query": "\n      type Test @unknown @unknown {\n        field: String! @unknown @unknown\n      }\n\n      extend type Test @unknown {\n        anotherField: String!\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Directives Are Unique Per Location/duplicate directives in one location",
       "rule": "UniqueDirectivesPerLocationRule",
-      "schema": 8,
+      "schema": "JcQm34rC4nzCQ4Cn4QDjItvRRlqLNNgWJlR58cdBrQc=",
       "query": "\n      fragment Test on Type {\n        field @directive @directive\n      }\n    ",
       "errors": [
         {
@@ -3178,7 +3205,7 @@
     {
       "name": "Validate: Directives Are Unique Per Location/many duplicate directives in one location",
       "rule": "UniqueDirectivesPerLocationRule",
-      "schema": 8,
+      "schema": "JcQm34rC4nzCQ4Cn4QDjItvRRlqLNNgWJlR58cdBrQc=",
       "query": "\n      fragment Test on Type {\n        field @directive @directive @directive\n      }\n    ",
       "errors": [
         {
@@ -3212,7 +3239,7 @@
     {
       "name": "Validate: Directives Are Unique Per Location/different duplicate directives in one location",
       "rule": "UniqueDirectivesPerLocationRule",
-      "schema": 8,
+      "schema": "JcQm34rC4nzCQ4Cn4QDjItvRRlqLNNgWJlR58cdBrQc=",
       "query": "\n      fragment Test on Type {\n        field @directiveA @directiveB @directiveA @directiveB\n      }\n    ",
       "errors": [
         {
@@ -3246,7 +3273,7 @@
     {
       "name": "Validate: Directives Are Unique Per Location/duplicate directives in many locations",
       "rule": "UniqueDirectivesPerLocationRule",
-      "schema": 8,
+      "schema": "JcQm34rC4nzCQ4Cn4QDjItvRRlqLNNgWJlR58cdBrQc=",
       "query": "\n      fragment Test on Type @directive @directive {\n        field @directive @directive\n      }\n    ",
       "errors": [
         {
@@ -3280,42 +3307,42 @@
     {
       "name": "Validate: Unique fragment names/no fragments",
       "rule": "UniqueFragmentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique fragment names/one fragment",
       "rule": "UniqueFragmentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        ...fragA\n      }\n\n      fragment fragA on Type {\n        field\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique fragment names/many fragments",
       "rule": "UniqueFragmentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        ...fragA\n        ...fragB\n        ...fragC\n      }\n      fragment fragA on Type {\n        fieldA\n      }\n      fragment fragB on Type {\n        fieldB\n      }\n      fragment fragC on Type {\n        fieldC\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique fragment names/inline fragments are always unique",
       "rule": "UniqueFragmentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        ...on Type {\n          fieldA\n        }\n        ...on Type {\n          fieldB\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique fragment names/fragment and operation named the same",
       "rule": "UniqueFragmentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo {\n        ...Foo\n      }\n      fragment Foo on Type {\n        field\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique fragment names/fragments named the same",
       "rule": "UniqueFragmentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        ...fragA\n      }\n      fragment fragA on Type {\n        fieldA\n      }\n      fragment fragA on Type {\n        fieldB\n      }\n    ",
       "errors": [
         {
@@ -3336,7 +3363,7 @@
     {
       "name": "Validate: Unique fragment names/fragments named the same without being referenced",
       "rule": "UniqueFragmentNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment fragA on Type {\n        fieldA\n      }\n      fragment fragA on Type {\n        fieldB\n      }\n    ",
       "errors": [
         {
@@ -3357,35 +3384,35 @@
     {
       "name": "Validate: Unique input field names/input object with fields",
       "rule": "UniqueInputFieldNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field(arg: { f: true })\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique input field names/same input object within two args",
       "rule": "UniqueInputFieldNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field(arg1: { f: true }, arg2: { f: true })\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique input field names/multiple input object fields",
       "rule": "UniqueInputFieldNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field(arg: { f1: \"value\", f2: \"value\", f3: \"value\" })\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique input field names/allows for nested input objects with similar fields",
       "rule": "UniqueInputFieldNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field(arg: {\n          deep: {\n            deep: {\n              id: 1\n            }\n            id: 1\n          }\n          id: 1\n        })\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique input field names/duplicate input object fields",
       "rule": "UniqueInputFieldNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field(arg: { f1: \"value\", f1: \"value\" })\n      }\n    ",
       "errors": [
         {
@@ -3406,7 +3433,7 @@
     {
       "name": "Validate: Unique input field names/many duplicate input object fields",
       "rule": "UniqueInputFieldNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field(arg: { f1: \"value\", f1: \"value\", f1: \"value\" })\n      }\n    ",
       "errors": [
         {
@@ -3440,7 +3467,7 @@
     {
       "name": "Validate: Unique input field names/nested duplicate input object fields",
       "rule": "UniqueInputFieldNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field(arg: { f1: {f2: \"value\", f2: \"value\" }})\n      }\n    ",
       "errors": [
         {
@@ -3461,49 +3488,49 @@
     {
       "name": "Validate: Unique operation names/no operations",
       "rule": "UniqueOperationNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment fragA on Type {\n        field\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique operation names/one anon operation",
       "rule": "UniqueOperationNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      {\n        field\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique operation names/one named operation",
       "rule": "UniqueOperationNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo {\n        field\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique operation names/multiple operations",
       "rule": "UniqueOperationNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo {\n        field\n      }\n\n      query Bar {\n        field\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique operation names/multiple operations of different types",
       "rule": "UniqueOperationNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo {\n        field\n      }\n\n      mutation Bar {\n        field\n      }\n\n      subscription Baz {\n        field\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique operation names/fragment and operation named the same",
       "rule": "UniqueOperationNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo {\n        ...Foo\n      }\n      fragment Foo on Type {\n        field\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique operation names/multiple operations of same name",
       "rule": "UniqueOperationNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo {\n        fieldA\n      }\n      query Foo {\n        fieldB\n      }\n    ",
       "errors": [
         {
@@ -3524,7 +3551,7 @@
     {
       "name": "Validate: Unique operation names/multiple ops of same name of different types (mutation)",
       "rule": "UniqueOperationNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo {\n        fieldA\n      }\n      mutation Foo {\n        fieldB\n      }\n    ",
       "errors": [
         {
@@ -3545,7 +3572,7 @@
     {
       "name": "Validate: Unique operation names/multiple ops of same name of different types (subscription)",
       "rule": "UniqueOperationNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo {\n        fieldA\n      }\n      subscription Foo {\n        fieldB\n      }\n    ",
       "errors": [
         {
@@ -3566,14 +3593,14 @@
     {
       "name": "Validate: Unique variable names/unique variable names",
       "rule": "UniqueVariableNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query A($x: Int, $y: String) { __typename }\n      query B($x: String, $y: Int) { __typename }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Unique variable names/duplicate variable names",
       "rule": "UniqueVariableNamesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query A($x: Int, $x: Int, $x: String) { __typename }\n      query B($x: String, $x: Int) { __typename }\n      query C($x: Int, $x: Int) { __typename }\n    ",
       "errors": [
         {
@@ -3624,21 +3651,21 @@
     {
       "name": "Validate: Variables are input types/unknown types are ignored",
       "rule": "VariablesAreInputTypesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($a: Unknown, $b: [[Unknown!]]!) {\n        field(a: $a, b: $b)\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Variables are input types/input types are valid",
       "rule": "VariablesAreInputTypesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($a: String, $b: [Boolean!]!, $c: ComplexInput) {\n        field(a: $a, b: $b, c: $c)\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Variables are input types/output types are invalid",
       "rule": "VariablesAreInputTypesRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Foo($a: Dog, $b: [[CatOrDog!]]!, $c: Pet) {\n        field(a: $a, b: $b, c: $c)\n      }\n    ",
       "errors": [
         {
@@ -3673,91 +3700,91 @@
     {
       "name": "Validate: Variables are in allowed positions/Boolean => Boolean",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Query($booleanArg: Boolean)\n      {\n        complicatedArgs {\n          booleanArgField(booleanArg: $booleanArg)\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Variables are in allowed positions/Boolean => Boolean within fragment",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment booleanArgFrag on ComplicatedArgs {\n        booleanArgField(booleanArg: $booleanArg)\n      }\n      query Query($booleanArg: Boolean)\n      {\n        complicatedArgs {\n          ...booleanArgFrag\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Variables are in allowed positions/Boolean => Boolean within fragment",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Query($booleanArg: Boolean)\n      {\n        complicatedArgs {\n          ...booleanArgFrag\n        }\n      }\n      fragment booleanArgFrag on ComplicatedArgs {\n        booleanArgField(booleanArg: $booleanArg)\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Variables are in allowed positions/Boolean! => Boolean",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Query($nonNullBooleanArg: Boolean!)\n      {\n        complicatedArgs {\n          booleanArgField(booleanArg: $nonNullBooleanArg)\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Variables are in allowed positions/Boolean! => Boolean within fragment",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment booleanArgFrag on ComplicatedArgs {\n        booleanArgField(booleanArg: $nonNullBooleanArg)\n      }\n\n      query Query($nonNullBooleanArg: Boolean!)\n      {\n        complicatedArgs {\n          ...booleanArgFrag\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Variables are in allowed positions/[String] => [String]",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Query($stringListVar: [String])\n      {\n        complicatedArgs {\n          stringListArgField(stringListArg: $stringListVar)\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Variables are in allowed positions/[String!] => [String]",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Query($stringListVar: [String!])\n      {\n        complicatedArgs {\n          stringListArgField(stringListArg: $stringListVar)\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Variables are in allowed positions/String => [String] in item position",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Query($stringVar: String)\n      {\n        complicatedArgs {\n          stringListArgField(stringListArg: [$stringVar])\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Variables are in allowed positions/String! => [String] in item position",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Query($stringVar: String!)\n      {\n        complicatedArgs {\n          stringListArgField(stringListArg: [$stringVar])\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Variables are in allowed positions/ComplexInput => ComplexInput",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Query($complexVar: ComplexInput)\n      {\n        complicatedArgs {\n          complexArgField(complexArg: $complexVar)\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Variables are in allowed positions/ComplexInput => ComplexInput in field position",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Query($boolVar: Boolean = false)\n      {\n        complicatedArgs {\n          complexArgField(complexArg: {requiredArg: $boolVar})\n        }\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Variables are in allowed positions/Boolean! => Boolean! in directive",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Query($boolVar: Boolean!)\n      {\n        dog @include(if: $boolVar)\n      }\n    ",
       "errors": []
     },
     {
       "name": "Validate: Variables are in allowed positions/Int => Int!",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Query($intArg: Int) {\n        complicatedArgs {\n          nonNullIntArgField(nonNullIntArg: $intArg)\n        }\n      }\n    ",
       "errors": [
         {
@@ -3778,7 +3805,7 @@
     {
       "name": "Validate: Variables are in allowed positions/Int => Int! within fragment",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment nonNullIntArgFieldFrag on ComplicatedArgs {\n        nonNullIntArgField(nonNullIntArg: $intArg)\n      }\n\n      query Query($intArg: Int) {\n        complicatedArgs {\n          ...nonNullIntArgFieldFrag\n        }\n      }\n    ",
       "errors": [
         {
@@ -3799,7 +3826,7 @@
     {
       "name": "Validate: Variables are in allowed positions/Int => Int! within nested fragment",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      fragment outerFrag on ComplicatedArgs {\n        ...nonNullIntArgFieldFrag\n      }\n\n      fragment nonNullIntArgFieldFrag on ComplicatedArgs {\n        nonNullIntArgField(nonNullIntArg: $intArg)\n      }\n\n      query Query($intArg: Int) {\n        complicatedArgs {\n          ...outerFrag\n        }\n      }\n    ",
       "errors": [
         {
@@ -3820,7 +3847,7 @@
     {
       "name": "Validate: Variables are in allowed positions/String over Boolean",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Query($stringVar: String) {\n        complicatedArgs {\n          booleanArgField(booleanArg: $stringVar)\n        }\n      }\n    ",
       "errors": [
         {
@@ -3841,7 +3868,7 @@
     {
       "name": "Validate: Variables are in allowed positions/String => [String]",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Query($stringVar: String) {\n        complicatedArgs {\n          stringListArgField(stringListArg: $stringVar)\n        }\n      }\n    ",
       "errors": [
         {
@@ -3862,7 +3889,7 @@
     {
       "name": "Validate: Variables are in allowed positions/Boolean => Boolean! in directive",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Query($boolVar: Boolean) {\n        dog @include(if: $boolVar)\n      }\n    ",
       "errors": [
         {
@@ -3883,7 +3910,7 @@
     {
       "name": "Validate: Variables are in allowed positions/String => Boolean! in directive",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Query($stringVar: String) {\n        dog @include(if: $stringVar)\n      }\n    ",
       "errors": [
         {
@@ -3904,7 +3931,7 @@
     {
       "name": "Validate: Variables are in allowed positions/[String] => [String!]",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n      query Query($stringListVar: [String])\n      {\n        complicatedArgs {\n          stringListNonNullArgField(stringListNonNullArg: $stringListVar)\n        }\n      }\n    ",
       "errors": [
         {
@@ -3925,7 +3952,7 @@
     {
       "name": "Validate: Variables are in allowed positions/Allows optional (nullable) variables with default values/Int => Int! fails when variable provides null default value",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n        query Query($intVar: Int = null) {\n          complicatedArgs {\n            nonNullIntArgField(nonNullIntArg: $intVar)\n          }\n        }\n      ",
       "errors": [
         {
@@ -3946,21 +3973,21 @@
     {
       "name": "Validate: Variables are in allowed positions/Allows optional (nullable) variables with default values/Int => Int! when variable provides non-null default value",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n        query Query($intVar: Int = 1) {\n          complicatedArgs {\n            nonNullIntArgField(nonNullIntArg: $intVar)\n          }\n        }",
       "errors": []
     },
     {
       "name": "Validate: Variables are in allowed positions/Allows optional (nullable) variables with default values/Int => Int! when optional argument provides default value",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n        query Query($intVar: Int) {\n          complicatedArgs {\n            nonNullFieldWithDefault(nonNullIntArg: $intVar)\n          }\n        }",
       "errors": []
     },
     {
       "name": "Validate: Variables are in allowed positions/Allows optional (nullable) variables with default values/Boolean => Boolean! in directive with default value with option",
       "rule": "VariablesInAllowedPositionRule",
-      "schema": 1,
+      "schema": "3vm8aJ4UHhzj01V2PFAYRVZj2R0SPm+mxfn/edqH9aU=",
       "query": "\n        query Query($boolVar: Boolean = false) {\n          dog @include(if: $boolVar)\n        }",
       "errors": []
     }

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -15,10 +15,15 @@ import (
 	"github.com/graph-gophers/graphql-go/internal/validation"
 )
 
+type Schema struct {
+	ID  string
+	SDL string
+}
+
 type Test struct {
 	Name   string
 	Rule   string
-	Schema int
+	Schema string
 	Query  string
 	Vars   map[string]interface{}
 	Errors []*errors.QueryError
@@ -45,15 +50,15 @@ func TestValidate(t *testing.T) {
 	}
 
 	var testData struct {
-		Schemas []string
+		Schemas []Schema
 		Tests   []*Test
 	}
 	if err := json.NewDecoder(f).Decode(&testData); err != nil {
 		t.Fatal(err)
 	}
 
-	schemas := make([]*ast.Schema, len(testData.Schemas))
-	for i, schemaStr := range testData.Schemas {
+	schemas := make(map[string]*ast.Schema, len(testData.Schemas))
+	for _, sc := range testData.Schemas {
 		s := schema.New()
 
 		s.Directives["oneOf"] = &ast.DirectiveDefinition{
@@ -65,11 +70,11 @@ func TestValidate(t *testing.T) {
 			Locations: []string{"INPUT_OBJECT"},
 		}
 
-		err := schema.Parse(s, schemaStr, false)
+		err := schema.Parse(s, sc.SDL, false)
 		if err != nil {
 			t.Fatal(err)
 		}
-		schemas[i] = s
+		schemas[sc.ID] = s
 	}
 
 	for _, test := range testData.Tests {


### PR DESCRIPTION
Schemas defined in the tests.json are highly dependent on the order that graphql-js tests register them. This results in re-ordering of the schemas and updates to many/all of the schema index values referring to them in tests when new schemas are inserted.

Attempting to add some stability to the JSON for future changes here by sorting the schemas, and referring to them by a SHA id of the schema content, rather than index ordering. This results in a large change here but hopefully smaller changes when adding and updating test cases from graphql-js in the future.