### PR TITLE
fix: Resolver cycles where one of the types is a union

### DIFF
--- a/graphql_test.go
+++ b/graphql_test.go
@@ -3903,6 +3903,108 @@ func TestTypeAssertions(t *testing.T) {
 	})
 }
 
+type unionCycleQueryResolver struct{}
+
+func (*unionCycleQueryResolver) Wrapper() *unionCycleWrapperResolver {
+	return &unionCycleWrapperResolver{}
+}
+
+type unionCycleWrapperResolver struct{}
+
+func (*unionCycleWrapperResolver) Item() *unionCycleItemResolver {
+	return &unionCycleItemResolver{}
+}
+
+type unionCycleItemResolver struct{}
+
+func (*unionCycleItemResolver) ToHuman() (*unionCycleHumanResolver, bool) {
+	return &unionCycleHumanResolver{}, true
+}
+
+type unionCycleHumanResolver struct{}
+
+func (*unionCycleHumanResolver) Name() string {
+	return "Luke Skywalker"
+}
+
+func (*unionCycleHumanResolver) Friend() *unionCycleFriendResolver {
+	return &unionCycleFriendResolver{}
+}
+
+type unionCycleFriendResolver struct{}
+
+func (*unionCycleFriendResolver) Item() *unionCycleItemResolver {
+	return &unionCycleItemResolver{}
+}
+
+func TestUnionTypeAssertionResolverCycles(t *testing.T) {
+	schema, err := graphql.ParseSchema(`
+		schema {
+			query: Query
+		}
+
+		type Query {
+			wrapper: Wrapper!
+		}
+
+		type Wrapper {
+			item: Item!
+		}
+
+		union Item = Human
+
+		type Human {
+			name: String!
+			friend: Friend!
+		}
+
+		type Friend {
+			item: Item!
+		}
+	`, &unionCycleQueryResolver{})
+	if err != nil {
+		t.Fatalf("ParseSchema: unexpected error: %v", err)
+	}
+
+	gqltesting.RunTests(t, []*gqltesting.Test{
+		{
+			Schema: schema,
+			Query: `
+				query {
+					wrapper {
+						item {
+							... on Human {
+								name
+								friend {
+									item {
+										... on Human {
+											name
+										}
+									}
+								}
+							}
+						}
+					}
+				}
+			`,
+			ExpectedResult: `
+				{
+					"wrapper": {
+						"item": {
+							"name": "Luke Skywalker",
+							"friend": {
+								"item": {
+									"name": "Luke Skywalker"
+								}
+							}
+						}
+					}
+				}
+			`,
+		},
+	})
+}
+
 func TestPanicTypeAssertionArguments(t *testing.T) {
 	panicMessage := `*graphql_test.badAssertionResolver does not resolve "Character": method "ToHuman" shouldn't have any arguments
 	used by (*graphql_test.badAssertionQueryResolver).Character`

--- a/internal/exec/resolvable/resolvable.go
+++ b/internal/exec/resolvable/resolvable.go
@@ -454,12 +454,16 @@ func (b *execBuilder) makeObjectExec(typeName string, fields ast.FieldsDefinitio
 			a := &TypeAssertion{
 				MethodIndex: methodIndex,
 			}
+			if err := b.assignExec(&a.TypeExec, impl, resolverType.Method(methodIndex).Type.Out(0)); err != nil {
+				return nil, err
+			}
+			if len(Fields) == 0 {
+				typeAssertions[impl.Name] = a
+				continue
+			}
 			implOutType := resolverType.Method(methodIndex).Type.Out(0)
 			implExec, err := b.lookupOrBuildExec(impl, implOutType)
 			if err != nil {
-				return nil, err
-			}
-			if err := b.assignExec(&a.TypeExec, impl, resolverType.Method(methodIndex).Type.Out(0)); err != nil {
 				return nil, err
 			}
 			objExec, ok := implExec.(*Object)


### PR DESCRIPTION
Version 1.10.0 introduced a breaking change for schemas with resolver cycles where one or more of the resolved types are a union. Here is an example error message from trying to generate our schema:

`*query.LinkedObjectResolver does not resolve "ParsedObject": type assertion "CargoQuote" did not resolve to an object`

In our schema `ParsedObject` is a union type while `CargoQuote` is one of the types in the union.

This PR is meant as a minimal fix to avoid the breaking change. Most of the diff is a new unit test of a cycle-with-union schema that fails in 1.10.0 but passes when the fix is applied.
