### PR TITLE
feat(validation): deprecated  iface impl discrepancy

### DIFF
--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -117,8 +117,13 @@ func Parse(s *ast.Schema, schemaString string, useStringDescriptions bool) error
 				}
 
 				for _, f := range intf.Fields.Names() {
-					if t.Fields.Get(f) == nil {
+					implField := t.Fields.Get(f)
+					if implField == nil {
 						return errors.Errorf("interface %q expects field %q but %q does not provide it", intf.Name, f, t.Name)
+					}
+					intfField := intf.Fields.Get(f)
+					if intfField.Directives.Get("deprecated") == nil && implField.Directives.Get("deprecated") != nil {
+						return errors.Errorf("interface %q field %q is not deprecated but implementing interface %q marks it as deprecated", intf.Name, f, t.Name)
 					}
 				}
 
@@ -149,8 +154,13 @@ func Parse(s *ast.Schema, schemaString string, useStringDescriptions bool) error
 				return errors.Errorf("type %q is not an interface", intfName)
 			}
 			for _, f := range intf.Fields.Names() {
-				if obj.Fields.Get(f) == nil {
+				implField := obj.Fields.Get(f)
+				if implField == nil {
 					return errors.Errorf("interface %q expects field %q but %q does not provide it", intfName, f, obj.Name)
+				}
+				intfField := intf.Fields.Get(f)
+				if intfField.Directives.Get("deprecated") == nil && implField.Directives.Get("deprecated") != nil {
+					return errors.Errorf("interface %q field %q is not deprecated but implementing type %q marks it as deprecated", intfName, f, obj.Name)
 				}
 			}
 			obj.Interfaces[i] = intf

--- a/internal/schema/schema_test.go
+++ b/internal/schema/schema_test.go
@@ -1245,6 +1245,70 @@ func TestInterfaceImplementsInterface(t *testing.T) {
 				return fmt.Errorf("unexpected error: want error about @oneOf only on INPUT_OBJECT, have %q", err.Error())
 			},
 		},
+		{
+			name: "Accepts object implementing interface where both field and interface field are deprecated",
+			sdl: `
+			interface Node {
+				id: ID! @deprecated(reason: "use newId")
+			}
+			type User implements Node {
+				id: ID! @deprecated(reason: "use newId")
+			}
+			`,
+			validateSchema: func(s *ast.Schema) error {
+				return nil
+			},
+		},
+		{
+			name: "Accepts object implementing interface where interface field is deprecated and implementing field is not",
+			sdl: `
+			interface Node {
+				id: ID! @deprecated(reason: "old")
+			}
+			type User implements Node {
+				id: ID!
+			}
+			`,
+			validateSchema: func(s *ast.Schema) error {
+				return nil
+			},
+		},
+		{
+			name: "Rejects object implementing interface where interface field is not deprecated but implementing field is",
+			sdl: `
+			interface Node {
+				id: ID!
+			}
+			type User implements Node {
+				id: ID! @deprecated(reason: "use newId")
+			}
+			`,
+			validateError: func(err error) error {
+				msg := `graphql: interface "Node" field "id" is not deprecated but implementing type "User" marks it as deprecated`
+				if err == nil || err.Error() != msg {
+					return fmt.Errorf("expected error %q, but got %q", msg, err)
+				}
+				return nil
+			},
+		},
+		{
+			name: "Rejects interface implementing interface where interface field is not deprecated but implementing interface field is",
+			sdl: `
+			interface Node {
+				id: ID!
+			}
+			interface Entity implements Node {
+				id: ID! @deprecated(reason: "use newId")
+			}
+			`,
+			validateError: func(err error) error {
+				msg := `graphql: interface "Node" field "id" is not deprecated but implementing interface "Entity" marks it as deprecated`
+				if err == nil || err.Error() != msg {
+					return fmt.Errorf("expected error %q, but got %q", msg, err)
+				}
+				return nil
+			},
+		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			s, err := schema.ParseSchema(tt.sdl, tt.useStringDescriptions)


### PR DESCRIPTION
Implementations may not deprecate a field that the interface hasn't deprecated.
Addresses https://github.com/graphql/graphql-spec/pull/1053