### PR TITLE
Support leading pipe in union definition

### DIFF
--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -488,6 +488,9 @@ func parseUnionDef(l *common.Lexer) *ast.Union {
 
 	union.Directives = common.ParseDirectives(l)
 	l.ConsumeToken('=')
+	if l.Peek() == '|' {
+		l.ConsumeToken('|')
+	}
 	union.TypeNames = []string{l.ConsumeIdent()}
 	for l.Peek() == '|' {
 		l.ConsumeToken('|')


### PR DESCRIPTION
The GraphQL spec [supports a leading pipe operator for union type definitions](https://github.com/graphql/graphql-spec/pull/320), but the parser in graphql-go fails on schemas defined that way. 

Notably, in [prettier has started using this format in v3](https://github.com/prettier/prettier/pull/15870), so many GraphQL schemas formatted by prettier will fail when used by this library.

This PR adds support for a leading pipe in union types. I added a unit test. I looked into why this wasn't captured by the validation tests that are generated from `graphql-js`, and it seems that this language feature [isn't represented](https://github.com/graphql/graphql-js/pull/907/files) in the validation tests.