### PR TITLE
test: subscription validation improvement

### DIFF
--- a/internal/exec/subscribe.go
+++ b/internal/exec/subscribe.go
@@ -29,12 +29,6 @@ func (r *Request) Subscribe(ctx context.Context, s *resolvable.Schema, op *ast.O
 		sels := selected.ApplyOperation(&r.Request, s, op)
 		var fields []*fieldToExec
 		collectFieldsToResolve(sels, s, s.SubscriptionResolver, &fields, make(map[string]*fieldToExec))
-
-		// TODO: move this check into validation.Validate
-		if len(fields) != 1 {
-			err = errors.Errorf("%s", "can subscribe to at most one subscription at a time")
-			return
-		}
 		f = fields[0]
 
 		var in []reflect.Value

--- a/internal/query/query.go
+++ b/internal/query/query.go
@@ -113,6 +113,7 @@ func parseFragment(l *common.Lexer) *ast.FragmentDefinition {
 func parseSelectionSet(l *common.Lexer) []ast.Selection {
 	var sels []ast.Selection
 	l.ConsumeToken('{')
+	sels = append(sels, parseSelection(l))
 	for l.Peek() != '}' {
 		sels = append(sels, parseSelection(l))
 	}

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -1,0 +1,37 @@
+package query
+
+import "testing"
+
+func TestParseRejectsEmptyOperationSelectionSet(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		query string
+	}{
+		{name: "query", query: "query {}"},
+		{name: "mutation", query: "mutation {}"},
+		{name: "subscription", query: "subscription {}"},
+		{name: "anonymous query", query: "{}"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := Parse(tc.query)
+			if err == nil {
+				t.Fatalf("Parse(%q): expected syntax error, got nil", tc.query)
+			}
+		})
+	}
+}
+
+func TestParseRejectsEmptyNestedSelectionSet(t *testing.T) {
+	t.Parallel()
+
+	_, err := Parse("query { user {} }")
+	if err == nil {
+		t.Fatalf("expected syntax error for empty nested selection set, got nil")
+	}
+}

--- a/internal/validation/testdata/export.cjs
+++ b/internal/validation/testdata/export.cjs
@@ -131,8 +131,6 @@ harness.expectValidationErrors = function expectValidationErrors(rule, queryStr)
 
 const validationTestsDir = path.join(graphqlRootDir, 'src/validation/__tests__');
 const incompatibleSuites = new Set([
-  // graphql-go does not target single-field subscription parity in this fixture set yet.
-  'SingleFieldSubscriptionsRule-test.ts',
   // graphql-go does not expose graphql-js custom validation rule MaxIntrospectionDepthRule.
   'MaxIntrospectionDepthRule-test.ts',
   // graphql-go does not expose graphql-js custom validation rule NoSchemaIntrospectionCustomRule.

--- a/internal/validation/testdata/tests.json
+++ b/internal/validation/testdata/tests.json
@@ -33,6 +33,10 @@
       "sdl": "interface SomeBox {\n  deepBox: SomeBox\n  unrelatedField: String\n}\n\ntype StringBox implements SomeBox {\n  scalar: String\n  deepBox: StringBox\n  unrelatedField: String\n  listStringBox: [StringBox]\n  stringBox: StringBox\n  intBox: IntBox\n}\n\ntype IntBox implements SomeBox {\n  scalar: Int\n  deepBox: IntBox\n  unrelatedField: String\n  listStringBox: [StringBox]\n  stringBox: StringBox\n  intBox: IntBox\n}\n\ninterface NonNullStringBox1 {\n  scalar: String!\n}\n\ntype NonNullStringBox1Impl implements SomeBox & NonNullStringBox1 {\n  scalar: String!\n  unrelatedField: String\n  deepBox: SomeBox\n}\n\ninterface NonNullStringBox2 {\n  scalar: String!\n}\n\ntype NonNullStringBox2Impl implements SomeBox & NonNullStringBox2 {\n  scalar: String!\n  unrelatedField: String\n  deepBox: SomeBox\n}\n\ntype Connection {\n  edges: [Edge]\n}\n\ntype Edge {\n  node: Node\n}\n\ntype Node {\n  id: ID\n  name: String\n}\n\ntype Query {\n  someBox: SomeBox\n  connection: Connection\n}"
     },
     {
+      "id": "7vWLhgiswrYZqrL5QFJ+J/En5qld4eE+PJy261hywOs=",
+      "sdl": "schema {\n  query: QueryRoot\n  subscription: SubscriptionRoot\n}\n\ntype Message {\n  body: String\n  sender: String\n}\n\ntype SubscriptionRoot {\n  importantEmails: [String]\n  notImportantEmails: [String]\n  moreImportantEmails: [String]\n  spamEmails: [String]\n  deletedEmails: [String]\n  newMessage: Message\n}\n\ntype QueryRoot {\n  dummy: String\n}"
+    },
+    {
       "id": "/1ZT17cHiYgigdJhFgBuef8CBYIDivmE0tiCwJxLBAM=",
       "sdl": "schema {\n  query: QueryRoot\n}\n\ndirective @onField on FIELD\n\ndirective @directive on FIELD | FRAGMENT_DEFINITION\n\ndirective @directiveA on FIELD | FRAGMENT_DEFINITION\n\ndirective @directiveB on FIELD | FRAGMENT_DEFINITION\n\ndirective @repeatable repeatable on FIELD | FRAGMENT_DEFINITION\n\ninterface Mammal {\n  mother: Mammal\n  father: Mammal\n}\n\ninterface Pet {\n  name(surname: Boolean): String\n}\n\ninterface Canine implements Mammal {\n  name(surname: Boolean): String\n  mother: Canine\n  father: Canine\n}\n\nenum DogCommand {\n  SIT\n  HEEL\n  DOWN\n}\n\ntype Dog implements Pet & Mammal & Canine {\n  name(surname: Boolean): String\n  nickname: String\n  barkVolume: Int\n  barks: Boolean\n  doesKnowCommand(dogCommand: DogCommand): Boolean\n  isHouseTrained(atOtherHomes: Boolean = true): Boolean\n  isAtLocation(x: Int, y: Int): Boolean\n  mother: Dog\n  father: Dog\n}\n\ntype Cat implements Pet {\n  name(surname: Boolean): String\n  nickname: String\n  meows: Boolean\n  meowsVolume: Int\n  furColor: FurColor\n}\n\nunion CatOrDog = Cat | Dog\n\ntype Human {\n  name(surname: Boolean): String\n  pets: [Pet]\n  relatives: [Human]\n}\n\nenum FurColor {\n  BROWN\n  BLACK\n  TAN\n  SPOTTED\n  NO_FUR\n  UNKNOWN\n}\n\ninput ComplexInput {\n  requiredField: Boolean!\n  nonNullField: Boolean! = false\n  intField: Int\n  stringField: String\n  booleanField: Boolean\n  stringListField: [String]\n}\n\ninput OneOfInput @oneOf {\n  stringField: String\n  intField: Int\n}\n\ntype ComplicatedArgs {\n  intArgField(intArg: Int): String\n  nonNullIntArgField(nonNullIntArg: Int!): String\n  stringArgField(stringArg: String): String\n  booleanArgField(booleanArg: Boolean): String\n  enumArgField(enumArg: FurColor): String\n  floatArgField(floatArg: Float): String\n  idArgField(idArg: ID): String\n  stringListArgField(stringListArg: [String]): String\n  stringListNonNullArgField(stringListNonNullArg: [String!]): String\n  complexArgField(complexArg: ComplexInput): String\n  oneOfArgField(oneOfArg: OneOfInput): String\n  multipleReqs(req1: Int!, req2: Int!): String\n  nonNullFieldWithDefault(arg: Int! = 0): String\n  multipleOpts(opt1: Int = 0, opt2: Int = 0): String\n  multipleOptAndReq(req1: Int!, req2: Int!, opt1: Int = 0, opt2: Int = 0): String\n}\n\ntype QueryRoot {\n  human(id: ID): Human\n  dog: Dog\n  cat: Cat\n  pet: Pet\n  catOrDog: CatOrDog\n  complicatedArgs: ComplicatedArgs\n}"
     },
@@ -47,6 +51,10 @@
     {
       "id": "aOfXLHXbe5uZ84mk/fKqbm+FXG2G1gGvi9JwNfSmqwY=",
       "sdl": "type Query {\n  anyArg(arg: Any): String\n}\n\nscalar Any"
+    },
+    {
+      "id": "aGRZ7PoIZFstEjVOfKqy/kXMrjtbzxrDr01aoCm08gg=",
+      "sdl": "type Query {\n  dummy: String\n}"
     },
     {
       "id": "oECbw4BIP7gX1R+fCGRDCcqbO2FV/Uf0MhhE0EDAWIw=",
@@ -3674,6 +3682,244 @@
           ]
         }
       ]
