### PR TITLE
refactor(exec): lookupOrBuildExec

### DIFF
--- a/internal/exec/resolvable/meta.go
+++ b/internal/exec/resolvable/meta.go
@@ -23,13 +23,13 @@ func newMeta(s *ast.Schema) *Meta {
 	b := newBuilder(s, false)
 
 	metaSchema := s.Types["__Schema"].(*ast.ObjectTypeDefinition)
-	so, err := b.makeObjectExec(metaSchema.Name, metaSchema.Fields, nil, nil, false, reflect.TypeFor[*introspection.Schema](), nil)
+	so, err := b.populateObjectExec(&Object{}, metaSchema.Name, metaSchema.Fields, nil, nil, false, reflect.TypeFor[*introspection.Schema]())
 	if err != nil {
 		panic(err)
 	}
 
 	metaType := s.Types["__Type"].(*ast.ObjectTypeDefinition)
-	t, err := b.makeObjectExec(metaType.Name, metaType.Fields, nil, nil, false, reflect.TypeFor[*introspection.Type](), nil)
+	t, err := b.populateObjectExec(&Object{}, metaType.Name, metaType.Fields, nil, nil, false, reflect.TypeFor[*introspection.Type]())
 	if err != nil {
 		panic(err)
 	}

--- a/internal/exec/resolvable/resolvable.go
+++ b/internal/exec/resolvable/resolvable.go
@@ -281,13 +281,11 @@ func (b *execBuilder) lookupOrBuildExec(t ast.Type, resolverType reflect.Type) (
 	if !ok {
 		ref = &resMapEntry{}
 		b.resMap[k] = ref
-		var shell *Object
 		if isObjectLikeType(t) {
-			shell = &Object{}
-			ref.exec = shell
+			ref.exec = &Object{}
 		}
 		var err error
-		ref.exec, err = b.makeExec(t, resolverType, shell)
+		ref.exec, err = b.makeExec(t, resolverType)
 		if err != nil {
 			ref.exec = nil
 			delete(b.resMap, k)
@@ -297,19 +295,20 @@ func (b *execBuilder) lookupOrBuildExec(t ast.Type, resolverType reflect.Type) (
 	return ref.exec, nil
 }
 
-func (b *execBuilder) makeExec(t ast.Type, resolverType reflect.Type, shell *Object) (Resolvable, error) {
+func (b *execBuilder) makeExec(t ast.Type, resolverType reflect.Type) (Resolvable, error) {
+	rawType := t
 	var nonNull bool
 	t, nonNull = unwrapNonNull(t)
 
 	switch t := t.(type) {
 	case *ast.ObjectTypeDefinition:
-		return b.makeObjectExec(t.Name, t.Fields, nil, t.Interfaces, nonNull, resolverType, shell)
+		return b.makeObjectExec(rawType, t.Name, t.Fields, nil, t.Interfaces, nonNull, resolverType)
 
 	case *ast.InterfaceTypeDefinition:
-		return b.makeObjectExec(t.Name, t.Fields, t.PossibleTypes, nil, nonNull, resolverType, shell)
+		return b.makeObjectExec(rawType, t.Name, t.Fields, t.PossibleTypes, nil, nonNull, resolverType)
 
 	case *ast.Union:
-		return b.makeObjectExec(t.Name, nil, t.UnionMemberTypes, nil, nonNull, resolverType, shell)
+		return b.makeObjectExec(rawType, t.Name, nil, t.UnionMemberTypes, nil, nonNull, resolverType)
 	}
 
 	if !nonNull {
@@ -362,11 +361,15 @@ func makeScalarExec(t *ast.ScalarTypeDefinition, resolverType reflect.Type) (Res
 	return &Scalar{}, nil
 }
 
-func (b *execBuilder) makeObjectExec(typeName string, fields ast.FieldsDefinition, possibleTypes []*ast.ObjectTypeDefinition, interfaces []*ast.InterfaceTypeDefinition, nonNull bool, resolverType reflect.Type, obj *Object) (*Object, error) {
+func (b *execBuilder) makeObjectExec(rawType ast.Type, typeName string, fields ast.FieldsDefinition, possibleTypes []*ast.ObjectTypeDefinition, interfaces []*ast.InterfaceTypeDefinition, nonNull bool, resolverType reflect.Type) (*Object, error) {
+	obj := b.objectShell(rawType, resolverType)
 	if obj == nil {
 		obj = &Object{}
 	}
+	return b.populateObjectExec(obj, typeName, fields, possibleTypes, interfaces, nonNull, resolverType)
+}
 
+func (b *execBuilder) populateObjectExec(obj *Object, typeName string, fields ast.FieldsDefinition, possibleTypes []*ast.ObjectTypeDefinition, interfaces []*ast.InterfaceTypeDefinition, nonNull bool, resolverType reflect.Type) (*Object, error) {
 	if !nonNull {
 		if resolverType.Kind() != reflect.Pointer && resolverType.Kind() != reflect.Interface {
 			return nil, fmt.Errorf("%s is not a pointer or interface", resolverType)
@@ -520,6 +523,15 @@ func (b *execBuilder) makeObjectExec(typeName string, fields ast.FieldsDefinitio
 	obj.TypeAssertions = typeAssertions
 	obj.Interfaces = ifaces
 	return obj, nil
+}
+
+func (b *execBuilder) objectShell(t ast.Type, resolverType reflect.Type) *Object {
+	ref, ok := b.resMap[typePair{t, resolverType}]
+	if !ok {
+		return nil
+	}
+	obj, _ := ref.exec.(*Object)
+	return obj
 }
 
 var (


### PR DESCRIPTION
Split `lookupOrBuildExec` into `makeObjectExec` and `populateObjectExec` to contain the shell creation.