### PR TITLE
feat(log): add panic logger func

### DIFF
--- a/log/log.go
+++ b/log/log.go
@@ -6,15 +6,23 @@ import (
 	"runtime"
 )
 
-// Logger is the interface used to log panics that occur during query execution. It is settable via graphql.ParseSchema
+// Logger is the interface used to log panics that occur during query execution. It is settable via graphql.ParseSchema.
 type Logger interface {
 	LogPanic(ctx context.Context, value interface{})
 }
 
-// DefaultLogger is the default logger used to log panics that occur during query execution
+// LoggerFunc is a function type that implements the Logger interface.
+type LoggerFunc func(ctx context.Context, value interface{})
+
+// LogPanic calls the LoggerFunc with the given context and panic value.
+func (f LoggerFunc) LogPanic(ctx context.Context, value interface{}) {
+	f(ctx, value)
+}
+
+// DefaultLogger is the default logger used to log panics that occur during query execution.
 type DefaultLogger struct{}
 
-// LogPanic is used to log recovered panic values that occur during query execution
+// LogPanic is used to log recovered panic values that occur during query execution.
 func (l *DefaultLogger) LogPanic(ctx context.Context, value interface{}) {
 	const size = 64 << 10
 	buf := make([]byte, size)

--- a/log/log_test.go
+++ b/log/log_test.go
@@ -1,0 +1,42 @@
+package log_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/graph-gophers/graphql-go"
+	"github.com/graph-gophers/graphql-go/log"
+)
+
+func ExampleLoggerFunc() {
+	logfn := log.LoggerFunc(func(ctx context.Context, err interface{}) {
+		// Here you can handle the panic, e.g., log it or send it to an error tracking service.
+		fmt.Printf("graphql: panic occurred: %v", err)
+	})
+
+	opts := []graphql.SchemaOpt{
+		graphql.Logger(logfn),
+		graphql.UseFieldResolvers(),
+	}
+
+	schemadef := `
+		type Query {
+			hello: String!
+		}
+	`
+	resolver := &struct {
+		Hello func() string
+	}{
+		Hello: func() string {
+			// Simulate a panic
+			panic("something went wrong")
+		},
+	}
+
+	schema := graphql.MustParseSchema(schemadef, resolver, opts...)
+	// Now, when you execute a query that causes a panic, it will be logged using the provided LoggerFunc.
+	schema.Exec(context.Background(), "{ hello }", "", nil)
+
+	// Output:
+	// graphql: panic occurred: something went wrong
+}


### PR DESCRIPTION
Add a logger func which can be used to log panic errors. This allows the users to choose between a logger type (i.e. struct) or a func analogous to `http.Handler` and `http.HandlerFunc`.