+    },
+    {
+      "name": "Validate: Subscriptions with single field/valid subscription",
+      "rule": "SingleFieldSubscriptionsRule",
+      "schema": "7vWLhgiswrYZqrL5QFJ+J/En5qld4eE+PJy261hywOs=",
+      "query": "\n      subscription ImportantEmails {\n        importantEmails\n      }\n    ",
+      "errors": []
+    },
+    {
+      "name": "Validate: Subscriptions with single field/valid subscription with fragment",
+      "rule": "SingleFieldSubscriptionsRule",
+      "schema": "7vWLhgiswrYZqrL5QFJ+J/En5qld4eE+PJy261hywOs=",
+      "query": "\n      subscription sub {\n        ...newMessageFields\n      }\n\n      fragment newMessageFields on SubscriptionRoot {\n        newMessage {\n          body\n          sender\n        }\n      }\n    ",
+      "errors": []
+    },
+    {
+      "name": "Validate: Subscriptions with single field/valid subscription with fragment and field",
+      "rule": "SingleFieldSubscriptionsRule",
+      "schema": "7vWLhgiswrYZqrL5QFJ+J/En5qld4eE+PJy261hywOs=",
+      "query": "\n      subscription sub {\n        newMessage {\n          body\n        }\n        ...newMessageFields\n      }\n\n      fragment newMessageFields on SubscriptionRoot {\n        newMessage {\n          body\n          sender\n        }\n      }\n    ",
+      "errors": []
+    },
+    {
+      "name": "Validate: Subscriptions with single field/fails with more than one root field",
+      "rule": "SingleFieldSubscriptionsRule",
+      "schema": "7vWLhgiswrYZqrL5QFJ+J/En5qld4eE+PJy261hywOs=",
+      "query": "\n      subscription ImportantEmails {\n        importantEmails\n        notImportantEmails\n      }\n    ",
+      "errors": [
+        {
+          "message": "Subscription \"ImportantEmails\" must select only one top level field.",
+          "locations": [
+            {
+              "line": 4,
+              "column": 9
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Validate: Subscriptions with single field/fails with more than one root field including introspection",
+      "rule": "SingleFieldSubscriptionsRule",
+      "schema": "7vWLhgiswrYZqrL5QFJ+J/En5qld4eE+PJy261hywOs=",
+      "query": "\n      subscription ImportantEmails {\n        importantEmails\n        __typename\n      }\n    ",
+      "errors": [
+        {
+          "message": "Subscription \"ImportantEmails\" must select only one top level field.",
+          "locations": [
+            {
+              "line": 4,
+              "column": 9
+            }
+          ]
+        },
+        {
+          "message": "Subscription \"ImportantEmails\" must not select an introspection top level field.",
+          "locations": [
+            {
+              "line": 4,
+              "column": 9
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Validate: Subscriptions with single field/fails with more than one root field including aliased introspection via fragment",
+      "rule": "SingleFieldSubscriptionsRule",
+      "schema": "7vWLhgiswrYZqrL5QFJ+J/En5qld4eE+PJy261hywOs=",
+      "query": "\n      subscription ImportantEmails {\n        importantEmails\n        ...Introspection\n      }\n      fragment Introspection on SubscriptionRoot {\n        typename: __typename\n      }\n    ",
+      "errors": [
+        {
+          "message": "Subscription \"ImportantEmails\" must select only one top level field.",
+          "locations": [
+            {
+              "line": 7,
+              "column": 9
+            }
+          ]
+        },
+        {
+          "message": "Subscription \"ImportantEmails\" must not select an introspection top level field.",
+          "locations": [
+            {
+              "line": 7,
+              "column": 9
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Validate: Subscriptions with single field/fails with many more than one root field",
+      "rule": "SingleFieldSubscriptionsRule",
+      "schema": "7vWLhgiswrYZqrL5QFJ+J/En5qld4eE+PJy261hywOs=",
+      "query": "\n      subscription ImportantEmails {\n        importantEmails\n        notImportantEmails\n        spamEmails\n      }\n    ",
+      "errors": [
+        {
+          "message": "Subscription \"ImportantEmails\" must select only one top level field.",
+          "locations": [
+            {
+              "line": 4,
+              "column": 9
+            },
+            {
+              "line": 5,
+              "column": 9
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Validate: Subscriptions with single field/fails with many more than one root field via fragments",
+      "rule": "SingleFieldSubscriptionsRule",
+      "schema": "7vWLhgiswrYZqrL5QFJ+J/En5qld4eE+PJy261hywOs=",
+      "query": "\n      subscription ImportantEmails {\n        importantEmails\n        ... {\n          more: moreImportantEmails\n        }\n        ...NotImportantEmails\n      }\n      fragment NotImportantEmails on SubscriptionRoot {\n        notImportantEmails\n        deleted: deletedEmails\n        ...SpamEmails\n      }\n      fragment SpamEmails on SubscriptionRoot {\n        spamEmails\n      }\n    ",
+      "errors": [
+        {
+          "message": "Subscription \"ImportantEmails\" must select only one top level field.",
+          "locations": [
+            {
+              "line": 5,
+              "column": 11
+            },
+            {
+              "line": 10,
+              "column": 9
+            },
+            {
+              "line": 11,
+              "column": 9
+            },
+            {
+              "line": 15,
+              "column": 9
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Validate: Subscriptions with single field/does not infinite loop on recursive fragments",
+      "rule": "SingleFieldSubscriptionsRule",
+      "schema": "7vWLhgiswrYZqrL5QFJ+J/En5qld4eE+PJy261hywOs=",
+      "query": "\n      subscription NoInfiniteLoop {\n        ...A\n      }\n      fragment A on SubscriptionRoot {\n        ...A\n      }\n    ",
+      "errors": []
+    },
+    {
+      "name": "Validate: Subscriptions with single field/fails with many more than one root field via fragments (anonymous)",
+      "rule": "SingleFieldSubscriptionsRule",
+      "schema": "7vWLhgiswrYZqrL5QFJ+J/En5qld4eE+PJy261hywOs=",
+      "query": "\n      subscription {\n        importantEmails\n        ... {\n          more: moreImportantEmails\n          ...NotImportantEmails\n        }\n        ...NotImportantEmails\n      }\n      fragment NotImportantEmails on SubscriptionRoot {\n        notImportantEmails\n        deleted: deletedEmails\n        ... {\n          ... {\n            archivedEmails\n          }\n        }\n        ...SpamEmails\n      }\n      fragment SpamEmails on SubscriptionRoot {\n        spamEmails\n        ...NonExistentFragment\n      }\n    ",
+      "errors": [
+        {
+          "message": "Anonymous Subscription must select only one top level field.",
+          "locations": [
+            {
+              "line": 5,
+              "column": 11
+            },
+            {
+              "line": 11,
+              "column": 9
+            },
+            {
+              "line": 12,
+              "column": 9
+            },
+            {
+              "line": 15,
+              "column": 13
+            },
+            {
+              "line": 21,
+              "column": 9
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Validate: Subscriptions with single field/fails with more than one root field in anonymous subscriptions",
+      "rule": "SingleFieldSubscriptionsRule",
+      "schema": "7vWLhgiswrYZqrL5QFJ+J/En5qld4eE+PJy261hywOs=",
+      "query": "\n      subscription {\n        importantEmails\n        notImportantEmails\n      }\n    ",
+      "errors": [
+        {
+          "message": "Anonymous Subscription must select only one top level field.",
+          "locations": [
+            {
+              "line": 4,
+              "column": 9
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Validate: Subscriptions with single field/fails with introspection field",
+      "rule": "SingleFieldSubscriptionsRule",
+      "schema": "7vWLhgiswrYZqrL5QFJ+J/En5qld4eE+PJy261hywOs=",
+      "query": "\n      subscription ImportantEmails {\n        __typename\n      }\n    ",
+      "errors": [
+        {
+          "message": "Subscription \"ImportantEmails\" must not select an introspection top level field.",
+          "locations": [
+            {
+              "line": 3,
+              "column": 9
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Validate: Subscriptions with single field/fails with introspection field in anonymous subscription",
+      "rule": "SingleFieldSubscriptionsRule",
+      "schema": "7vWLhgiswrYZqrL5QFJ+J/En5qld4eE+PJy261hywOs=",
+      "query": "\n      subscription {\n        __typename\n      }\n    ",
+      "errors": [
+        {
+          "message": "Anonymous Subscription must not select an introspection top level field.",
+          "locations": [
+            {
+              "line": 3,
+              "column": 9
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "name": "Validate: Subscriptions with single field/skips if not subscription type",
+      "rule": "SingleFieldSubscriptionsRule",
+      "schema": "aGRZ7PoIZFstEjVOfKqy/kXMrjtbzxrDr01aoCm08gg=",
+      "query": "\n        subscription {\n          __typename\n        }\n      ",
+      "errors": []
     },
     {
       "name": "Validate: Unique argument names/no arguments on field",

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -408,8 +408,14 @@ func validateSingleFieldSubscription(c *opContext, op *ast.OperationDefinition, 
 	fields := make(map[string][]*ast.Field)
 	responseOrder := make([]string, 0)
 	visitedFragments := make(map[string]struct{})
+	forbiddenDirectiveLocs := make([]errors.Location, 0)
 
-	collectSubscriptionRootFields(c.context, subscriptionType, op.Selections, fields, &responseOrder, visitedFragments)
+	collectSubscriptionRootFields(c.context, subscriptionType, op.Selections, fields, &responseOrder, visitedFragments, &forbiddenDirectiveLocs)
+
+	if len(forbiddenDirectiveLocs) > 0 {
+		c.addErrMultiLoc(forbiddenDirectiveLocs, "SingleFieldSubscriptionsRule", "%s", subscriptionDirectivesNotAllowedMessage(op.Name.Name))
+		return
+	}
 
 	if len(responseOrder) > 1 {
 		locs := make([]errors.Location, 0)
@@ -448,13 +454,12 @@ func collectSubscriptionRootFields(
 	fields map[string][]*ast.Field,
 	responseOrder *[]string,
 	visitedFragments map[string]struct{},
+	forbiddenDirectiveLocs *[]errors.Location,
 ) {
 	for _, selection := range selections {
 		switch s := selection.(type) {
 		case *ast.Field:
-			if !shouldIncludeByDirective(s.Directives) {
-				continue
-			}
+			appendSkipIncludeDirectiveLocs(s.Directives, forbiddenDirectiveLocs)
 			key := fieldResponseName(s)
 			if _, ok := fields[key]; !ok {
 				*responseOrder = append(*responseOrder, key)
@@ -462,15 +467,14 @@ func collectSubscriptionRootFields(
 			fields[key] = append(fields[key], s)
 
 		case *ast.InlineFragment:
-			if !shouldIncludeByDirective(s.Directives) || !fragmentConditionMatches(c, runtimeType, s.On) {
+			appendSkipIncludeDirectiveLocs(s.Directives, forbiddenDirectiveLocs)
+			if !fragmentConditionMatches(c, runtimeType, s.On) {
 				continue
 			}
-			collectSubscriptionRootFields(c, runtimeType, s.Selections, fields, responseOrder, visitedFragments)
+			collectSubscriptionRootFields(c, runtimeType, s.Selections, fields, responseOrder, visitedFragments, forbiddenDirectiveLocs)
 
 		case *ast.FragmentSpread:
-			if !shouldIncludeByDirective(s.Directives) {
-				continue
-			}
+			appendSkipIncludeDirectiveLocs(s.Directives, forbiddenDirectiveLocs)
 
 			fragName := s.Name.Name
 			if _, ok := visitedFragments[fragName]; ok {
@@ -483,7 +487,7 @@ func collectSubscriptionRootFields(
 				continue
 			}
 
-			collectSubscriptionRootFields(c, runtimeType, frag.Selections, fields, responseOrder, visitedFragments)
+			collectSubscriptionRootFields(c, runtimeType, frag.Selections, fields, responseOrder, visitedFragments, forbiddenDirectiveLocs)
 		}
 	}
 }
@@ -501,40 +505,12 @@ func fragmentConditionMatches(c *context, runtimeType ast.NamedType, on ast.Type
 	return compatible(runtimeType, fragType)
 }
 
-func shouldIncludeByDirective(directives ast.DirectiveList) bool {
-	if skip, ok := directiveIfBool(directives.Get("skip")); ok && skip {
-		return false
-	}
-
-	if include, ok := directiveIfBool(directives.Get("include")); ok && !include {
-		return false
-	}
-
-	return true
-}
-
-func directiveIfBool(d *ast.Directive) (bool, bool) {
-	if d == nil {
-		return false, false
-	}
-
-	arg, ok := d.Arguments.Get("if")
-	if !ok {
-		return false, false
-	}
-
-	v, ok := arg.(*ast.PrimitiveValue)
-	if !ok || v.Type != scanner.Ident {
-		return false, false
-	}
-
-	switch v.Text {
-	case "true":
-		return true, true
-	case "false":
-		return false, true
-	default:
-		return false, false
+func appendSkipIncludeDirectiveLocs(directives ast.DirectiveList, locs *[]errors.Location) {
+	for _, d := range directives {
+		switch d.Name.Name {
+		case "skip", "include":
+			*locs = append(*locs, d.Name.Loc)
+		}
 	}
 }
 
@@ -552,6 +528,14 @@ func introspectionSubscriptionMessage(operationName string) string {
 	}
 
 	return "Anonymous Subscription must not select an introspection top level field."
+}
+
+func subscriptionDirectivesNotAllowedMessage(operationName string) string {
+	if operationName != "" {
+		return fmt.Sprintf("Subscription %q must not use `@skip` or `@include` directives in the top level selection.", operationName)
+	}
+
+	return "Anonymous Subscription must not use `@skip` or `@include` directives in the top level selection."
 }
 
 func selectionTopLevelFieldNames(c *context, sel ast.Selection) (map[string]struct{}, bool) {

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -155,6 +155,10 @@ func Validate(s *ast.Schema, doc *ast.ExecutableDefinition, variables map[string
 			panic("unreachable")
 		}
 
+		if op.Type == query.Subscription && entryPoint != nil {
+			validateSingleFieldSubscription(opc, op, entryPoint)
+		}
+
 		validateSelectionSet(opc, op.Selections, entryPoint)
 
 		fragUsed := make(map[*ast.FragmentDefinition]struct{})
@@ -398,6 +402,156 @@ func fieldResponseName(f *ast.Field) string {
 		return f.Alias.Name
 	}
 	return f.Name.Name
+}
+
+func validateSingleFieldSubscription(c *opContext, op *ast.OperationDefinition, subscriptionType ast.NamedType) {
+	fields := make(map[string][]*ast.Field)
+	responseOrder := make([]string, 0)
+	visitedFragments := make(map[string]struct{})
+
+	collectSubscriptionRootFields(c.context, subscriptionType, op.Selections, fields, &responseOrder, visitedFragments)
+
+	if len(responseOrder) > 1 {
+		locs := make([]errors.Location, 0)
+		for _, key := range responseOrder[1:] {
+			for _, field := range fields[key] {
+				locs = append(locs, field.Alias.Loc)
+			}
+		}
+
+		if len(locs) > 0 {
+			c.addErrMultiLoc(locs, "SingleFieldSubscriptionsRule", "%s", singleFieldSubscriptionMessage(op.Name.Name))
+		}
+	}
+
+	for _, key := range responseOrder {
+		fieldNodes := fields[key]
+		if len(fieldNodes) == 0 {
+			continue
+		}
+
+		field := fieldNodes[0]
+		if strings.HasPrefix(field.Name.Name, "__") {
+			locs := make([]errors.Location, 0, len(fieldNodes))
+			for _, node := range fieldNodes {
+				locs = append(locs, node.Alias.Loc)
+			}
+			c.addErrMultiLoc(locs, "SingleFieldSubscriptionsRule", "%s", introspectionSubscriptionMessage(op.Name.Name))
+		}
+	}
+}
+
+func collectSubscriptionRootFields(
+	c *context,
+	runtimeType ast.NamedType,
+	selections []ast.Selection,
+	fields map[string][]*ast.Field,
+	responseOrder *[]string,
+	visitedFragments map[string]struct{},
+) {
+	for _, selection := range selections {
+		switch s := selection.(type) {
+		case *ast.Field:
+			if !shouldIncludeByDirective(s.Directives) {
+				continue
+			}
+			key := fieldResponseName(s)
+			if _, ok := fields[key]; !ok {
+				*responseOrder = append(*responseOrder, key)
+			}
+			fields[key] = append(fields[key], s)
+
+		case *ast.InlineFragment:
+			if !shouldIncludeByDirective(s.Directives) || !fragmentConditionMatches(c, runtimeType, s.On) {
+				continue
+			}
+			collectSubscriptionRootFields(c, runtimeType, s.Selections, fields, responseOrder, visitedFragments)
+
+		case *ast.FragmentSpread:
+			if !shouldIncludeByDirective(s.Directives) {
+				continue
+			}
+
+			fragName := s.Name.Name
+			if _, ok := visitedFragments[fragName]; ok {
+				continue
+			}
+			visitedFragments[fragName] = struct{}{}
+
+			frag := c.doc.Fragments.Get(fragName)
+			if frag == nil || !fragmentConditionMatches(c, runtimeType, frag.On) {
+				continue
+			}
+
+			collectSubscriptionRootFields(c, runtimeType, frag.Selections, fields, responseOrder, visitedFragments)
+		}
+	}
+}
+
+func fragmentConditionMatches(c *context, runtimeType ast.NamedType, on ast.TypeName) bool {
+	if on.Name == "" {
+		return true
+	}
+
+	fragType := unwrapType(resolveType(c, &on))
+	if runtimeType == nil || fragType == nil {
+		return false
+	}
+
+	return compatible(runtimeType, fragType)
+}
+
+func shouldIncludeByDirective(directives ast.DirectiveList) bool {
+	if skip, ok := directiveIfBool(directives.Get("skip")); ok && skip {
+		return false
+	}
+
+	if include, ok := directiveIfBool(directives.Get("include")); ok && !include {
+		return false
+	}
+
+	return true
+}
+
+func directiveIfBool(d *ast.Directive) (bool, bool) {
+	if d == nil {
+		return false, false
+	}
+
+	arg, ok := d.Arguments.Get("if")
+	if !ok {
+		return false, false
+	}
+
+	v, ok := arg.(*ast.PrimitiveValue)
+	if !ok || v.Type != scanner.Ident {
+		return false, false
+	}
+
+	switch v.Text {
+	case "true":
+		return true, true
+	case "false":
+		return false, true
+	default:
+		return false, false
+	}
+}
+
+func singleFieldSubscriptionMessage(operationName string) string {
+	if operationName != "" {
+		return fmt.Sprintf("Subscription %q must select only one top level field.", operationName)
+	}
+
+	return "Anonymous Subscription must select only one top level field."
+}
+
+func introspectionSubscriptionMessage(operationName string) string {
+	if operationName != "" {
+		return fmt.Sprintf("Subscription %q must not select an introspection top level field.", operationName)
+	}
+
+	return "Anonymous Subscription must not select an introspection top level field."
 }
 
 func selectionTopLevelFieldNames(c *context, sel ast.Selection) (map[string]struct{}, bool) {

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -467,8 +467,12 @@ func TestError_multiple_subscription_fields(t *testing.T) {
 						msg: String!
 					}
 			`, &rootResolver{helloSaidResolver: &helloSaidResolver{upstream: closedUpstream(&helloSaidEventResolver{msg: "Hello world!"})}}),
-			Query:       `subscription { helloSaid { msg } otherField }`,
-			ExpectedErr: qerrors.Errorf("Anonymous Subscription must select only one top level field."),
+			Query: `subscription { helloSaid { msg } otherField }`,
+			ExpectedResults: []gqltesting.TestResponse{
+				{
+					Errors: []*qerrors.QueryError{{Message: "Anonymous Subscription must select only one top level field.", Locations: []qerrors.Location{{Line: 1, Column: 34}}}},
+				},
+			},
 		},
 	})
 }

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -473,6 +473,70 @@ func TestError_multiple_subscription_fields(t *testing.T) {
 	})
 }
 
+func TestError_subscription_skip_include_top_level_directives(t *testing.T) {
+	schema := graphql.MustParseSchema(`
+		schema {
+			query: Query
+			subscription: Subscription
+		}
+		type Query {
+			hello: String!
+		}
+		type Subscription {
+			helloSaid: HelloSaidEvent!
+			otherField: Int!
+		}
+		type HelloSaidEvent {
+			msg: String!
+		}
+	`, &rootResolver{helloSaidResolver: &helloSaidResolver{upstream: closedUpstream(&helloSaidEventResolver{msg: "Hello world!"})}})
+
+	gqltesting.RunSubscribes(t, []*gqltesting.TestSubscription{
+		{
+			Name:   "Named subscription",
+			Schema: schema,
+			Query: `
+				subscription RequiredRuntimeValidation($bool: Boolean!) {
+					helloSaid @include(if: $bool) {
+						msg
+					}
+					otherField @skip(if: $bool)
+				}
+			`,
+			Variables:   map[string]any{"bool": true},
+			ExpectedErr: qerrors.Errorf("Subscription \"RequiredRuntimeValidation\" must not use `@skip` or `@include` directives in the top level selection."),
+		},
+		{
+			Name:   "Anonymous subscription",
+			Schema: schema,
+			Query: `
+				subscription ($bool: Boolean!) {
+					helloSaid @include(if: $bool) {
+						msg
+					}
+					otherField @skip(if: $bool)
+				}
+			`,
+			Variables:   map[string]any{"bool": true},
+			ExpectedErr: qerrors.Errorf("Anonymous Subscription must not use `@skip` or `@include` directives in the top level selection."),
+		},
+		{
+			Name:        "Single field with skip directive",
+			Schema:      schema,
+			Query:       `subscription RequiredRuntimeValidation($bool: Boolean!) { otherField @skip(if: $bool) }`,
+			Variables:   map[string]any{"bool": true},
+			ExpectedErr: qerrors.Errorf("Subscription \"RequiredRuntimeValidation\" must not use `@skip` or `@include` directives in the top level selection."),
+		},
+		{
+			Name:        "Single field with include directive",
+			Schema:      schema,
+			Query:       `subscription RequiredRuntimeValidation($bool: Boolean!) { helloSaid @include(if: $bool) { msg } }`,
+			Variables:   map[string]any{"bool": true},
+			ExpectedErr: qerrors.Errorf("Subscription \"RequiredRuntimeValidation\" must not use `@skip` or `@include` directives in the top level selection."),
+		},
+	})
+}
+
 const schema = `
 	schema {
 		subscription: Subscription,

--- a/subscription_test.go
+++ b/subscription_test.go
@@ -467,12 +467,8 @@ func TestError_multiple_subscription_fields(t *testing.T) {
 						msg: String!
 					}
 			`, &rootResolver{helloSaidResolver: &helloSaidResolver{upstream: closedUpstream(&helloSaidEventResolver{msg: "Hello world!"})}}),
-			Query: `subscription { helloSaid { msg } otherField }`,
-			ExpectedResults: []gqltesting.TestResponse{
-				{
-					Errors: []*qerrors.QueryError{qerrors.Errorf("can subscribe to at most one subscription at a time")},
-				},
-			},
+			Query:       `subscription { helloSaid { msg } otherField }`,
+			ExpectedErr: qerrors.Errorf("Anonymous Subscription must select only one top level field."),
 		},
 	})
 }


### PR DESCRIPTION
Bring the subscription validation in parity with the graphql-js library validation rules in `src/validation/__tests__/SingleFieldSubscriptionsRule-test.ts`.
