### PR TITLE
feat: support full unicode in lexer

### DIFF
--- a/errors/errors.go
+++ b/errors/errors.go
@@ -5,6 +5,15 @@ import (
 	"strings"
 )
 
+type constErr string
+
+func (e constErr) Error() string {
+	return string(e)
+}
+
+// ErrSyntax marks GraphQL syntax parsing failures.
+const ErrSyntax constErr = "graphql syntax error"
+
 type QueryError struct {
 	Err           error          `json:"-"` // Err holds underlying if available
 	Message       string         `json:"message"`

--- a/internal/common/lexer.go
+++ b/internal/common/lexer.go
@@ -4,11 +4,11 @@ import (
 	"bytes"
 	"fmt"
 	"strconv"
-	"strings"
 	"text/scanner"
 
 	"github.com/graph-gophers/graphql-go/ast"
 	"github.com/graph-gophers/graphql-go/errors"
+	"github.com/graph-gophers/graphql-go/internal/common/norm"
 )
 
 type syntaxError string
@@ -29,7 +29,7 @@ func NewLexer(s string, useStringDescriptions bool) *Lexer {
 	sc := &scanner.Scanner{
 		Mode: scanner.ScanIdents | scanner.ScanInts | scanner.ScanFloats | scanner.ScanStrings,
 	}
-	sc.Init(strings.NewReader(s))
+	sc.Init(norm.NewReader(s)) // strings.NewReader doesn't support unicode normalization
 
 	l := Lexer{sc: sc, useStringDescriptions: useStringDescriptions}
 	l.sc.Error = l.CatchScannerError
@@ -42,6 +42,7 @@ func (l *Lexer) CatchSyntaxError(f func()) (errRes *errors.QueryError) {
 		if err := recover(); err != nil {
 			if err, ok := err.(syntaxError); ok {
 				errRes = errors.Errorf("syntax error: %s", err)
+				errRes.Err = fmt.Errorf("%w: %s", errors.ErrSyntax, err)
 				errRes.Locations = []errors.Location{l.Location()}
 				return
 			}
@@ -135,6 +136,11 @@ func (l *Lexer) ConsumeKeyword(keyword string) {
 
 func (l *Lexer) ConsumeLiteral() *ast.PrimitiveValue {
 	lit := &ast.PrimitiveValue{Type: l.next, Text: l.sc.TokenText()}
+	if l.next == scanner.String && l.sc.Peek() == '"' {
+		// Triple-quoted block strings are tokenized as an empty string followed by
+		// another quote by text/scanner. Normalize to a regular quoted string.
+		lit.Text = strconv.Quote(l.consumeTripleQuoteComment())
+	}
 	l.ConsumeWhitespace()
 	return lit
 }

--- a/internal/common/lexer_bench_test.go
+++ b/internal/common/lexer_bench_test.go
@@ -1,0 +1,57 @@
+package common
+
+import (
+	"io"
+	"strings"
+	"testing"
+	"text/scanner"
+
+	"github.com/graph-gophers/graphql-go/internal/common/norm"
+)
+
+const benchmarkLexerNonTransformingInput = `
+schema {
+	query: Query
+}
+
+type Query {
+	user(id: ID!): User
+	users(limit: Int = 100): [User!]!
+}
+
+type User {
+	id: ID!
+	name: String!
+	email: String!
+	friends(first: Int = 10): [User!]!
+}
+`
+
+func BenchmarkLexerReaderNonTransforming(b *testing.B) {
+	b.Run("before_strings_reader", func(b *testing.B) {
+		benchmarkScanWithReader(b, func() io.Reader {
+			return strings.NewReader(benchmarkLexerNonTransformingInput)
+		})
+	})
+
+	b.Run("after_norm_reader", func(b *testing.B) {
+		benchmarkScanWithReader(b, func() io.Reader {
+			return norm.NewReader(benchmarkLexerNonTransformingInput)
+		})
+	})
+}
+
+func benchmarkScanWithReader(b *testing.B, reader func() io.Reader) {
+	b.Helper()
+	b.ReportAllocs()
+
+	for b.Loop() {
+		sc := &scanner.Scanner{
+			Mode: scanner.ScanIdents | scanner.ScanInts | scanner.ScanFloats | scanner.ScanStrings,
+		}
+		sc.Init(reader())
+
+		for tok := sc.Scan(); tok != scanner.EOF; tok = sc.Scan() {
+		}
+	}
+}

--- a/internal/common/norm/reader.go
+++ b/internal/common/norm/reader.go
@@ -1,4 +1,25 @@
-// Package norm provides a Reader that normalizes Unicode escape sequences in GraphQL string literals to satisfy the GraphQL spec.
+// Package norm provides a reader that normalizes Unicode escape sequences in GraphQL string literals.
+//
+// Summary of behavior and motivation:
+//   - Newly supported executable GraphQL documents include string literals using GraphQL-specific
+//     Unicode escapes, especially braced escapes (for example, \u{1F600}, \u{10FFFF}, \u{0})
+//     and valid UTF-16 surrogate pairs (for example, \uD83D\uDE00).
+//   - Raw UTF-8 characters (for example, 😀) were already supported by text/scanner because it can
+//     decode UTF-8 source text.
+//   - The gap was escape grammar compatibility, not UTF-8 decoding: GraphQL escape forms are not a
+//     strict match for Go string escape handling in text/scanner.
+//   - This reader rewrites GraphQL escapes inside normal string literals into scanner-compatible
+//     forms while leaving block strings, comments, and non-string source text unchanged.
+//
+// Example query form enabled by normalization:
+//
+//	mutation {
+//	  createReview(episode: JEDI, review: { stars: 5, commentary: "Loved it \u{1F600}" }) {
+//	    commentary
+//	  }
+//	}
+//
+// Required as of Sep 2025 GraphQL spec: https://github.com/graphql/graphql-spec/pull/849.
 package norm
 
 import (
@@ -11,7 +32,6 @@ import (
 
 // reader normalizes Unicode escape sequences in GraphQL string literals.
 // It implements [io.Reader] and rewrites escape sequences like \u{1F37A} and \uD83C\uDF7A to Go's \U format for parser compatibility.
-// This supports the GraphQL spec requirement: https://github.com/graphql/graphql-js/pull/3117.
 type reader struct {
 	src           string
 	i             int
@@ -33,8 +53,7 @@ func NewReader(src string) io.Reader {
 	return &reader{src: src}
 }
 
-// Read implements [io.Reader].
-// It reads from the source stream, normalizing Unicode escape sequences within GraphQL string literals.
+// Reader reads from the source stream, normalizing Unicode escape sequences within GraphQL string literals.
 func (r *reader) Read(p []byte) (int, error) {
 	if len(p) == 0 {
 		if r.pendingOffset >= len(r.pending) && r.i >= len(r.src) {

--- a/internal/common/norm/reader.go
+++ b/internal/common/norm/reader.go
@@ -1,0 +1,243 @@
+// Package norm provides a Reader that normalizes Unicode escape sequences in GraphQL string literals to satisfy the GraphQL spec.
+package norm
+
+import (
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"unicode/utf8"
+)
+
+// reader normalizes Unicode escape sequences in GraphQL string literals.
+// It implements [io.Reader] and rewrites escape sequences like \u{1F37A} and \uD83C\uDF7A to Go's \U format for parser compatibility.
+// This supports the GraphQL spec requirement: https://github.com/graphql/graphql-js/pull/3117.
+type reader struct {
+	src           string
+	i             int
+	pending       string
+	pendingOffset int
+	inString      bool
+	inBlockString bool
+	inComment     bool
+}
+
+// NewReader returns an [io.Reader] for src.
+// For sources without any \u escapes it returns [strings.Reader] directly.
+// Otherwise it returns a normalizing reader that rewrites GraphQL Unicode escapes.
+func NewReader(src string) io.Reader {
+	if !strings.Contains(src, `\u`) {
+		return strings.NewReader(src)
+	}
+
+	return &reader{src: src}
+}
+
+// Read implements [io.Reader].
+// It reads from the source stream, normalizing Unicode escape sequences within GraphQL string literals.
+func (r *reader) Read(p []byte) (int, error) {
+	if len(p) == 0 {
+		if r.pendingOffset >= len(r.pending) && r.i >= len(r.src) {
+			return 0, io.EOF
+		}
+		return 0, nil
+	}
+
+	var n int
+	for n < len(p) {
+		if r.pendingOffset < len(r.pending) {
+			k := copy(p[n:], r.pending[r.pendingOffset:])
+			r.pendingOffset += k
+			n += k
+			continue
+		}
+
+		r.pending = ""
+		r.pendingOffset = 0
+
+		if r.i >= len(r.src) {
+			if n == 0 {
+				return 0, io.EOF
+			}
+			return n, nil
+		}
+
+		r.produceNext()
+	}
+
+	return n, nil
+}
+
+// produceNext fetches and processes the next character, escape sequence, or string delimiter from the source.
+// It tracks whether we are inside a normal string, block string, or unquoted region, and rewrites Unicode escapes accordingly.
+func (r *reader) produceNext() {
+	if r.inComment {
+		if r.src[r.i] == '\n' || r.src[r.i] == '\r' {
+			r.inComment = false
+		}
+		r.emitNextRune()
+		return
+	}
+
+	if !r.inString && !r.inBlockString {
+		if r.src[r.i] == '#' {
+			r.inComment = true
+			r.pending = "#"
+			r.i++
+			return
+		}
+
+		if hasPrefixAt(r.src, r.i, `"""`) {
+			r.inBlockString = true
+			r.pending = `"""`
+			r.i += 3
+			return
+		}
+		if r.src[r.i] == '"' {
+			r.inString = true
+			r.pending = `"`
+			r.i++
+			return
+		}
+		r.emitNextRune()
+		return
+	}
+
+	if r.inBlockString {
+		if hasPrefixAt(r.src, r.i, `\"""`) {
+			r.pending = `\"""`
+			r.i += 4
+			return
+		}
+		if hasPrefixAt(r.src, r.i, `"""`) {
+			r.inBlockString = false
+			r.pending = `"""`
+			r.i += 3
+			return
+		}
+		r.emitNextRune()
+		return
+	}
+
+	// Normal string mode.
+	if r.src[r.i] == '\\' {
+		if rewritten, consumed, ok := rewriteUnicodeEscape(r.src[r.i:]); ok {
+			r.pending = rewritten
+			r.i += consumed
+			return
+		}
+
+		if r.i+1 < len(r.src) {
+			r.pending = r.src[r.i : r.i+2]
+			r.i += 2
+			return
+		}
+
+		r.pending = r.src[r.i : r.i+1]
+		r.i++
+		return
+	}
+
+	if r.src[r.i] == '"' {
+		r.inString = false
+		r.pending = `"`
+		r.i++
+		return
+	}
+
+	r.emitNextRune()
+}
+
+// emitNextRune outputs the next UTF-8 encoded rune from the source without transformation.
+func (r *reader) emitNextRune() {
+	_, size := utf8.DecodeRuneInString(r.src[r.i:])
+	r.pending = r.src[r.i : r.i+size]
+	r.i += size
+}
+
+// rewriteUnicodeEscape converts GraphQL Unicode escape syntax to Go's \U format.
+// It handles \u{...} braced form, \uXXXX surrogate pairs, and invalid sequences.
+// It returns (rewritten string, bytes consumed, ok). Invalid forms return empty string and false.
+func rewriteUnicodeEscape(input string) (string, int, bool) {
+	if len(input) < 2 || input[0] != '\\' || input[1] != 'u' {
+		return "", 0, false
+	}
+
+	// \u{1F37A}
+	if len(input) >= 4 && input[2] == '{' {
+		j := 3
+		for j < len(input) && isHexDigit(input[j]) {
+			j++
+		}
+		if j-3 > 8 {
+			if j < len(input) && input[j] == '}' {
+				return `\u{}`, j + 1, true
+			}
+			return `\u{}`, j, true
+		}
+		if j == 3 || j >= len(input) || input[j] != '}' {
+			return "", 0, false
+		}
+
+		cp, err := strconv.ParseUint(input[3:j], 16, 32)
+		if err != nil || cp > 0x10FFFF || (cp >= 0xD800 && cp <= 0xDFFF) {
+			return "", 0, false
+		}
+
+		return fmt.Sprintf("\\U%08X", cp), j + 1, true
+	}
+
+	if len(input) < 6 {
+		return "", 0, false
+	}
+
+	// \uD83C\uDF7A
+	hex := input[2:6]
+	if !allHex(hex) {
+		return "", 0, false
+	}
+	code, err := strconv.ParseUint(hex, 16, 16)
+	if err != nil {
+		return "", 0, false
+	}
+
+	if code >= 0xDC00 && code <= 0xDFFF {
+		// Force a syntax error later for an unpaired low surrogate.
+		return fmt.Sprintf("\\u{%04X}", code), 6, true
+	}
+
+	if code < 0xD800 || code > 0xDBFF {
+		return "", 0, false
+	}
+
+	if len(input) < 12 || input[6] != '\\' || input[7] != 'u' || !allHex(input[8:12]) {
+		// Force a syntax error later for an unpaired high surrogate.
+		return fmt.Sprintf("\\u{%04X}", code), 6, true
+	}
+
+	low, err := strconv.ParseUint(input[8:12], 16, 16)
+	if err != nil || low < 0xDC00 || low > 0xDFFF {
+		// Force a syntax error later for an unpaired high surrogate.
+		return fmt.Sprintf("\\u{%04X}", code), 6, true
+	}
+
+	cp := ((code-0xD800)<<10 | (low - 0xDC00)) + 0x10000
+	return fmt.Sprintf("\\U%08X", cp), 12, true
+}
+
+func hasPrefixAt(s string, i int, prefix string) bool {
+	return i+len(prefix) <= len(s) && s[i:i+len(prefix)] == prefix
+}
+
+func isHexDigit(b byte) bool {
+	return ('0' <= b && b <= '9') || ('a' <= b && b <= 'f') || ('A' <= b && b <= 'F')
+}
+
+func allHex(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if !isHexDigit(s[i]) {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/common/norm/reader.go
+++ b/internal/common/norm/reader.go
@@ -53,7 +53,7 @@ func NewReader(src string) io.Reader {
 	return &reader{src: src}
 }
 
-// Reader reads from the source stream, normalizing Unicode escape sequences within GraphQL string literals.
+// Read reads from the source stream, normalizing Unicode escape sequences within GraphQL string literals.
 func (r *reader) Read(p []byte) (int, error) {
 	if len(p) == 0 {
 		if r.pendingOffset >= len(r.pending) && r.i >= len(r.src) {

--- a/internal/common/norm/reader_fuzz_test.go
+++ b/internal/common/norm/reader_fuzz_test.go
@@ -1,0 +1,141 @@
+package norm
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"testing"
+	"text/scanner"
+)
+
+const maxReadIterations = 1 << 20
+
+func readAllChunkedStrict(r io.Reader, chunk int) (string, error) {
+	if chunk <= 0 {
+		return "", fmt.Errorf("invalid chunk size %d", chunk)
+	}
+
+	var b strings.Builder
+	buf := make([]byte, chunk)
+
+	for range maxReadIterations {
+		n, err := r.Read(buf)
+		if n > 0 {
+			b.Write(buf[:n])
+		}
+
+		if errors.Is(err, io.EOF) {
+			return b.String(), nil
+		}
+		if err != nil {
+			return "", err
+		}
+
+		if n == 0 {
+			return "", errors.New("reader made no progress without EOF")
+		}
+	}
+
+	return "", errors.New("reader did not terminate")
+}
+
+func scanAll(src string) {
+	var sc scanner.Scanner
+	sc.Init(strings.NewReader(src))
+	sc.Mode = scanner.ScanIdents | scanner.ScanInts | scanner.ScanFloats | scanner.ScanStrings
+
+	for {
+		tok := sc.Scan()
+		if tok == scanner.EOF {
+			return
+		}
+	}
+}
+
+// go test ./internal/common/norm -run=^$ -fuzz=FuzzReader_ChunkInvariantAndBoundedOutput -fuzztime=10m
+func FuzzReader_ChunkInvariantAndBoundedOutput(f *testing.F) {
+	seeds := [][]byte{
+		[]byte(``),
+		[]byte(`{ f(arg: "plain") }`),
+		[]byte(`{ f(arg: "\u{1F37A}") }`),
+		[]byte(`{ f(arg: "\uD83C\uDF7A") }`),
+		[]byte(`{ f(arg: "\uD83C") }`),
+		[]byte(`{ f(arg: "\uDEAD") }`),
+		[]byte(`{ f(arg: "\u{000000000}") }`),
+		[]byte(`# comment with \u{1F37A}` + "\n" + `{ f(arg: "\u{41}") }`),
+		[]byte(`{ f(arg: """\u{1F37A}""") }`),
+		{0xff, '\\', 'u', '{', 'F', 'F', '}', 0x00, '\\', 'u', 'D', '8', '0', '0'},
+	}
+
+	for _, s := range seeds {
+		f.Add(s, uint8(1))
+		f.Add(s, uint8(31))
+	}
+
+	f.Fuzz(func(t *testing.T, raw []byte, chunkByte uint8) {
+		input := string(raw)
+		chunk := int(chunkByte%32) + 1
+
+		outChunked, err := readAllChunkedStrict(NewReader(input), chunk)
+		if err != nil {
+			t.Fatalf("chunked read failed: %v", err)
+		}
+
+		outByteByByte, err := readAllChunkedStrict(NewReader(input), 1)
+		if err != nil {
+			t.Fatalf("byte-by-byte read failed: %v", err)
+		}
+
+		if outChunked != outByteByByte {
+			t.Fatalf("output differs by chunking\nchunk=%d\noutChunked=%q\noutByteByByte=%q", chunk, outChunked, outByteByByte)
+		}
+
+		// Rewrites only happen from escapes beginning with `\u`, so output growth is bounded.
+		if len(outChunked) > 2*len(input)+16 {
+			t.Fatalf("unexpected output growth: in=%d out=%d", len(input), len(outChunked))
+		}
+
+		// Ensure the normalized stream is always scanner-safe (no panics).
+		scanAll(outChunked)
+	})
+}
+
+// go test ./internal/common/norm -run=^$ -fuzz=FuzzReader_FastPathParityWithoutUnicodeMarker -fuzztime=1m
+func FuzzReader_FastPathParityWithoutUnicodeMarker(f *testing.F) {
+	seeds := [][]byte{
+		[]byte(``),
+		[]byte(`query { field }`),
+		[]byte(`"\\u"`),
+		[]byte(`prefix u suffix`),
+		{0xff, 0xfe, 'a', 'b'},
+	}
+
+	for _, s := range seeds {
+		f.Add(s, uint8(7))
+	}
+
+	f.Fuzz(func(t *testing.T, raw []byte, chunkByte uint8) {
+		if bytes.Contains(raw, []byte(`\u`)) {
+			t.Skip()
+		}
+
+		input := string(raw)
+		chunk := int(chunkByte%32) + 1
+
+		got, err := readAllChunkedStrict(NewReader(input), chunk)
+		if err != nil {
+			t.Fatalf("read failed: %v", err)
+		}
+
+		want, err := readAllChunkedStrict(strings.NewReader(input), chunk)
+		if err != nil {
+			t.Fatalf("reference read failed: %v", err)
+		}
+
+		if got != want {
+			t.Fatalf("fast-path mismatch\ngot =%q\nwant=%q", got, want)
+		}
+	})
+}

--- a/internal/common/norm/reader_test.go
+++ b/internal/common/norm/reader_test.go
@@ -1,0 +1,257 @@
+package norm_test
+
+import (
+	"errors"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/graph-gophers/graphql-go/internal/common/norm"
+)
+
+type readStep struct {
+	n    int
+	eof  bool
+	data string
+}
+
+func runReadSize(r io.Reader, readSizes []int) []readStep {
+	steps := make([]readStep, 0, len(readSizes))
+	for _, size := range readSizes {
+		buf := make([]byte, size)
+		n, err := r.Read(buf)
+		steps = append(steps, readStep{
+			n:    n,
+			eof:  errors.Is(err, io.EOF),
+			data: string(buf[:n]),
+		})
+	}
+	return steps
+}
+
+func assertStringsReaderParity(t *testing.T, input string, readSizes []int) {
+	t.Helper()
+
+	got := runReadSize(norm.NewReader(input), readSizes)
+	want := runReadSize(strings.NewReader(input), readSizes)
+
+	if len(got) != len(want) {
+		t.Fatalf("step count mismatch: got=%d want=%d", len(got), len(want))
+	}
+	for i := range got {
+		if got[i].n != want[i].n || got[i].eof != want[i].eof || got[i].data != want[i].data {
+			t.Fatalf("step %d mismatch:\n got: n=%d eof=%v data=%q\nwant: n=%d eof=%v data=%q",
+				i, got[i].n, got[i].eof, got[i].data,
+				want[i].n, want[i].eof, want[i].data,
+			)
+		}
+	}
+}
+
+func readAllChunked(r io.Reader, chunk int) (string, error) {
+	var b strings.Builder
+	buf := make([]byte, chunk)
+	for {
+		n, err := r.Read(buf)
+		if n > 0 {
+			b.Write(buf[:n])
+		}
+		if errors.Is(err, io.EOF) {
+			return b.String(), nil
+		}
+		if err != nil {
+			return "", err
+		}
+	}
+}
+
+func TestReader_ReadParity_NonTransformingInputs(t *testing.T) {
+	t.Parallel()
+
+	// readSizes drives per-call Read buffer lengths to stress io.Reader parity (zero-length, tiny, and oversized reads) against strings.NewReader.
+	readSizes := []int{
+		0, 1, 2, 3, 5, 8, 0, 13, 21, 1, 1, 34, 0, 55, 89, 0, 144, 1, 1, 1, 0, 233,
+	}
+
+	inputs := []struct {
+		name string
+		in   string
+	}{
+		{"empty", ""},
+		{"ascii", "abc"},
+		{"plain_ascii", "hello world"},
+		{"graphql_plain", `{ f(arg: "plain") }`},
+		{"graphql_escape_sequences", "{ f(arg: \"slashes \\n \\t \\u \\u{\") } }"},
+		{"graphql_block_string_unicode", `{ f(arg: """block with \u{1F37A} stays literal""") }`},
+		{"emoji_and_combining", "emoji 🍺 and combining e\u0301 and composed é"},
+		{"invalid_utf8_with_newline", string([]byte{0xff, 'a', 0xc3, 0x28, '\n', 'z'})},
+		{"comment_only", "# just a comment"},
+		{"comment_with_crlf", "# comment\r\nquery { id }"},
+		{"block_string_with_escaped_delim", `{ f(arg: """line1\n"""other""") }`},
+		{"multiple_block_strings", `"""first""" """second"""`},
+		{"whitespace_only", "   \t  \n  "},
+		{"mixed_newlines", "line1\rline2\nline3\r\nline4"},
+		{"long_plain_text", "The quick brown fox jumps over the lazy dog. " + "Lorem ipsum dolor sit amet, consectetur adipiscing elit. " + "This is a longer test string to stress buffering."},
+		{"tabs_and_spaces", "query\t{\n  field\t\t{\n    id\n  }\n}"},
+		{"quote_chars_outside_strings", `query { id } # "not a string" 'also not'`},
+		{"unicode_edge_cases", string([]rune{
+			0x0000, 0x0001, 0x0002, 0x0003, 0x0004, 0x0005, 0x0006, 0x0007, 0x0008, 0x0009,
+			0x000A, 0x000B, 0x000C, 0x000D, 0x000E, 0x000F, 0x0010, 0x0011, 0x0012, 0x0013,
+			// omitting characters for brevity
+			0x10FFFD, 0x10FFFE, 0x10FFFF,
+		})},
+		{"combined", "# comment\nquery { field(arg: \"value with unicode 🍺 and escapes \\n\") }\n" + `"""block string with \u{1F37A} and "quotes""""`},
+	}
+
+	for _, tt := range inputs {
+		t.Run(tt.name, func(t *testing.T) {
+			assertStringsReaderParity(t, tt.in, readSizes)
+		})
+	}
+}
+
+func TestReader_Read_TransformingInputs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "brace escape",
+			in:   `{ f(arg: "\u{1F37A}") }`,
+			want: `{ f(arg: "\U0001F37A") }`,
+		},
+		{
+			name: "valid surrogate pair",
+			in:   `{ f(arg: "\uD83C\uDF7A") }`,
+			want: `{ f(arg: "\U0001F37A") }`,
+		},
+		{
+			name: "unpaired low surrogate becomes sentinel",
+			in:   `{ f(arg: "\uDEAD") }`,
+			want: `{ f(arg: "\u{DEAD}") }`,
+		},
+		{
+			name: "unpaired high surrogate becomes sentinel",
+			in:   `{ f(arg: "\uD83C\u0041") }`,
+			want: `{ f(arg: "\u{D83C}\u0041") }`,
+		},
+		{
+			name: "too long brace escape becomes sentinel",
+			in:   `{ f(arg: "\u{000000000}") }`,
+			want: `{ f(arg: "\u{}") }`,
+		},
+		{
+			name: "only inside normal string transforms",
+			in:   `\u{1F37A} { f(arg: "\u{1F37A}") }`,
+			want: `\u{1F37A} { f(arg: "\U0001F37A") }`,
+		},
+		{
+			name: "block string unchanged",
+			in:   `{ f(arg: """\u{1F37A}""") }`,
+			want: `{ f(arg: """\u{1F37A}""") }`,
+		},
+		{
+			name: "braced minimum code point",
+			in:   `{ f(arg: "\u{0}") }`,
+			want: `{ f(arg: "\U00000000") }`,
+		},
+		{
+			name: "braced maximum code point",
+			in:   `{ f(arg: "\u{10FFFF}") }`,
+			want: `{ f(arg: "\U0010FFFF") }`,
+		},
+		{
+			name: "braced leading zeros",
+			in:   `{ f(arg: "\u{00000000}") }`,
+			want: `{ f(arg: "\U00000000") }`,
+		},
+		{
+			name: "valid surrogate pair minimum",
+			in:   `{ f(arg: "\uD800\uDC00") }`,
+			want: `{ f(arg: "\U00010000") }`,
+		},
+		{
+			name: "valid surrogate pair maximum",
+			in:   `{ f(arg: "\uDBFF\uDFFF") }`,
+			want: `{ f(arg: "\U0010FFFF") }`,
+		},
+		{
+			name: "high surrogate at end of string",
+			in:   `{ f(arg: "\uD83C") }`,
+			want: `{ f(arg: "\u{D83C}") }`,
+		},
+		{
+			name: "high surrogate followed by plain char",
+			in:   `{ f(arg: "\uD83Cx") }`,
+			want: `{ f(arg: "\u{D83C}x") }`,
+		},
+		{
+			name: "two high surrogates in a row",
+			in:   `{ f(arg: "\uD800\uD800") }`,
+			want: `{ f(arg: "\u{D800}\u{D800}") }`,
+		},
+		{
+			name: "two low surrogates in a row",
+			in:   `{ f(arg: "\uDC00\uDC00") }`,
+			want: `{ f(arg: "\u{DC00}\u{DC00}") }`,
+		},
+		{
+			name: "braced surrogate is not allowed",
+			in:   `{ f(arg: "\u{DEAD}") }`,
+			want: `{ f(arg: "\u{DEAD}") }`,
+		},
+		{
+			name: "invalid braced non-hex unchanged",
+			in:   `{ f(arg: "\u{FXXX}") }`,
+			want: `{ f(arg: "\u{FXXX}") }`,
+		},
+		{
+			name: "incomplete braced escape unchanged",
+			in:   `{ f(arg: "\u{FFFF") }`,
+			want: `{ f(arg: "\u{FFFF") }`,
+		},
+		{
+			name: "escape before closing quote",
+			in:   `{ f(arg: "x\u{1F37A}") }`,
+			want: `{ f(arg: "x\U0001F37A") }`,
+		},
+		{
+			name: "multiple escapes in one string",
+			in:   `{ f(arg: "\u{41}\uD83C\uDF7A\u{42}") }`,
+			want: `{ f(arg: "\U00000041\U0001F37A\U00000042") }`,
+		},
+		{
+			name: "escaped block delimiter sequence remains in block string",
+			in:   `{ f(arg: """x\"""\u{1F37A}y""") }`,
+			want: `{ f(arg: """x\"""\u{1F37A}y""") }`,
+		},
+		{
+			name: "comment with quotes does not enter string mode",
+			in:   `# " """ \u{1F37A}` + "\n" + `{ f(arg: "\u{41}") }`,
+			want: `# " """ \u{1F37A}` + "\n" + `{ f(arg: "\U00000041") }`,
+		},
+		{
+			name: "comment ending with carriage return resumes normal lexing",
+			in:   `# "\u{1F37A}` + "\r\n" + `{ f(arg: "\u{42}") }`,
+			want: `# "\u{1F37A}` + "\r\n" + `{ f(arg: "\U00000042") }`,
+		},
+	}
+
+	chunks := []int{1, 2, 3, 7, 16, 64}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			for _, chunk := range chunks {
+				got, err := readAllChunked(norm.NewReader(tt.in), chunk)
+				if err != nil {
+					t.Fatalf("chunk=%d: unexpected err: %v", chunk, err)
+				}
+				if got != tt.want {
+					t.Fatalf("chunk=%d\ngot =%q\nwant=%q", chunk, got, tt.want)
+				}
+			}
+		})
+	}
+}

--- a/internal/query/query_test.go
+++ b/internal/query/query_test.go
@@ -35,3 +35,39 @@ func TestParseRejectsEmptyNestedSelectionSet(t *testing.T) {
 		t.Fatalf("expected syntax error for empty nested selection set, got nil")
 	}
 }
+
+func TestParseAcceptsFullUnicodeEscapeSyntax(t *testing.T) {
+	t.Parallel()
+
+	_, err := Parse(`query { user(id: "\u{1F37A}") { id } }`)
+	if err != nil {
+		t.Fatalf("expected query to parse, got error: %v", err)
+	}
+}
+
+func TestParseAcceptsSupplementaryPlaneCodePoint(t *testing.T) {
+	t.Parallel()
+
+	_, err := Parse(`query { user(id: "🍺") { id } }`)
+	if err != nil {
+		t.Fatalf("expected query to parse, got error: %v", err)
+	}
+}
+
+func TestParseAcceptsValidSurrogatePairEscape(t *testing.T) {
+	t.Parallel()
+
+	_, err := Parse(`query { user(id: "\uD83C\uDF7A") { id } }`)
+	if err != nil {
+		t.Fatalf("expected query to parse, got error: %v", err)
+	}
+}
+
+func TestParseRejectsInvalidSurrogatePairEscape(t *testing.T) {
+	t.Parallel()
+
+	_, err := Parse(`query { user(id: "\uD83C\u0041") { id } }`)
+	if err == nil {
+		t.Fatal("expected syntax error for invalid surrogate pair, got nil")
+	}
+}

--- a/internal/query/unicode_lexer_parser_parity_test.go
+++ b/internal/query/unicode_lexer_parser_parity_test.go
@@ -1,0 +1,115 @@
+package query
+
+import (
+	"errors"
+	"testing"
+
+	gqlerrors "github.com/graph-gophers/graphql-go/errors"
+)
+
+// TestParse_UnicodeLexerParserParity covers graphql-js PR3117 Unicode lexer/parser parity behavior.
+// Reference: https://github.com/graphql/graphql-js/pull/3117.
+func TestParse_UnicodeLexerParserParity(t *testing.T) {
+	t.Parallel()
+
+	t.Run("StringAndBlockStringValidCases", func(t *testing.T) {
+		t.Parallel()
+
+		valid := []string{
+			`query { f(arg: "unescaped unicode outside BMP 😀") }`,
+			`query { f(arg: "unescaped maximal unicode outside BMP 􏿿") }`,
+			`query { f(arg: "unicode \u{1234}\u{5678}\u{90AB}\u{CDEF}") }`,
+			`query { f(arg: "string with unicode escape outside BMP \u{1F600}") }`,
+			`query { f(arg: "string with minimal unicode escape \u{0}") }`,
+			`query { f(arg: "string with maximal unicode escape \u{10FFFF}") }`,
+			`query { f(arg: "string with maximal minimal unicode escape \u{00000000}") }`,
+			`query { f(arg: "string with unicode surrogate pair escape \uD83D\uDE00") }`,
+			`query { f(arg: "string with minimal surrogate pair escape \uD800\uDC00") }`,
+			`query { f(arg: "string with maximal surrogate pair escape \uDBFF\uDFFF") }`,
+			`query { f(arg: """unescaped unicode outside BMP 😀""") }`,
+		}
+
+		for _, q := range valid {
+			t.Run(q, func(t *testing.T) {
+				t.Parallel()
+				_, err := Parse(q)
+				if err != nil {
+					t.Fatalf("expected parse success, got: %v", err)
+				}
+			})
+		}
+	})
+
+	t.Run("InvalidUnicodeEscapeCases", func(t *testing.T) {
+		t.Parallel()
+
+		invalid := []string{
+			`query { f(arg: "bad surrogate \uDEAD") }`,
+			`query { f(arg: "bad high surrogate pair \uDEAD\uDEAD") }`,
+			`query { f(arg: "bad low surrogate pair \uD800\uD800") }`,
+			`query { f(arg: "bad \u{} esc") }`,
+			`query { f(arg: "bad \u{FXXX} esc") }`,
+			`query { f(arg: "bad \u{FFFF esc") }`,
+			`query { f(arg: "bad \u{FFFF") }`,
+			`query { f(arg: "too high \u{110000} esc") }`,
+			`query { f(arg: "way too high \u{12345678} esc") }`,
+			`query { f(arg: "too long \u{000000000} esc") }`,
+			`query { f(arg: "bad surrogate \uDEAD esc") }`,
+			`query { f(arg: "bad surrogate \u{DEAD} esc") }`,
+			`query { f(arg: "cannot use braces for surrogate pair \u{D83D}\u{DE00} esc") }`,
+			`query { f(arg: "bad high surrogate pair \uDEAD\uDEAD esc") }`,
+			`query { f(arg: "bad low surrogate pair \uD800\uD800 esc") }`,
+			`query { f(arg: "bad \uD83D\not an escape") }`,
+		}
+
+		for _, q := range invalid {
+			t.Run(q, func(t *testing.T) {
+				t.Parallel()
+				_, err := Parse(q)
+				if err == nil {
+					t.Fatal("expected syntax error, got nil")
+				}
+			})
+		}
+	})
+
+	t.Run("CommentAndSourceCharacterCases", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := Parse("# Comment 😀\nquery { f }")
+		if err != nil {
+			t.Fatalf("expected comment with supplementary code point to parse, got: %v", err)
+		}
+
+		_, err = Parse("😀")
+		if err == nil {
+			t.Fatal("expected syntax error for unexpected top-level supplementary character")
+		}
+
+		_, err = Parse("\x08")
+		if err == nil {
+			t.Fatal("expected syntax error for backspace control character")
+		}
+
+		nul := string([]byte{0})
+		_, err = Parse(nul)
+		if err == nil {
+			t.Fatal("expected syntax error for NUL control character")
+		}
+	})
+
+	t.Run("ErrorTextForUnicodeEscapeReportsInvalidCharEscape", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := Parse(`query { f(arg: "too high \u{110000} esc") }`)
+		if err == nil {
+			t.Fatal("expected syntax error")
+		}
+		if !errors.Is(err, gqlerrors.ErrSyntax) {
+			t.Fatalf("expected syntax sentinel error, got: %v", err)
+		}
+		if got, want := err.Message, "syntax error: invalid char escape"; got != want {
+			t.Fatalf("expected %q, got: %v", want, err)
+		}
+	})
+}


### PR DESCRIPTION
Implements full unicode support in lexer to satisfy Sep 2025 GraphQL Spec changes https://github.com/graphql/graphql-spec/pull/849.

[Graphql-js implementation](https://github.com/graphql/graphql-js/pull/3117/) for reference. 

Fixes #729 