### PR TITLE
fix: disallow empty field lists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+[Unreleased]
+
+* [BUGFIX] Reject object, interface, and input object type definitions that declare zero fields/input values (spec compliance).
+
 [v1.7.0](https://github.com/graph-gophers/graphql-go/releases/tag/v1.7.0) Release v1.7.0
 
 * [FEATURE] Add resolver field selection inspection helpers (`SelectedFieldNames`, `HasSelectedField`, `SortedSelectedFieldNames`). Helpers are available by default and compute results lazily only when called. An explicit opt-out (`DisableFieldSelections()` schema option) is provided for applications that want to remove even the minimal context insertion overhead when the helpers are never used.
@@ -32,7 +36,7 @@
 
 * [FEATURE] Add types package #437
 * [FEATURE] Expose `packer.Unmarshaler` as `decode.Unmarshaler` to the public #450
-* [FEATURE] Add location fields to type definitions #454 
+* [FEATURE] Add location fields to type definitions #454
 * [FEATURE] `errors.Errorf` preserves original error similar to `fmt.Errorf` #456
 * [BUGFIX] Fix duplicated __typename in response (fixes #369) #443
 

--- a/example_nullbool_test.go
+++ b/example_nullbool_test.go
@@ -20,6 +20,10 @@ func (*mutnb) Toggle(args struct{ Enabled graphql.NullBool }) string {
 	return fmt.Sprintf("enabled '%v'", *args.Enabled.Value)
 }
 
+func (r *mutnb) Name() string {
+	return "test"
+}
+
 // ExampleNullBool demonstrates how to use nullable Bool type when it is necessary to differentiate between nil and not set.
 func ExampleNullBool() {
 	const s = `
@@ -27,7 +31,9 @@ func ExampleNullBool() {
 			query: Query
 			mutation: Mutation
 		}
-		type Query{}
+		type Query{
+			name: String!
+		}
 		type Mutation{
 			toggle(enabled: Boolean): String!
 		}

--- a/example_scalar_map_test.go
+++ b/example_scalar_map_test.go
@@ -31,6 +31,10 @@ type Args struct {
 
 type mutation struct{}
 
+func (m *mutation) Name() string {
+	return "test"
+}
+
 func (*mutation) Hello(args Args) string {
 	fmt.Println(args)
 	return "Args accepted!"
@@ -40,7 +44,9 @@ func Example_customScalarMap() {
 	s := `
 		scalar Map
 	
-		type Query {}
+		type Query {
+			name: String!
+		}
 		
 		type Mutation {
 			hello(

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -1459,6 +1459,10 @@ func (r *testDeprecatedDirectiveResolver) C() int32 {
 	return 0
 }
 
+func (r *testDeprecatedDirectiveResolver) Name() string {
+	return "test"
+}
+
 func TestDeprecatedDirective(t *testing.T) {
 	t.Parallel()
 
@@ -1511,6 +1515,7 @@ func TestDeprecatedDirective(t *testing.T) {
 				}
 
 				type Query {
+					name: String!
 				}
 
 				enum Test {
@@ -1552,6 +1557,9 @@ func TestDeprecatedDirective(t *testing.T) {
 }
 
 func TestSpecifiedByDirective(t *testing.T) {
+	type nameResolver struct {
+		Name string
+	}
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
 			Schema: graphql.MustParseSchema(`
@@ -1559,11 +1567,12 @@ func TestSpecifiedByDirective(t *testing.T) {
 				query: Query
 			}
 			type Query {
+			    name: String!
 			}
 			scalar UUID @specifiedBy(
 				url: "https://tools.ietf.org/html/rfc4122"
 			)
-			`, &struct{}{}),
+			`, &nameResolver{Name: "Pavel"}, graphql.UseFieldResolvers()),
 			Query: `
 				query {
 					__type(name: "UUID") {

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -259,12 +259,18 @@ func mergeExtensions(s *ast.Schema) error {
 func resolveNamedType(s *ast.Schema, t ast.NamedType) error {
 	switch t := t.(type) {
 	case *ast.ObjectTypeDefinition:
+		if len(t.Fields) == 0 {
+			return errors.Errorf("object type %q must define one or more fields", t.Name)
+		}
 		for _, f := range t.Fields {
 			if err := resolveField(s, f); err != nil {
 				return err
 			}
 		}
 	case *ast.InterfaceTypeDefinition:
+		if len(t.Fields) == 0 {
+			return errors.Errorf("interface type %q must define one or more fields", t.Name)
+		}
 		for _, f := range t.Fields {
 			if err := resolveField(s, f); err != nil {
 				return err
@@ -274,6 +280,9 @@ func resolveNamedType(s *ast.Schema, t ast.NamedType) error {
 			return err
 		}
 	case *ast.InputObject:
+		if len(t.Values) == 0 {
+			return errors.Errorf("input object type %q must define one or more fields", t.Name)
+		}
 		if err := resolveInputObject(s, t.Values); err != nil {
 			return err
 		}

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -41,8 +41,9 @@ func TestParse(t *testing.T) {
 			sdl: `
 			interface Greeting { 
 				message: String!
-			} 
+			}
 			type Welcome implements Greeting {
+				id: ID!
 			}`,
 			validateError: func(err error) error {
 				if err == nil {
@@ -967,7 +968,7 @@ Second line of the description.
 		{
 			name: "Decorating input object with an undeclared directive should return an error",
 			sdl: `
-			input InputObject @undeclareddirective{}
+			input InputObject @undeclareddirective{field: String!}
 			`,
 			validateError: func(err error) error {
 				prefix := `graphql: directive "undeclareddirective" not found`
@@ -980,7 +981,7 @@ Second line of the description.
 		{
 			name: "Decorating interface with an undeclared directive should return an error",
 			sdl: `
-			interface I @undeclareddirective {}
+			interface I @undeclareddirective {field: String!}
 			`,
 			validateError: func(err error) error {
 				prefix := `graphql: directive "undeclareddirective" not found`

--- a/schema_empty_types_test.go
+++ b/schema_empty_types_test.go
@@ -1,0 +1,48 @@
+package graphql_test
+
+import (
+	"testing"
+
+	"github.com/graph-gophers/graphql-go"
+)
+
+func TestSchemaEmptyTypeDefinitions(t *testing.T) {
+	cases := []struct {
+		name    string
+		sdl     string
+		wantErr bool
+	}{
+		{
+			name:    "empty object type",
+			sdl:     `type Query { dummy: Int } type Empty { }`,
+			wantErr: true,
+		},
+		{
+			name:    "empty interface type",
+			sdl:     `type Query { dummy: Int } interface EmptyInterface { }`,
+			wantErr: true,
+		},
+		{
+			name:    "empty input object type",
+			sdl:     `type Query { dummy(arg: EmptyInput): Int } input EmptyInput { }`,
+			wantErr: true,
+		},
+		{
+			name:    "valid types (controls)",
+			sdl:     `type Query { dummy: Int } interface Node { id: ID! } input Something { v: Int }`,
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := graphql.ParseSchema(tc.sdl, nil)
+			if tc.wantErr && err == nil {
+				t.Fatalf("expected error for %s, got none", tc.name)
+			}
+			if !tc.wantErr && err != nil {
+				t.Fatalf("unexpected error for %s: %v", tc.name, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Make the library compliant with the spects and disallow empty fields in [objects](https://spec.graphql.org/October2021/#sec-Objects.Type-Validation), [interfaces](https://spec.graphql.org/October2021/#sec-Interfaces.Type-Validation) and [input objects](https://spec.graphql.org/October2021/#sec-Input-Objects.Type-Validation).