### PR TITLE
chore: validation parity with graphql-js

### DIFF
--- a/example/social/introspect.json
+++ b/example/social/introspect.json
@@ -18,7 +18,8 @@
         "locations": [
           "FIELD_DEFINITION",
           "ENUM_VALUE",
-          "ARGUMENT_DEFINITION"
+          "ARGUMENT_DEFINITION",
+          "INPUT_FIELD_DEFINITION"
         ],
         "name": "deprecated"
       },

--- a/example/starwars/introspect.json
+++ b/example/starwars/introspect.json
@@ -18,7 +18,8 @@
         "locations": [
           "FIELD_DEFINITION",
           "ENUM_VALUE",
-          "ARGUMENT_DEFINITION"
+          "ARGUMENT_DEFINITION",
+          "INPUT_FIELD_DEFINITION"
         ],
         "name": "deprecated"
       },

--- a/example/starwars/starwars.go
+++ b/example/starwars/starwars.go
@@ -284,6 +284,10 @@ type review struct {
 
 var reviews = make(map[string][]*review)
 
+func ResetReviews() {
+	reviews = make(map[string][]*review)
+}
+
 type Resolver struct{}
 
 func (*Resolver) Query() *QueryResolver {

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -1660,7 +1660,7 @@ func TestEnums(t *testing.T) {
 			`,
 			ExpectedErrors: []*gqlerrors.QueryError{
 				{
-					Message:   "Argument \"episode\" has invalid value WRATH_OF_KHAN.\nExpected type \"Episode\", found WRATH_OF_KHAN.",
+					Message:   "Value \"WRATH_OF_KHAN\" does not exist in \"Episode\" enum.",
 					Locations: []gqlerrors.Location{{Column: 20, Line: 3}},
 					Rule:      "ValuesOfCorrectTypeRule",
 				},
@@ -2150,6 +2150,8 @@ func TestConnections(t *testing.T) {
 }
 
 func TestMutation(t *testing.T) {
+	starwars.ResetReviews()
+
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{
 			Schema: starwarsSchema,
@@ -2557,7 +2559,8 @@ func TestIntrospection(t *testing.T) {
 									"locations": [
 										"FIELD_DEFINITION",
 										"ENUM_VALUE",
-										"ARGUMENT_DEFINITION"
+										"ARGUMENT_DEFINITION",
+										"INPUT_FIELD_DEFINITION"
 									],
 									"args": [
 										{
@@ -4484,7 +4487,7 @@ func TestQueryVariablesValidation(t *testing.T) {
         			}
         		}`,
 		ExpectedErrors: []*gqlerrors.QueryError{{
-			Message:   "Argument \"filter\" has invalid value {}.\nIn field \"required\": Expected \"String!\", found null.",
+			Message:   "Field \"SearchFilter.required\" of required type \"String!\" was not provided.",
 			Locations: []gqlerrors.Location{{Line: 3, Column: 27}},
 			Rule:      "ValuesOfCorrectTypeRule",
 		}},

--- a/internal/schema/meta.go
+++ b/internal/schema/meta.go
@@ -56,7 +56,7 @@ var metaSrc = `
 		# for how to access supported similar data. Formatted in
 		# [Markdown](https://daringfireball.net/projects/markdown/).
 		reason: String = "No longer supported"
-	) on FIELD_DEFINITION | ENUM_VALUE | ARGUMENT_DEFINITION
+	) on FIELD_DEFINITION | ENUM_VALUE | ARGUMENT_DEFINITION | INPUT_FIELD_DEFINITION
 
 	# Provides a scalar specification URL for specifying the behavior of custom scalar types.
 	directive @specifiedBy(

--- a/internal/validation/testdata/README.md
+++ b/internal/validation/testdata/README.md
@@ -15,6 +15,11 @@ go generate .
 A Node.js project is used to pull in graphql-js as a dependency. The `export.cjs` script runs with Node,
 transpiles graphql-js TypeScript files on the fly, loads selected validation test files with a lightweight in-process Mocha shim, and captures expected validation errors into `tests.json`. These test cases in the JSON file are then used to drive the Go tests.
 
+Some upstream validation suites are intentionally disabled in `export.cjs` when
+they rely on currently unsupported behavior (for example, subscription-only
+fixtures) or known parser/validation parity gaps. Each disabled import has an
+inline rationale and should be re-evaluated as parity work progresses.
+
 ## Updating dependency
 
 With changes to [graphql-js], update the dependency and regenerate `tests.json`:

--- a/internal/validation/testdata/export.cjs
+++ b/internal/validation/testdata/export.cjs
@@ -9,7 +9,7 @@ Module._extensions['.ts'] = function compileTypeScript(module, filename) {
   const compiled = ts.transpileModule(source, {
     compilerOptions: {
       module: ts.ModuleKind.CommonJS,
-      moduleResolution: ts.ModuleResolutionKind.NodeJs,
+      moduleResolution: ts.ModuleResolutionKind.Node10,
       target: ts.ScriptTarget.ES2022,
       esModuleInterop: true,
       sourceMap: false,
@@ -67,14 +67,6 @@ describe.only = describe;
 describe.skip = () => {};
 
 function it(name, fn) {
-  if (
-    name === 'ignores type definitions' ||
-    name === 'reports correctly when a non-exclusive follows an exclusive' ||
-    name === 'disallows differing subfields'
-  ) {
-    return;
-  }
-
   suiteNames.push(name);
 
   try {

--- a/internal/validation/testdata/export.cjs
+++ b/internal/validation/testdata/export.cjs
@@ -46,6 +46,7 @@ Module._resolveFilename = function patchedResolveFilename(request, parent, ...re
 const captured = [];
 const suiteNames = [];
 const schemaRefs = [];
+const graphqlRootDir = path.dirname(require.resolve('graphql/package.json'));
 
 const { printSchema } = require('graphql/src/utilities/printSchema.ts');
 
@@ -136,37 +137,29 @@ harness.expectValidationErrors = function expectValidationErrors(rule, queryStr)
   return harness.expectValidationErrorsWithSchema(harness.testSchema, rule, queryStr);
 };
 
-// Import test files to register test cases (these need to run first)
-// TODO: Fix test failures.
-// require('graphql/src/validation/__tests__/ExecutableDefinitions-test.ts');
-require('graphql/src/validation/__tests__/FieldsOnCorrectTypeRule-test.ts');
-require('graphql/src/validation/__tests__/FragmentsOnCompositeTypesRule-test.ts');
-require('graphql/src/validation/__tests__/KnownArgumentNamesRule-test.ts');
-require('graphql/src/validation/__tests__/KnownDirectivesRule-test.ts');
-require('graphql/src/validation/__tests__/KnownFragmentNamesRule-test.ts');
-require('graphql/src/validation/__tests__/KnownTypeNamesRule-test.ts');
-require('graphql/src/validation/__tests__/LoneAnonymousOperationRule-test.ts');
-require('graphql/src/validation/__tests__/NoFragmentCyclesRule-test.ts');
-require('graphql/src/validation/__tests__/NoUndefinedVariablesRule-test.ts');
-require('graphql/src/validation/__tests__/NoUnusedFragmentsRule-test.ts');
-require('graphql/src/validation/__tests__/NoUnusedVariablesRule-test.ts');
-require('graphql/src/validation/__tests__/OverlappingFieldsCanBeMergedRule-test.ts');
-require('graphql/src/validation/__tests__/PossibleFragmentSpreadsRule-test.ts');
-require('graphql/src/validation/__tests__/ProvidedRequiredArgumentsRule-test.ts');
-require('graphql/src/validation/__tests__/ScalarLeafsRule-test.ts');
-// TODO: Add support for subscriptions.
-// require('graphql/src/validation/__tests__/SingleFieldSubscriptions-test.ts');
-require('graphql/src/validation/__tests__/UniqueArgumentNamesRule-test.ts');
-require('graphql/src/validation/__tests__/UniqueDirectivesPerLocationRule-test.ts');
-require('graphql/src/validation/__tests__/UniqueFragmentNamesRule-test.ts');
-require('graphql/src/validation/__tests__/UniqueInputFieldNamesRule-test.ts');
-require('graphql/src/validation/__tests__/UniqueOperationNamesRule-test.ts');
-require('graphql/src/validation/__tests__/UniqueVariableNamesRule-test.ts');
-require('graphql/src/validation/__tests__/ValuesOfCorrectTypeRule-test.ts');
-require('graphql/src/validation/__tests__/VariablesAreInputTypesRule-test.ts');
-// TODO: Fix test failures.
-// require('graphql/src/validation/__tests__/VariablesDefaultValueAllowed-test.ts');
-require('graphql/src/validation/__tests__/VariablesInAllowedPositionRule-test.ts');
+const validationTestsDir = path.join(graphqlRootDir, 'src/validation/__tests__');
+const incompatibleSuites = new Set([
+  // graphql-go does not target single-field subscription parity in this fixture set yet.
+  'SingleFieldSubscriptionsRule-test.ts',
+  // graphql-go does not expose graphql-js custom validation rule MaxIntrospectionDepthRule.
+  'MaxIntrospectionDepthRule-test.ts',
+  // graphql-go does not expose graphql-js custom validation rule NoSchemaIntrospectionCustomRule.
+  'NoSchemaIntrospectionCustomRule-test.ts',
+]);
+
+const suiteFiles = fs
+  .readdirSync(validationTestsDir, { withFileTypes: true })
+  .filter(entry => entry.isFile() && entry.name.endsWith('-test.ts'))
+  .map(entry => entry.name)
+  .sort();
+
+for (const suiteFile of suiteFiles) {
+  if (incompatibleSuites.has(suiteFile)) {
+    continue;
+  }
+
+  require(path.join(validationTestsDir, suiteFile));
+}
 
 let schemas = schemaRefs.map(schema => {
   const sdl = printSchema(schema);

--- a/internal/validation/testdata/tests.json
+++ b/internal/validation/testdata/tests.json
@@ -2790,6 +2790,35 @@
       ]
     },
     {
+      "name": "Validate: Overlapping fields can be merged/return types must be unambiguous/reports correctly when a non-exclusive follows an exclusive",
+      "rule": "OverlappingFieldsCanBeMergedRule",
+      "schema": "lI0vTN4faZpDsH78EAqnHxgWvSXnGiiQrLUtNc+zVJw=",
+      "query": "\n          {\n            someBox {\n              ... on IntBox {\n                deepBox {\n                  ...X\n                }\n              }\n            }\n            someBox {\n              ... on StringBox {\n                deepBox {\n                  ...Y\n                }\n              }\n            }\n            memoed: someBox {\n              ... on IntBox {\n                deepBox {\n                  ...X\n                }\n              }\n            }\n            memoed: someBox {\n              ... on StringBox {\n                deepBox {\n                  ...Y\n                }\n              }\n            }\n            other: someBox {\n              ...X\n            }\n            other: someBox {\n              ...Y\n            }\n          }\n          fragment X on SomeBox {\n            scalar\n          }\n          fragment Y on SomeBox {\n            scalar: unrelatedField\n          }\n        ",
+      "errors": [
+        {
+          "message": "Fields \"other\" conflict because subfields \"scalar\" conflict because \"scalar\" and \"unrelatedField\" are different fields. Use different aliases on the fields to fetch both if this was intentional.",
+          "locations": [
+            {
+              "line": 31,
+              "column": 13
+            },
+            {
+              "line": 39,
+              "column": 13
+            },
+            {
+              "line": 34,
+              "column": 13
+            },
+            {
+              "line": 42,
+              "column": 13
+            }
+          ]
+        }
+      ]
+    },
+    {
       "name": "Validate: Overlapping fields can be merged/return types must be unambiguous/disallows differing return type nullability despite no overlap",
       "rule": "OverlappingFieldsCanBeMergedRule",
       "schema": "lI0vTN4faZpDsH78EAqnHxgWvSXnGiiQrLUtNc+zVJw=",
@@ -2847,6 +2876,27 @@
             {
               "line": 10,
               "column": 17
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Validate: Overlapping fields can be merged/return types must be unambiguous/disallows differing subfields",
+      "rule": "OverlappingFieldsCanBeMergedRule",
+      "schema": "lI0vTN4faZpDsH78EAqnHxgWvSXnGiiQrLUtNc+zVJw=",
+      "query": "\n          {\n            someBox {\n              ... on IntBox {\n                box: stringBox {\n                  val: scalar\n                  val: unrelatedField\n                }\n              }\n              ... on StringBox {\n                box: stringBox {\n                  val: scalar\n                }\n              }\n            }\n          }\n        ",
+      "errors": [
+        {
+          "message": "Fields \"val\" conflict because \"scalar\" and \"unrelatedField\" are different fields. Use different aliases on the fields to fetch both if this was intentional.",
+          "locations": [
+            {
+              "line": 6,
+              "column": 19
+            },
+            {
+              "line": 7,
+              "column": 19
             }
           ]
         }

--- a/internal/validation/testdata/tests.json
+++ b/internal/validation/testdata/tests.json
@@ -5,6 +5,18 @@
       "sdl": "directive @onQuery on QUERY\n\ndirective @onMutation on MUTATION\n\ndirective @onSubscription on SUBSCRIPTION\n\ndirective @onField on FIELD\n\ndirective @onFragmentDefinition on FRAGMENT_DEFINITION\n\ndirective @onFragmentSpread on FRAGMENT_SPREAD\n\ndirective @onInlineFragment on INLINE_FRAGMENT\n\ndirective @onVariableDefinition on VARIABLE_DEFINITION\n\ntype Query {\n  dummy: String\n}"
     },
     {
+      "id": "Ju1H8WKxt95vnuzAQz75L9JT/W+GwE3JLSv4p7w2Aa8=",
+      "sdl": "directive @someDirective(normalArg: String, deprecatedArg: String @deprecated(reason: \"Some arg reason.\")) on FIELD\n\ntype Query {\n  someField: String\n}"
+    },
+    {
+      "id": "tQLpFAeM24vdDKIIZe4kz+GZD5OL+HojfbN9WdPVaQE=",
+      "sdl": "directive @someDirective(someArg: InputType) on FIELD\n\ninput InputType {\n  normalField: String\n  deprecatedField: String @deprecated(reason: \"Some input field reason.\")\n}\n\ntype Query {\n  someField(someArg: InputType): String\n}"
+    },
+    {
+      "id": "2qyt7N2OkolAmpdwhY4sUNUs1tK69PbUrrMsIZYSeDI=",
+      "sdl": "enum EnumType {\n  NORMAL_VALUE\n  DEPRECATED_VALUE @deprecated(reason: \"Some enum reason.\")\n}\n\ntype Query {\n  someField(enumArg: EnumType): String\n}"
+    },
+    {
       "id": "FPFhio7mA1zxXhXd/8NCpbdwBrysWfBkn36GZ1uvDAA=",
       "sdl": "input SomeInput {\n  a: String\n  b: String\n}\n\ntype Query {\n  someField(arg: SomeInput): String\n}"
     },
@@ -45,11 +57,94 @@
       "sdl": "type Query {\n  invalidArg(arg: CustomScalar): String\n}\n\nscalar CustomScalar"
     },
     {
+      "id": "4j+i1Ccyc1jIBonw6um5nG/psLPZZF0gITulJ1ZTbFg=",
+      "sdl": "type Query {\n  normalField: String\n  deprecatedField: String @deprecated(reason: \"Some field reason.\")\n}"
+    },
+    {
       "id": "6+inK6Z824FQA4uBaUhxFXmMhc79+vKbamUi32/NtdQ=",
       "sdl": "type Query {\n  someField(a: String, b: String): String\n}"
+    },
+    {
+      "id": "HBXrgVi0mNZ9SLn1G8AUa2/quB8U1lIj0XtN51eWxJo=",
+      "sdl": "type Query {\n  someField(normalArg: String, deprecatedArg: String @deprecated(reason: \"Some arg reason.\")): String\n}"
     }
   ],
   "tests": [
+    {
+      "name": "Validate: Executable definitions/with only operation",
+      "rule": "ExecutableDefinitionsRule",
+      "schema": "70tUDwcPSZzv9khhs9WW2+o2xvsp13FhjrvVhLjYen4=",
+      "query": "\n      query Foo {\n        dog {\n          name\n        }\n      }\n    ",
+      "errors": []
+    },
+    {
+      "name": "Validate: Executable definitions/with operation and fragment",
+      "rule": "ExecutableDefinitionsRule",
+      "schema": "70tUDwcPSZzv9khhs9WW2+o2xvsp13FhjrvVhLjYen4=",
+      "query": "\n      query Foo {\n        dog {\n          name\n          ...Frag\n        }\n      }\n\n      fragment Frag on Dog {\n        name\n      }\n    ",
+      "errors": []
+    },
+    {
+      "name": "Validate: Executable definitions/with type definition",
+      "rule": "ExecutableDefinitionsRule",
+      "schema": "70tUDwcPSZzv9khhs9WW2+o2xvsp13FhjrvVhLjYen4=",
+      "query": "\n      query Foo {\n        dog {\n          name\n        }\n      }\n\n      type Cow {\n        name: String\n      }\n\n      extend type Dog {\n        color: String\n      }\n    ",
+      "errors": [
+        {
+          "message": "The \"Cow\" definition is not executable.",
+          "locations": [
+            {
+              "line": 8,
+              "column": 7
+            }
+          ]
+        },
+        {
+          "message": "The \"Dog\" definition is not executable.",
+          "locations": [
+            {
+              "line": 12,
+              "column": 7
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Validate: Executable definitions/with schema definition",
+      "rule": "ExecutableDefinitionsRule",
+      "schema": "70tUDwcPSZzv9khhs9WW2+o2xvsp13FhjrvVhLjYen4=",
+      "query": "\n      schema {\n        query: Query\n      }\n\n      type Query {\n        test: String\n      }\n\n      extend schema @directive\n    ",
+      "errors": [
+        {
+          "message": "The schema definition is not executable.",
+          "locations": [
+            {
+              "line": 2,
+              "column": 7
+            }
+          ]
+        },
+        {
+          "message": "The \"Query\" definition is not executable.",
+          "locations": [
+            {
+              "line": 6,
+              "column": 7
+            }
+          ]
+        },
+        {
+          "message": "The schema definition is not executable.",
+          "locations": [
+            {
+              "line": 10,
+              "column": 7
+            }
+          ]
+        }
+      ]
+    },
     {
       "name": "Validate: Fields on correct type/Object field selection",
       "rule": "FieldsOnCorrectTypeRule",
@@ -996,6 +1091,188 @@
             {
               "line": 2,
               "column": 7
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Validate: no deprecated/no deprecated fields/ignores fields that are not deprecated",
+      "rule": "NoDeprecatedCustomRule",
+      "schema": "4j+i1Ccyc1jIBonw6um5nG/psLPZZF0gITulJ1ZTbFg=",
+      "query": "\n        {\n          normalField\n        }\n      ",
+      "errors": []
+    },
+    {
+      "name": "Validate: no deprecated/no deprecated fields/ignores unknown fields",
+      "rule": "NoDeprecatedCustomRule",
+      "schema": "4j+i1Ccyc1jIBonw6um5nG/psLPZZF0gITulJ1ZTbFg=",
+      "query": "\n        {\n          unknownField\n        }\n\n        fragment UnknownFragment on UnknownType {\n          deprecatedField\n        }\n      ",
+      "errors": []
+    },
+    {
+      "name": "Validate: no deprecated/no deprecated fields/reports error when a deprecated field is selected",
+      "rule": "NoDeprecatedCustomRule",
+      "schema": "4j+i1Ccyc1jIBonw6um5nG/psLPZZF0gITulJ1ZTbFg=",
+      "query": "\n        {\n          deprecatedField\n        }\n\n        fragment QueryFragment on Query {\n          deprecatedField\n        }\n      ",
+      "errors": [
+        {
+          "message": "The field Query.deprecatedField is deprecated. Some field reason.",
+          "locations": [
+            {
+              "line": 3,
+              "column": 11
+            }
+          ]
+        },
+        {
+          "message": "The field Query.deprecatedField is deprecated. Some field reason.",
+          "locations": [
+            {
+              "line": 7,
+              "column": 11
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Validate: no deprecated/no deprecated arguments on fields/ignores arguments that are not deprecated",
+      "rule": "NoDeprecatedCustomRule",
+      "schema": "HBXrgVi0mNZ9SLn1G8AUa2/quB8U1lIj0XtN51eWxJo=",
+      "query": "\n        {\n          normalField(normalArg: \"\")\n        }\n      ",
+      "errors": []
+    },
+    {
+      "name": "Validate: no deprecated/no deprecated arguments on fields/ignores unknown arguments",
+      "rule": "NoDeprecatedCustomRule",
+      "schema": "HBXrgVi0mNZ9SLn1G8AUa2/quB8U1lIj0XtN51eWxJo=",
+      "query": "\n        {\n          someField(unknownArg: \"\")\n          unknownField(deprecatedArg: \"\")\n        }\n      ",
+      "errors": []
+    },
+    {
+      "name": "Validate: no deprecated/no deprecated arguments on fields/reports error when a deprecated argument is used",
+      "rule": "NoDeprecatedCustomRule",
+      "schema": "HBXrgVi0mNZ9SLn1G8AUa2/quB8U1lIj0XtN51eWxJo=",
+      "query": "\n        {\n          someField(deprecatedArg: \"\")\n        }\n      ",
+      "errors": [
+        {
+          "message": "Field \"Query.someField\" argument \"deprecatedArg\" is deprecated. Some arg reason.",
+          "locations": [
+            {
+              "line": 3,
+              "column": 21
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Validate: no deprecated/no deprecated arguments on directives/ignores arguments that are not deprecated",
+      "rule": "NoDeprecatedCustomRule",
+      "schema": "Ju1H8WKxt95vnuzAQz75L9JT/W+GwE3JLSv4p7w2Aa8=",
+      "query": "\n        {\n          someField @someDirective(normalArg: \"\")\n        }\n      ",
+      "errors": []
+    },
+    {
+      "name": "Validate: no deprecated/no deprecated arguments on directives/ignores unknown arguments",
+      "rule": "NoDeprecatedCustomRule",
+      "schema": "Ju1H8WKxt95vnuzAQz75L9JT/W+GwE3JLSv4p7w2Aa8=",
+      "query": "\n        {\n          someField @someDirective(unknownArg: \"\")\n          someField @unknownDirective(deprecatedArg: \"\")\n        }\n      ",
+      "errors": []
+    },
+    {
+      "name": "Validate: no deprecated/no deprecated arguments on directives/reports error when a deprecated argument is used",
+      "rule": "NoDeprecatedCustomRule",
+      "schema": "Ju1H8WKxt95vnuzAQz75L9JT/W+GwE3JLSv4p7w2Aa8=",
+      "query": "\n        {\n          someField @someDirective(deprecatedArg: \"\")\n        }\n      ",
+      "errors": [
+        {
+          "message": "Directive \"@someDirective\" argument \"deprecatedArg\" is deprecated. Some arg reason.",
+          "locations": [
+            {
+              "line": 3,
+              "column": 36
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Validate: no deprecated/no deprecated input fields/ignores input fields that are not deprecated",
+      "rule": "NoDeprecatedCustomRule",
+      "schema": "tQLpFAeM24vdDKIIZe4kz+GZD5OL+HojfbN9WdPVaQE=",
+      "query": "\n        {\n          someField(\n            someArg: { normalField: \"\" }\n          ) @someDirective(someArg: { normalField: \"\" })\n        }\n      ",
+      "errors": []
+    },
+    {
+      "name": "Validate: no deprecated/no deprecated input fields/ignores unknown input fields",
+      "rule": "NoDeprecatedCustomRule",
+      "schema": "tQLpFAeM24vdDKIIZe4kz+GZD5OL+HojfbN9WdPVaQE=",
+      "query": "\n        {\n          someField(\n            someArg: { unknownField: \"\" }\n          )\n\n          someField(\n            unknownArg: { unknownField: \"\" }\n          )\n\n          unknownField(\n            unknownArg: { unknownField: \"\" }\n          )\n        }\n      ",
+      "errors": []
+    },
+    {
+      "name": "Validate: no deprecated/no deprecated input fields/reports error when a deprecated input field is used",
+      "rule": "NoDeprecatedCustomRule",
+      "schema": "tQLpFAeM24vdDKIIZe4kz+GZD5OL+HojfbN9WdPVaQE=",
+      "query": "\n        {\n          someField(\n            someArg: { deprecatedField: \"\" }\n          ) @someDirective(someArg: { deprecatedField: \"\" })\n        }\n      ",
+      "errors": [
+        {
+          "message": "The input field InputType.deprecatedField is deprecated. Some input field reason.",
+          "locations": [
+            {
+              "line": 4,
+              "column": 24
+            }
+          ]
+        },
+        {
+          "message": "The input field InputType.deprecatedField is deprecated. Some input field reason.",
+          "locations": [
+            {
+              "line": 5,
+              "column": 39
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Validate: no deprecated/no deprecated enum values/ignores enum values that are not deprecated",
+      "rule": "NoDeprecatedCustomRule",
+      "schema": "2qyt7N2OkolAmpdwhY4sUNUs1tK69PbUrrMsIZYSeDI=",
+      "query": "\n        {\n          normalField(enumArg: NORMAL_VALUE)\n        }\n      ",
+      "errors": []
+    },
+    {
+      "name": "Validate: no deprecated/no deprecated enum values/ignores unknown enum values",
+      "rule": "NoDeprecatedCustomRule",
+      "schema": "2qyt7N2OkolAmpdwhY4sUNUs1tK69PbUrrMsIZYSeDI=",
+      "query": "\n        query (\n          $unknownValue: EnumType = UNKNOWN_VALUE\n          $unknownType: UnknownType = UNKNOWN_VALUE\n        ) {\n          someField(enumArg: UNKNOWN_VALUE)\n          someField(unknownArg: UNKNOWN_VALUE)\n          unknownField(unknownArg: UNKNOWN_VALUE)\n        }\n\n        fragment SomeFragment on Query {\n          someField(enumArg: UNKNOWN_VALUE)\n        }\n      ",
+      "errors": []
+    },
+    {
+      "name": "Validate: no deprecated/no deprecated enum values/reports error when a deprecated enum value is used",
+      "rule": "NoDeprecatedCustomRule",
+      "schema": "2qyt7N2OkolAmpdwhY4sUNUs1tK69PbUrrMsIZYSeDI=",
+      "query": "\n        query (\n          $variable: EnumType = DEPRECATED_VALUE\n        ) {\n          someField(enumArg: DEPRECATED_VALUE)\n        }\n      ",
+      "errors": [
+        {
+          "message": "The enum value \"EnumType.DEPRECATED_VALUE\" is deprecated. Some enum reason.",
+          "locations": [
+            {
+              "line": 3,
+              "column": 33
+            }
+          ]
+        },
+        {
+          "message": "The enum value \"EnumType.DEPRECATED_VALUE\" is deprecated. Some enum reason.",
+          "locations": [
+            {
+              "line": 5,
+              "column": 30
             }
           ]
         }

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -38,7 +38,7 @@ type context struct {
 	opErrs               map[*ast.OperationDefinition][]*errors.QueryError
 	usedVars             map[*ast.OperationDefinition]varSet
 	fieldMap             map[*ast.Field]fieldInfo
-	overlapValidated     map[selectionPair]struct{}
+	overlapValidated     map[selectionPair]bool
 	maxDepth             int
 	overlapPairLimit     int
 	overlapPairsObserved int
@@ -69,7 +69,7 @@ func newContext(s *ast.Schema, doc *ast.ExecutableDefinition, maxDepth int, over
 		opErrs:           make(map[*ast.OperationDefinition][]*errors.QueryError),
 		usedVars:         make(map[*ast.OperationDefinition]varSet),
 		fieldMap:         make(map[*ast.Field]fieldInfo),
-		overlapValidated: make(map[selectionPair]struct{}),
+		overlapValidated: make(map[selectionPair]bool),
 		maxDepth:         maxDepth,
 		overlapPairLimit: overlapPairLimit,
 	}
@@ -365,7 +365,7 @@ func validateSelectionSet(c *opContext, sels []ast.Selection, t ast.NamedType) {
 				if c.overlapLimitHit {
 					break
 				}
-				c.validateOverlap(a, b, nil, nil)
+				c.validateOverlap(a, b, nil, nil, false)
 			}
 		}
 	}
@@ -386,14 +386,14 @@ func validateSelectionSet(c *opContext, sels []ast.Selection, t ast.NamedType) {
 				if c.overlapLimitHit {
 					break
 				}
-				c.validateOverlap(fld, fa, nil, nil)
+				c.validateOverlap(fld, fa, nil, nil, false)
 			}
 			// Compare fragment with following fragments
 			for _, fb := range fragments[i+1:] {
 				if c.overlapLimitHit {
 					break
 				}
-				c.validateOverlap(fa, fb, nil, nil)
+				c.validateOverlap(fa, fb, nil, nil, false)
 			}
 		}
 	}
@@ -633,7 +633,7 @@ func detectFragmentCycleSel(c *context, sel ast.Selection, fragVisited map[*ast.
 	}
 }
 
-func (c *context) validateOverlap(a, b ast.Selection, reasons *[]string, locs *[]errors.Location) {
+func (c *context) validateOverlap(a, b ast.Selection, reasons *[]string, locs *[]errors.Location, parentMutuallyExclusive bool) {
 	if a == b {
 		return
 	}
@@ -645,10 +645,16 @@ func (c *context) validateOverlap(a, b ast.Selection, reasons *[]string, locs *[
 	if pb < pa { // canonical ordering for key only
 		key = selectionPair{a: b, b: a}
 	}
-	if _, ok := c.overlapValidated[key]; ok {
-		return
+	if existing, ok := c.overlapValidated[key]; ok {
+		// Mutually exclusive comparisons are always safe to skip once this pair was seen.
+		if parentMutuallyExclusive {
+			return
+		}
+		if !existing {
+			return
+		}
 	}
-	c.overlapValidated[key] = struct{}{}
+	c.overlapValidated[key] = parentMutuallyExclusive
 
 	if c.overlapPairLimit > 0 && !c.overlapLimitHit {
 		c.overlapPairsObserved++
@@ -675,7 +681,7 @@ func (c *context) validateOverlap(a, b ast.Selection, reasons *[]string, locs *[
 	case *ast.Field:
 		switch b := b.(type) {
 		case *ast.Field:
-			if reasons2, locs2 := c.validateFieldOverlap(a, b); len(reasons2) != 0 {
+			if reasons2, locs2 := c.validateFieldOverlap(a, b, parentMutuallyExclusive); len(reasons2) != 0 {
 				locs2 = append(locs2, a.Alias.Loc, b.Alias.Loc)
 				if reasons == nil {
 					c.addErrMultiLoc(locs2, "OverlappingFieldsCanBeMergedRule", "Fields %q conflict because %s. Use different aliases on the fields to fetch both if this was intentional.", a.Alias.Name, strings.Join(reasons2, " and "))
@@ -689,13 +695,13 @@ func (c *context) validateOverlap(a, b ast.Selection, reasons *[]string, locs *[
 
 		case *ast.InlineFragment:
 			for _, sel := range b.Selections {
-				c.validateOverlap(a, sel, reasons, locs)
+				c.validateOverlap(a, sel, reasons, locs, parentMutuallyExclusive)
 			}
 
 		case *ast.FragmentSpread:
 			if frag := c.doc.Fragments.Get(b.Name.Name); frag != nil {
 				for _, sel := range frag.Selections {
-					c.validateOverlap(a, sel, reasons, locs)
+					c.validateOverlap(a, sel, reasons, locs, parentMutuallyExclusive)
 				}
 			}
 
@@ -705,13 +711,13 @@ func (c *context) validateOverlap(a, b ast.Selection, reasons *[]string, locs *[
 
 	case *ast.InlineFragment:
 		for _, sel := range a.Selections {
-			c.validateOverlap(sel, b, reasons, locs)
+			c.validateOverlap(sel, b, reasons, locs, parentMutuallyExclusive)
 		}
 
 	case *ast.FragmentSpread:
 		if frag := c.doc.Fragments.Get(a.Name.Name); frag != nil {
 			for _, sel := range frag.Selections {
-				c.validateOverlap(sel, b, reasons, locs)
+				c.validateOverlap(sel, b, reasons, locs, parentMutuallyExclusive)
 			}
 		}
 
@@ -720,7 +726,7 @@ func (c *context) validateOverlap(a, b ast.Selection, reasons *[]string, locs *[
 	}
 }
 
-func (c *context) validateFieldOverlap(a, b *ast.Field) ([]string, []errors.Location) {
+func (c *context) validateFieldOverlap(a, b *ast.Field, parentMutuallyExclusive bool) ([]string, []errors.Location) {
 	if a.Alias.Name != b.Alias.Name {
 		return nil, nil
 	}
@@ -735,7 +741,8 @@ func (c *context) validateFieldOverlap(a, b *ast.Field) ([]string, []errors.Loca
 
 	at := c.fieldMap[a].parent
 	bt := c.fieldMap[b].parent
-	if at == nil || bt == nil || at == bt {
+	areMutuallyExclusive := parentMutuallyExclusive || mutuallyExclusiveParents(at, bt)
+	if !areMutuallyExclusive {
 		if a.Name.Name != b.Name.Name {
 			return []string{fmt.Sprintf("%q and %q are different fields", a.Name.Name, b.Name.Name)}, nil
 		}
@@ -781,21 +788,30 @@ func (c *context) validateFieldOverlap(a, b *ast.Field) ([]string, []errors.Loca
 			// Compare only against same-name fields + all non-field selections.
 			if matches := bFieldIndex[name]; len(matches) != 0 {
 				for _, bMatch := range matches {
-					c.validateOverlap(a2, bMatch, &reasons, &locs)
+					c.validateOverlap(a2, bMatch, &reasons, &locs, areMutuallyExclusive)
 				}
 			}
 			for _, bnf := range bNonField {
-				c.validateOverlap(a2, bnf, &reasons, &locs)
+				c.validateOverlap(a2, bnf, &reasons, &locs, areMutuallyExclusive)
 			}
 			continue
 		}
 		// For fragments / inline fragments we still need to compare against every selection in B.
 		for _, b2 := range b.SelectionSet {
-			c.validateOverlap(a2, b2, &reasons, &locs)
+			c.validateOverlap(a2, b2, &reasons, &locs, areMutuallyExclusive)
 		}
 	}
 
 	return reasons, locs
+}
+
+func mutuallyExclusiveParents(a, b ast.NamedType) bool {
+	if a == nil || b == nil || a == b {
+		return false
+	}
+	_, aIsObject := a.(*ast.ObjectTypeDefinition)
+	_, bIsObject := b.(*ast.ObjectTypeDefinition)
+	return aIsObject && bIsObject
 }
 
 func argumentsConflict(a, b ast.ArgumentList) bool {

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -26,6 +26,11 @@ type fieldInfo struct {
 	parent ast.NamedType
 }
 
+type valueTypeIssue struct {
+	loc     errors.Location
+	message string
+}
+
 type context struct {
 	schema               *ast.Schema
 	doc                  *ast.ExecutableDefinition
@@ -113,8 +118,20 @@ func Validate(s *ast.Schema, doc *ast.ExecutableDefinition, variables map[string
 						c.addErr(v.Default.Location(), "DefaultValuesOfCorrectType", "Variable %q of type %q is required and will not use the default value. Perhaps you meant to use type %q.", "$"+v.Name.Name, t, nn.OfType)
 					}
 
-					if ok, reason := validateValueType(opc, v.Default, t); !ok {
-						c.addErr(v.Default.Location(), "DefaultValuesOfCorrectType", "Variable %q of type %q has invalid default value %s.\n%s", "$"+v.Name.Name, t, v.Default, reason)
+					if inputType := unwrapInputObjectType(t); inputType != nil {
+						if obj, ok := v.Default.(*ast.ObjectValue); ok {
+							issues := collectInputObjectValueIssues(opc, obj, inputType)
+							if len(issues) > 0 {
+								for _, issue := range issues {
+									c.addErr(issue.loc, "ValuesOfCorrectTypeRule", "%s", issue.message)
+								}
+								continue
+							}
+						}
+					}
+
+					if ok, errLoc, reason := validateValueType(opc, v.Default, t); !ok {
+						c.addErr(errLoc, "ValuesOfCorrectTypeRule", "%s", reason)
 					}
 				}
 			}
@@ -422,10 +439,42 @@ func validateSelection(c *opContext, sel ast.Selection, t ast.NamedType) {
 
 		validateArgumentLiterals(c, sel.Arguments)
 		if f != nil {
+			if reason, ok := deprecatedReason(f.Directives); ok && t != nil {
+				c.addErr(sel.Name.Loc, "NoDeprecatedCustomRule", "The field %s.%s is deprecated. %s", t.TypeName(), fieldName, reason)
+			}
+
 			validateArgumentTypes(c, sel.Arguments, f.Arguments, sel.Alias.Loc,
 				func() string { return fmt.Sprintf(`field "%s.%s"`, t, fieldName) },
 				func() string { return fmt.Sprintf("Field %q", fieldName) },
 			)
+
+			if t != nil {
+				for _, selArg := range sel.Arguments {
+					argDecl := f.Arguments.Get(selArg.Name.Name)
+					if argDecl == nil {
+						continue
+					}
+					if reason, ok := deprecatedReason(argDecl.Directives); ok {
+						c.addErr(selArg.Name.Loc, "NoDeprecatedCustomRule", "Field %q argument %q is deprecated. %s", t.TypeName()+"."+fieldName, selArg.Name.Name, reason)
+					}
+				}
+
+				for _, directive := range sel.Directives {
+					directiveDef, ok := c.schema.Directives[directive.Name.Name]
+					if !ok {
+						continue
+					}
+					for _, selArg := range directive.Arguments {
+						argDecl := directiveDef.Arguments.Get(selArg.Name.Name)
+						if argDecl == nil {
+							continue
+						}
+						if reason, ok := deprecatedReason(argDecl.Directives); ok {
+							c.addErr(selArg.Name.Loc, "NoDeprecatedCustomRule", "Directive %q argument %q is deprecated. %s", "@"+directive.Name.Name, selArg.Name.Name, reason)
+						}
+					}
+				}
+			}
 		}
 
 		var ft ast.Type
@@ -823,6 +872,18 @@ func validateDirectives(c *opContext, loc string, directives ast.DirectiveList) 
 			func() string { return fmt.Sprintf("directive %q", "@"+dirName) },
 			func() string { return fmt.Sprintf("Directive %q", "@"+dirName) },
 		)
+
+		if loc != "FIELD" {
+			for _, selArg := range d.Arguments {
+				argDecl := dd.Arguments.Get(selArg.Name.Name)
+				if argDecl == nil {
+					continue
+				}
+				if reason, ok := deprecatedReason(argDecl.Directives); ok {
+					c.addErr(selArg.Name.Loc, "NoDeprecatedCustomRule", "Directive %q argument %q is deprecated. %s", "@"+dirName, selArg.Name.Name, reason)
+				}
+			}
+		}
 	}
 
 	// Iterating in the declared order, rather than using the directiveNames ordering which is random
@@ -884,8 +945,8 @@ func validateArgumentTypes(c *opContext, args ast.ArgumentList, argDecls ast.Arg
 			continue
 		}
 		value := selArg.Value
-		if ok, reason := validateValueType(c, value, arg.Type); !ok {
-			c.addErr(value.Location(), "ValuesOfCorrectTypeRule", "Argument %q has invalid value %s.\n%s", arg.Name.Name, value, reason)
+		if ok, errLoc, reason := validateValueType(c, value, arg.Type); !ok {
+			c.addErr(errLoc, "ValuesOfCorrectTypeRule", "%s", reason)
 		}
 	}
 	for _, decl := range argDecls {
@@ -952,13 +1013,13 @@ func validateLiteral(c *opContext, l ast.Value) {
 				})
 				continue
 			}
-			validateValueType(c, l, resolveType(c.context, v.Type))
+			_, _, _ = validateValueType(c, l, resolveType(c.context, v.Type))
 			c.usedVars[op][v] = struct{}{}
 		}
 	}
 }
 
-func validateValueType(c *opContext, v ast.Value, t ast.Type) (bool, string) {
+func validateValueType(c *opContext, v ast.Value, t ast.Type) (bool, errors.Location, string) {
 	if v, ok := v.(*ast.Variable); ok {
 		for _, op := range c.ops {
 			if v2 := op.Vars.Get(v.Name); v2 != nil {
@@ -973,54 +1034,71 @@ func validateValueType(c *opContext, v ast.Value, t ast.Type) (bool, string) {
 				}
 			}
 		}
-		return true, ""
+		return true, errors.Location{}, ""
 	}
 
 	if nn, ok := t.(*ast.NonNull); ok {
 		if isNull(v) {
-			return false, fmt.Sprintf("Expected %q, found null.", t)
+			return false, v.Location(), fmt.Sprintf("Expected value of type %q, found null.", t)
 		}
 		t = nn.OfType
 	}
 	if isNull(v) {
-		return true, ""
+		return true, errors.Location{}, ""
 	}
 
 	switch t := t.(type) {
 	case *ast.ScalarTypeDefinition, *ast.EnumTypeDefinition:
 		if lit, ok := v.(*ast.PrimitiveValue); ok {
-			if validateBasicLit(lit, t) {
-				return true, ""
+			if ok, reason := validateBasicLit(lit, t); ok {
+				if enumType, isEnum := t.(*ast.EnumTypeDefinition); isEnum && lit.Type == scanner.Ident {
+					for _, option := range enumType.EnumValuesDefinition {
+						if option.EnumValue != lit.Text {
+							continue
+						}
+						if depReason, deprecated := deprecatedReason(option.Directives); deprecated {
+							c.addErr(lit.Location(), "NoDeprecatedCustomRule", "The enum value %q is deprecated. %s", enumType.Name+"."+option.EnumValue, depReason)
+						}
+						break
+					}
+				}
+				return true, errors.Location{}, ""
+			} else {
+				return false, lit.Location(), reason
 			}
-			return false, fmt.Sprintf("Expected type %q, found %s.", t, v)
 		}
-		return true, ""
+		return true, errors.Location{}, ""
 
 	case *ast.List:
 		list, ok := v.(*ast.ListValue)
 		if !ok {
 			return validateValueType(c, v, t.OfType) // single value instead of list
 		}
-		for i, entry := range list.Values {
-			if ok, reason := validateValueType(c, entry, t.OfType); !ok {
-				return false, fmt.Sprintf("In element #%d: %s", i, reason)
+		for _, entry := range list.Values {
+			if ok, errLoc, reason := validateValueType(c, entry, t.OfType); !ok {
+				return false, errLoc, reason
 			}
 		}
-		return true, ""
+		return true, errors.Location{}, ""
 
 	case *ast.InputObject:
+		orig := v
 		v, ok := v.(*ast.ObjectValue)
 		if !ok {
-			return false, fmt.Sprintf("Expected %q, found not an object.", t)
+			return false, orig.Location(), fmt.Sprintf("Expected value of type %q, found %s.", t, orig)
 		}
 		for _, f := range v.Fields {
 			name := f.Name.Name
 			iv := t.Values.Get(name)
 			if iv == nil {
-				return false, fmt.Sprintf("In field %q: Unknown field.", name)
+				suggestion := makeSuggestion("Did you mean", t.Values.Names(), name)
+				return false, f.Name.Loc, fmt.Sprintf("Field %q is not defined by type %q.%s", name, t.Name, suggestion)
 			}
-			if ok, reason := validateValueType(c, f.Value, iv.Type); !ok {
-				return false, fmt.Sprintf("In field %q: %s", name, reason)
+			if depReason, deprecated := deprecatedReason(iv.Directives); deprecated {
+				c.addErr(f.Name.Loc, "NoDeprecatedCustomRule", "The input field %s.%s is deprecated. %s", t.Name, iv.Name.Name, depReason)
+			}
+			if ok, errLoc, reason := validateValueType(c, f.Value, iv.Type); !ok {
+				return false, errLoc, reason
 			}
 		}
 		for _, iv := range t.Values {
@@ -1033,7 +1111,7 @@ func validateValueType(c *opContext, v ast.Value, t ast.Type) (bool, string) {
 			}
 			if !found {
 				if _, ok := iv.Type.(*ast.NonNull); ok && iv.Default == nil {
-					return false, fmt.Sprintf("In field %q: Expected %q, found null.", iv.Name.Name, iv.Type)
+					return false, v.Location(), fmt.Sprintf("Field %q of required type %q was not provided.", t.Name+"."+iv.Name.Name, iv.Type)
 				}
 			}
 		}
@@ -1042,7 +1120,7 @@ func validateValueType(c *opContext, v ast.Value, t ast.Type) (bool, string) {
 		if t.Directives.Get("oneOf") != nil {
 			if len(v.Fields) != 1 {
 				c.addErr(v.Location(), "ValuesOfCorrectTypeRule", "OneOf Input Object %q must specify exactly one key.", t.Name)
-				return true, ""
+				return true, errors.Location{}, ""
 			}
 
 			f := v.Fields[0]
@@ -1050,7 +1128,7 @@ func validateValueType(c *opContext, v ast.Value, t ast.Type) (bool, string) {
 			// Check for explicit null values
 			if _, isNull := f.Value.(*ast.NullValue); isNull {
 				c.addErr(v.Location(), "ValuesOfCorrectTypeRule", "Field %q must be non-null.", t.Name+"."+f.Name.Name)
-				return true, ""
+				return true, errors.Location{}, ""
 			}
 
 			// Check for nullable variables
@@ -1063,54 +1141,143 @@ func validateValueType(c *opContext, v ast.Value, t ast.Type) (bool, string) {
 								varType = resolved
 							}
 							c.addErrMultiLoc([]errors.Location{varDef.Loc, varRef.Loc}, "VariablesInAllowedPositionRule", "Variable %q is of type %q but must be non-nullable to be used for OneOf Input Object %q.", "$"+varRef.Name, varType, t.Name)
-							return true, ""
+							return true, errors.Location{}, ""
 						}
 					}
 				}
 			}
 		}
 
-		return true, ""
+		return true, errors.Location{}, ""
 	}
 
-	return false, fmt.Sprintf("Expected type %q, found %s.", t, v)
+	return false, v.Location(), fmt.Sprintf("Expected type %q, found %s.", t, v)
 }
 
-func validateBasicLit(v *ast.PrimitiveValue, t ast.Type) bool {
+func deprecatedReason(directives ast.DirectiveList) (string, bool) {
+	deprecated := directives.Get("deprecated")
+	if deprecated == nil {
+		return "", false
+	}
+	arg, ok := deprecated.Arguments.Get("reason")
+	if !ok {
+		return "No longer supported", true
+	}
+	reason, ok := arg.Deserialize(nil).(string)
+	if !ok || reason == "" {
+		return "No longer supported", true
+	}
+	return reason, true
+}
+
+func unwrapInputObjectType(t ast.Type) *ast.InputObject {
+	for {
+		switch tt := t.(type) {
+		case *ast.NonNull:
+			t = tt.OfType
+		case *ast.InputObject:
+			return tt
+		default:
+			return nil
+		}
+	}
+}
+
+func collectInputObjectValueIssues(c *opContext, obj *ast.ObjectValue, inputType *ast.InputObject) []valueTypeIssue {
+	issues := make([]valueTypeIssue, 0)
+	for _, field := range obj.Fields {
+		decl := inputType.Values.Get(field.Name.Name)
+		if decl == nil {
+			continue
+		}
+		if ok, errLoc, reason := validateValueType(c, field.Value, decl.Type); !ok {
+			issues = append(issues, valueTypeIssue{loc: errLoc, message: reason})
+		}
+	}
+	return issues
+}
+
+func validateBasicLit(v *ast.PrimitiveValue, t ast.Type) (bool, string) {
 	switch t := t.(type) {
 	case *ast.ScalarTypeDefinition:
 		switch t.Name {
 		case "Int":
-			if v.Type != scanner.Int {
-				return false
+			if v.Type == scanner.Int {
+				if validateBuiltInScalar(v.Text, "Int") {
+					return true, ""
+				}
+				return false, fmt.Sprintf("Int cannot represent non 32-bit signed integer value: %s", v)
 			}
-			return validateBuiltInScalar(v.Text, "Int")
+			return false, fmt.Sprintf("Int cannot represent non-integer value: %s", v)
 		case "Float":
-			return (v.Type == scanner.Int || v.Type == scanner.Float) && validateBuiltInScalar(v.Text, "Float")
+			if v.Type == scanner.Int || v.Type == scanner.Float {
+				if validateBuiltInScalar(v.Text, "Float") {
+					return true, ""
+				}
+			}
+			return false, fmt.Sprintf("Float cannot represent non numeric value: %s", v)
 		case "String":
-			return v.Type == scanner.String && validateBuiltInScalar(v.Text, "String")
+			if v.Type == scanner.String && validateBuiltInScalar(v.Text, "String") {
+				return true, ""
+			}
+			return false, fmt.Sprintf("String cannot represent a non string value: %s", v)
 		case "Boolean":
-			return v.Type == scanner.Ident && validateBuiltInScalar(v.Text, "Boolean")
+			if v.Type == scanner.Ident && validateBuiltInScalar(v.Text, "Boolean") {
+				return true, ""
+			}
+			return false, fmt.Sprintf("Boolean cannot represent a non boolean value: %s", v)
 		case "ID":
-			return (v.Type == scanner.Int && validateBuiltInScalar(v.Text, "Int")) || (v.Type == scanner.String && validateBuiltInScalar(v.Text, "String"))
+			if (v.Type == scanner.Int && validateBuiltInScalar(v.Text, "Int")) || (v.Type == scanner.String && validateBuiltInScalar(v.Text, "String")) {
+				return true, ""
+			}
+			return false, fmt.Sprintf("ID cannot represent a non-string and non-integer value: %s", v)
 		default:
 			// TODO: Type-check against expected type by Unmarshalling
-			return true
+			return true, ""
 		}
 
 	case *ast.EnumTypeDefinition:
-		if v.Type != scanner.Ident {
-			return false
-		}
+		values := make([]string, 0, len(t.EnumValuesDefinition))
 		for _, option := range t.EnumValuesDefinition {
-			if option.EnumValue == v.Text {
-				return true
-			}
+			values = append(values, option.EnumValue)
 		}
-		return false
-	}
 
-	return false
+		if v.Type == scanner.Ident {
+			if v.Text == "true" || v.Text == "false" {
+				return false, fmt.Sprintf("Enum %q cannot represent non-enum value: %s.", t.Name, v)
+			}
+
+			for _, option := range t.EnumValuesDefinition {
+				if option.EnumValue == v.Text {
+					return true, ""
+				}
+			}
+
+			suggestion := makeSuggestion("Did you mean the enum value", values, v.Text)
+			if suggestion == "" {
+				for _, option := range values {
+					if strings.EqualFold(option, v.Text) {
+						suggestion = fmt.Sprintf(" Did you mean the enum value %q?", option)
+						break
+					}
+				}
+			}
+			if suggestion != "" {
+				return false, fmt.Sprintf("Value %q does not exist in %q enum.%s", v.Text, t.Name, suggestion)
+			}
+			return false, fmt.Sprintf("Value %q does not exist in %q enum.", v.Text, t.Name)
+		}
+
+		candidate := strings.Trim(v.Text, "\"")
+		suggestion := makeSuggestion("Did you mean the enum value", values, candidate)
+		if suggestion != "" {
+			return false, fmt.Sprintf("Enum %q cannot represent non-enum value: %s.%s", t.Name, v, suggestion)
+		}
+		return false, fmt.Sprintf("Enum %q cannot represent non-enum value: %s.", t.Name, v)
+
+	default:
+		return false, fmt.Sprintf("Expected type %q, found %s.", t, v)
+	}
 }
 
 func validateBuiltInScalar(v string, n string) bool {

--- a/internal/validation/validation_bench_test.go
+++ b/internal/validation/validation_bench_test.go
@@ -1,0 +1,88 @@
+package validation_test
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/graph-gophers/graphql-go/internal/query"
+	"github.com/graph-gophers/graphql-go/internal/schema"
+	"github.com/graph-gophers/graphql-go/internal/validation"
+)
+
+const benchmarkSchemaSDL = `
+schema {
+  query: Query
+}
+
+type Query {
+  root: Thing
+}
+
+type Thing {
+  id: ID!
+  name: String
+  value: String
+}
+`
+
+var benchErrs any
+
+func BenchmarkValidate(b *testing.B) {
+	s := schema.New()
+	if err := schema.Parse(s, benchmarkSchemaSDL, false); err != nil {
+		b.Fatal(err)
+	}
+
+	cases := []struct {
+		name  string
+		query string
+	}{
+		{
+			name:  "baseline",
+			query: `query { root { id name value } }`,
+		},
+		{
+			name:  "overlap-heavy-10",
+			query: overlapHeavyQuery(10),
+		},
+		{
+			name:  "overlap-heavy-50",
+			query: overlapHeavyQuery(50),
+		},
+		{
+			name:  "overlap-heavy-100",
+			query: overlapHeavyQuery(100),
+		},
+	}
+
+	for _, tc := range cases {
+		doc, err := query.Parse(tc.query)
+		if err != nil {
+			b.Fatalf("parse %q: %v", tc.name, err)
+		}
+
+		b.Run(tc.name, func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				benchErrs = validation.Validate(s, doc, nil, 0, 0)
+			}
+		})
+	}
+}
+
+func overlapHeavyQuery(n int) string {
+	var builder strings.Builder
+	builder.Grow(64 + n*24)
+	builder.WriteString("query { root {")
+	for i := range n {
+		builder.WriteString(" f")
+		builder.WriteString(strconv.Itoa(i))
+		builder.WriteString(": id")
+		builder.WriteString(" f")
+		builder.WriteString(strconv.Itoa(i))
+		builder.WriteString(": name")
+	}
+	builder.WriteString(" } }")
+	return builder.String()
+}

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -28,28 +28,26 @@ type Test struct {
 	Errors []*errors.QueryError
 }
 
-var skippedValidationTests = map[string]struct{}{
-	// known-rule-overlap: extra error under PossibleFragmentSpreadsRule.
-	"Validate: Possible fragment spreads/ignores incorrect type (caught by FragmentsOnCompositeTypesRule)": {},
-	// parser-mismatch: graphql-js fixture parses SDL as executable query.
-	"Validate: Directives Are Unique Per Location/unknown directives must be ignored": {},
-	"Validate: Executable definitions/with schema definition":                         {},
-	"Validate: Executable definitions/with type definition":                           {},
-	// schema-difference: meta schema always includes standard scalar types.
-	"Validate: Known type names/references to standard scalars that are missing in schema": {},
-	// unsupported-feature: experimental @stream directives.
-	"Validate: Overlapping fields can be merged/different stream directive label":               {},
-	"Validate: Overlapping fields can be merged/different stream directive initialCount":        {},
-	"Validate: Overlapping fields can be merged/different stream directive first missing args":  {},
-	"Validate: Overlapping fields can be merged/different stream directive second missing args": {},
-	"Validate: Overlapping fields can be merged/different stream directive extra argument":      {},
-	"Validate: Overlapping fields can be merged/mix of stream and no stream":                    {},
-	// unresolved-scalar-parse-literal: graphql-js can reject literal via scalar parseLiteral(undefined) behavior.
-	"Validate: Values of correct type/Invalid input object value/reports error for custom scalar that returns undefined": {},
-}
-
 func TestValidate(t *testing.T) {
-	skip := skippedValidationTests
+	skip := map[string]struct{}{
+		// known-rule-overlap: extra error under PossibleFragmentSpreadsRule.
+		"Validate: Possible fragment spreads/ignores incorrect type (caught by FragmentsOnCompositeTypesRule)": {},
+		// parser-mismatch: graphql-js fixture parses SDL as executable query.
+		"Validate: Directives Are Unique Per Location/unknown directives must be ignored": {},
+		"Validate: Executable definitions/with schema definition":                         {},
+		"Validate: Executable definitions/with type definition":                           {},
+		// schema-difference: meta schema always includes standard scalar types.
+		"Validate: Known type names/references to standard scalars that are missing in schema": {},
+		// unsupported-feature: experimental @stream directives.
+		"Validate: Overlapping fields can be merged/different stream directive label":               {},
+		"Validate: Overlapping fields can be merged/different stream directive initialCount":        {},
+		"Validate: Overlapping fields can be merged/different stream directive first missing args":  {},
+		"Validate: Overlapping fields can be merged/different stream directive second missing args": {},
+		"Validate: Overlapping fields can be merged/different stream directive extra argument":      {},
+		"Validate: Overlapping fields can be merged/mix of stream and no stream":                    {},
+		// unresolved-scalar-parse-literal: graphql-js can reject literal via scalar parseLiteral(undefined) behavior.
+		"Validate: Values of correct type/Invalid input object value/reports error for custom scalar that returns undefined": {},
+	}
 
 	f, err := os.Open("testdata/tests.json")
 	if err != nil {

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -28,66 +28,28 @@ type Test struct {
 	Errors []*errors.QueryError
 }
 
+var skippedValidationTests = map[string]struct{}{
+	// known-rule-overlap: extra error under PossibleFragmentSpreadsRule.
+	"Validate: Possible fragment spreads/ignores incorrect type (caught by FragmentsOnCompositeTypesRule)": {},
+	// parser-mismatch: graphql-js fixture parses SDL as executable query.
+	"Validate: Directives Are Unique Per Location/unknown directives must be ignored": {},
+	"Validate: Executable definitions/with schema definition":                         {},
+	"Validate: Executable definitions/with type definition":                           {},
+	// schema-difference: meta schema always includes standard scalar types.
+	"Validate: Known type names/references to standard scalars that are missing in schema": {},
+	// unsupported-feature: experimental @stream directives.
+	"Validate: Overlapping fields can be merged/different stream directive label":               {},
+	"Validate: Overlapping fields can be merged/different stream directive initialCount":        {},
+	"Validate: Overlapping fields can be merged/different stream directive first missing args":  {},
+	"Validate: Overlapping fields can be merged/different stream directive second missing args": {},
+	"Validate: Overlapping fields can be merged/different stream directive extra argument":      {},
+	"Validate: Overlapping fields can be merged/mix of stream and no stream":                    {},
+	// unresolved-scalar-parse-literal: graphql-js can reject literal via scalar parseLiteral(undefined) behavior.
+	"Validate: Values of correct type/Invalid input object value/reports error for custom scalar that returns undefined": {},
+}
+
 func TestValidate(t *testing.T) {
-	skip := map[string]struct{}{
-		// Minor issue: reporting extra error under PossibleFragmentSpreadsRule which is not intended
-		"Validate: Possible fragment spreads/ignores incorrect type (caught by FragmentsOnCompositeTypesRule)": {},
-		// graphql-js test case parses SDL as if it was a query here, which fails since we only accept a query
-		"Validate: Directives Are Unique Per Location/unknown directives must be ignored": {},
-		// The meta schema always includes the standard types, so this isn't applicable
-		"Validate: Known type names/references to standard scalars that are missing in schema": {},
-		// Ignore tests using experimental @stream
-		"Validate: Overlapping fields can be merged/different stream directive label":               {},
-		"Validate: Overlapping fields can be merged/different stream directive initialCount":        {},
-		"Validate: Overlapping fields can be merged/different stream directive first missing args":  {},
-		"Validate: Overlapping fields can be merged/different stream directive second missing args": {},
-		"Validate: Overlapping fields can be merged/different stream directive extra argument":      {},
-		"Validate: Overlapping fields can be merged/mix of stream and no stream":                    {},
-		// ValuesOfCorrectTypeRule: Error message format differs from graphql-js. graphql-go includes argument name and type details, while graphql-js uses simpler coercion messages.
-		// TODO: Align error message format with graphql-js or update tests.json to match graphql-go's implementation.
-		"Validate: Values of correct type/Invalid String values/Int into String":                                                           {},
-		"Validate: Values of correct type/Invalid String values/Float into String":                                                         {},
-		"Validate: Values of correct type/Invalid String values/Boolean into String":                                                       {},
-		"Validate: Values of correct type/Invalid String values/Unquoted String into String":                                               {},
-		"Validate: Values of correct type/Invalid Int values/String into Int":                                                              {},
-		"Validate: Values of correct type/Invalid Int values/Big Int into Int":                                                             {},
-		"Validate: Values of correct type/Invalid Int values/Unquoted String into Int":                                                     {},
-		"Validate: Values of correct type/Invalid Int values/Simple Float into Int":                                                        {},
-		"Validate: Values of correct type/Invalid Int values/Float into Int":                                                               {},
-		"Validate: Values of correct type/Invalid Float values/String into Float":                                                          {},
-		"Validate: Values of correct type/Invalid Float values/Boolean into Float":                                                         {},
-		"Validate: Values of correct type/Invalid Float values/Unquoted into Float":                                                        {},
-		"Validate: Values of correct type/Invalid Boolean value/Int into Boolean":                                                          {},
-		"Validate: Values of correct type/Invalid Boolean value/Float into Boolean":                                                        {},
-		"Validate: Values of correct type/Invalid Boolean value/String into Boolean":                                                       {},
-		"Validate: Values of correct type/Invalid Boolean value/Unquoted into Boolean":                                                     {},
-		"Validate: Values of correct type/Invalid ID value/Float into ID":                                                                  {},
-		"Validate: Values of correct type/Invalid ID value/Boolean into ID":                                                                {},
-		"Validate: Values of correct type/Invalid ID value/Unquoted into ID":                                                               {},
-		"Validate: Values of correct type/Invalid Enum value/Int into Enum":                                                                {},
-		"Validate: Values of correct type/Invalid Enum value/Float into Enum":                                                              {},
-		"Validate: Values of correct type/Invalid Enum value/String into Enum":                                                             {},
-		"Validate: Values of correct type/Invalid Enum value/Boolean into Enum":                                                            {},
-		"Validate: Values of correct type/Invalid Enum value/Unknown Enum Value into Enum":                                                 {},
-		"Validate: Values of correct type/Invalid Enum value/Different case Enum Value into Enum":                                          {},
-		"Validate: Values of correct type/Invalid List value/Incorrect item type":                                                          {},
-		"Validate: Values of correct type/Invalid List value/Single value of incorrect type":                                               {},
-		"Validate: Values of correct type/Invalid non-nullable value/Incorrect value type":                                                 {},
-		"Validate: Values of correct type/Invalid non-nullable value/Incorrect value and missing argument (ProvidedRequiredArgumentsRule)": {},
-		"Validate: Values of correct type/Invalid non-nullable value/Null value":                                                           {},
-		"Validate: Values of correct type/Invalid input object value/Partial object, missing required":                                     {},
-		"Validate: Values of correct type/Invalid input object value/Partial object, invalid field type":                                   {},
-		"Validate: Values of correct type/Invalid input object value/Partial object, null to non-null field":                               {},
-		"Validate: Values of correct type/Invalid input object value/Partial object, unknown field arg":                                    {},
-		"Validate: Values of correct type/Invalid input object value/reports error for custom scalar that returns undefined":               {},
-		"Validate: Values of correct type/Invalid oneOf input object value/Invalid field type":                                             {},
-		"Validate: Values of correct type/Directive arguments/with directive with incorrect types":                                         {},
-		"Validate: Values of correct type/Variable default values/variables with invalid default null values":                              {},
-		"Validate: Values of correct type/Variable default values/variables with invalid default values":                                   {},
-		"Validate: Values of correct type/Variable default values/variables with complex invalid default values":                           {},
-		"Validate: Values of correct type/Variable default values/complex variables missing required field":                                {},
-		"Validate: Values of correct type/Variable default values/list variables with invalid item":                                        {},
-	}
+	skip := skippedValidationTests
 
 	f, err := os.Open("testdata/tests.json")
 	if err != nil {
@@ -130,8 +92,8 @@ func TestValidate(t *testing.T) {
 					got = append(got, err)
 				}
 			}
-			sortLocations(test.Errors)
-			sortLocations(got)
+			normalizeErrors(test.Errors)
+			normalizeErrors(got)
 			if !reflect.DeepEqual(test.Errors, got) {
 				t.Errorf("wrong errors for rule %q\nexpected: %v\ngot:      %v", test.Rule, test.Errors, got)
 			}
@@ -139,9 +101,30 @@ func TestValidate(t *testing.T) {
 	}
 }
 
-func sortLocations(errs []*errors.QueryError) {
+func normalizeErrors(errs []*errors.QueryError) {
 	for _, err := range errs {
 		locs := err.Locations
 		sort.Slice(locs, func(i, j int) bool { return locs[i].Before(locs[j]) })
 	}
+
+	sort.Slice(errs, func(i, j int) bool {
+		if errs[i].Message != errs[j].Message {
+			return errs[i].Message < errs[j].Message
+		}
+
+		il := errs[i].Locations
+		jl := errs[j].Locations
+		if len(il) == 0 || len(jl) == 0 {
+			return len(il) < len(jl)
+		}
+
+		if il[0].Line != jl[0].Line {
+			return il[0].Line < jl[0].Line
+		}
+		if il[0].Column != jl[0].Column {
+			return il[0].Column < jl[0].Column
+		}
+
+		return len(il) < len(jl)
+	})
 }

--- a/scripts/coverage.sh
+++ b/scripts/coverage.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+# coverage.sh - compute project-wide cross-package coverage excluding example/ packages.
+# Only a single number (cross-package aggregated coverage) is printed.
+#
+# Usage:
+#   scripts/coverage.sh
+#   PROFILE=custom.out scripts/coverage.sh
+#   COVER_MODE=count scripts/coverage.sh
+#
+# Env vars:
+#   PROFILE     coverprofile path (default: coverage.out)
+#   COVER_MODE  covermode (default: atomic)
+#   VERBOSE=1   print underlying go test output (otherwise suppressed)
+set -euo pipefail
+
+PROFILE=${PROFILE:-coverage.out}
+COVER_MODE=${COVER_MODE:-atomic}
+
+# Collect packages excluding example/ (any path segment named 'example'). Works on macOS bash 3.2.
+PKGS=""
+while IFS= read -r pkg; do
+  [ -n "${pkg}" ] || continue
+  PKGS+=" ${pkg}"
+done < <(go list ./... | grep -v '/example/')
+
+if [ -z "${PKGS// /}" ]; then
+  echo "No packages found" >&2
+  exit 1
+fi
+
+# Trim leading space and convert to array safely for later loops.
+PKGS_TRIMMED=${PKGS# }
+
+# Build comma-separated list for -coverpkg (instrument all packages so tests in one package
+# can contribute coverage for code in another).
+COVERPKG=$(echo "${PKGS_TRIMMED}" | tr ' ' ',')
+
+COUNT_PKGS=$(echo "${PKGS_TRIMMED}" | tr ' ' '\n' | wc -l | tr -d ' ')
+
+echo "Running cross-package coverage across ${COUNT_PKGS} packages..." >&2
+
+LOGFILE=$(mktemp 2>/dev/null || mktemp -t graphql_cover)
+if GOFLAGS="${GOFLAGS:-}" go test -covermode="${COVER_MODE}" -coverpkg="${COVERPKG}" -coverprofile="${PROFILE}" ${PKGS_TRIMMED} >"${LOGFILE}" 2>&1; then
+  :
+else
+  echo "go test failed; showing output:" >&2
+  cat "${LOGFILE}" >&2
+  rm -f "${LOGFILE}"
+  exit 1
+fi
+
+[ "${VERBOSE:-}" != "" ] && cat "${LOGFILE}" >&2
+rm -f "${LOGFILE}"
+
+TOTAL_PERCENT=$(go tool cover -func="${PROFILE}" | awk '/total:/ {print $3}')
+if [ -z "${TOTAL_PERCENT}" ]; then
+  echo "ERROR: could not parse total coverage from ${PROFILE}" >&2
+  exit 2
+fi
+
+echo "${TOTAL_PERCENT}"  # single number output


### PR DESCRIPTION
* Improve validation parity with graphql-js:
  * Aligns ValuesOfCorrectTypeRule error messaging/locations and normalizes validation test comparisons.
  * Adds NoDeprecatedCustomRule coverage for deprecated fields/args/input fields/enum values and updates fixtures.
  * Include various test cases which were skipped previously when test data was generated.
* Expands `@deprecated` directive locations to include INPUT_FIELD_DEFINITION and updates introspection expectations.