### PR TITLE
feature: New Parse opt AllowDeprecatedUsage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # CHANGELOG
 
+* [FEATURE] Add `AllowDeprecatedUsage()` schema option to restore pre-v1.10.0 validation behavior for deprecated fields, arguments, enum values, input fields, and directive arguments.
 * [FEATURE] Support executable-document description strings on full-form operations, fragments, and variable definitions. Descriptions remain non-semantic and do not change validation or execution behavior. Executable `#` comments remain ignored.
 
 [v1.9.0](https://github.com/graph-gophers/graphql-go/releases/tag/v1.9.0) Release v1.9.0

--- a/README.md
+++ b/README.md
@@ -155,6 +155,7 @@ schema := graphql.MustParseSchema(sdl, &RootResolver{}, nil)
 
 - `UseStringDescriptions()` enables schema/type-system description strings (double and triple quoted). When this is not enabled, schema comments are parsed as descriptions instead.
 - `UseFieldResolvers()` specifies whether to use struct field resolvers.
+- `AllowDeprecatedUsage()` restores pre-v1.10.0 validation behavior by allowing deprecated fields, arguments, enum values, input fields, and directive arguments to be used without validation errors.
 - `MaxDepth(n int)` specifies the maximum field nesting depth in a query. The default is 0 which disables max depth checking.
 - `MaxParallelism(n int)` specifies the maximum number of resolvers per request allowed to run in parallel. The default is 10.
 - `MaxPooledBufferCap(n int)` specifies the maximum buffer capacity of buffers stored in the internal memory pool. Defaults to 16KB. Buffers larger than this limit are discarded instead of pooled.

--- a/graphql.go
+++ b/graphql.go
@@ -105,6 +105,7 @@ func (s *Schema) Clone(resolver any, opts ...SchemaOpt) (*Schema, error) {
 		maxPooledBufferCapacity:  s.maxPooledBufferCapacity,
 		maxDepth:                 s.maxDepth,
 		useStringDescriptions:    s.useStringDescriptions,
+		allowDeprecatedUsage:     s.allowDeprecatedUsage,
 		subscribeResolverTimeout: s.subscribeResolverTimeout,
 		useFieldResolvers:        s.useFieldResolvers,
 		disableFieldSelections:   s.disableFieldSelections,
@@ -188,6 +189,7 @@ type Schema struct {
 	logger                   log.Logger
 	panicHandler             errors.PanicHandler
 	useStringDescriptions    bool
+	allowDeprecatedUsage     bool
 	subscribeResolverTimeout time.Duration
 	useFieldResolvers        bool
 	disableFieldSelections   bool
@@ -227,6 +229,15 @@ func UseStringDescriptions() SchemaOpt {
 func UseFieldResolvers() SchemaOpt {
 	return func(s *Schema) {
 		s.useFieldResolvers = true
+	}
+}
+
+// AllowDeprecatedUsage restores pre-v1.10.0 validation behavior by allowing
+// deprecated fields, arguments, enum values, input fields, and directive
+// arguments to be used without returning NoDeprecatedCustomRule errors.
+func AllowDeprecatedUsage() SchemaOpt {
+	return func(s *Schema) {
+		s.allowDeprecatedUsage = true
 	}
 }
 
@@ -379,7 +390,7 @@ func (s *Schema) ValidateWithVariables(queryString string, variables map[string]
 		return []*errors.QueryError{errors.Errorf("executable document must contain at least one operation")}
 	}
 
-	return validation.Validate(s.schema, doc, variables, s.maxDepth, s.overlapPairLimit)
+	return validation.Validate(s.schema, doc, variables, s.maxDepth, s.overlapPairLimit, s.allowDeprecatedUsage)
 }
 
 // Exec executes the given query with the schema's resolver. It panics if the schema was created
@@ -402,7 +413,7 @@ func (s *Schema) exec(ctx context.Context, queryString string, operationName str
 	}
 
 	validationFinish := s.validationTracer.TraceValidation(ctx)
-	errs := validation.Validate(s.schema, doc, variables, s.maxDepth, s.overlapPairLimit)
+	errs := validation.Validate(s.schema, doc, variables, s.maxDepth, s.overlapPairLimit, s.allowDeprecatedUsage)
 	validationFinish(errs)
 	if len(errs) != 0 {
 		return &Response{Errors: errs}

--- a/graphql_test.go
+++ b/graphql_test.go
@@ -1784,6 +1784,48 @@ func TestDeprecatedArgs(t *testing.T) {
 	`, &testDeprecatedArgsResolver{})
 }
 
+type testAllowDeprecatedUsageResolver struct{}
+
+func (r *testAllowDeprecatedUsageResolver) DeprecatedField() string {
+	return "ok"
+}
+
+func TestAllowDeprecatedUsage(t *testing.T) {
+	t.Parallel()
+
+	const sdl = `
+		schema {
+			query: Query
+		}
+		type Query {
+			deprecatedField: String! @deprecated(reason: "Use replacementField")
+		}
+	`
+
+	gqltesting.RunTests(t, []*gqltesting.Test{
+		{
+			Schema: graphql.MustParseSchema(sdl, &testAllowDeprecatedUsageResolver{}),
+			Query:  `{ deprecatedField }`,
+			ExpectedErrors: []*gqlerrors.QueryError{
+				{
+					Message:   "The field Query.deprecatedField is deprecated. Use replacementField",
+					Locations: []gqlerrors.Location{{Line: 1, Column: 3}},
+					Rule:      "NoDeprecatedCustomRule",
+				},
+			},
+		},
+		{
+			Schema: graphql.MustParseSchema(sdl, &testAllowDeprecatedUsageResolver{}, graphql.AllowDeprecatedUsage()),
+			Query:  `{ deprecatedField }`,
+			ExpectedResult: `
+				{
+					"deprecatedField": "ok"
+				}
+			`,
+		},
+	})
+}
+
 func TestInlineFragments(t *testing.T) {
 	gqltesting.RunTests(t, []*gqltesting.Test{
 		{

--- a/internal/schema/schema.go
+++ b/internal/schema/schema.go
@@ -125,8 +125,8 @@ func Parse(s *ast.Schema, schemaString string, useStringDescriptions bool) error
 					if err := validateImplementingFieldArguments(intf.Name, t.Name, "interface", intfField, implField); err != nil {
 						return err
 					}
-					if intfField.Directives.Get("deprecated") == nil && implField.Directives.Get("deprecated") != nil {
-						return errors.Errorf("interface %q field %q is not deprecated but implementing interface %q marks it as deprecated", intf.Name, f, t.Name)
+					if err := validateImplementingFieldDeprecation(intf.Name, t.Name, "interface", intfField, implField); err != nil {
+						return err
 					}
 				}
 
@@ -165,8 +165,8 @@ func Parse(s *ast.Schema, schemaString string, useStringDescriptions bool) error
 				if err := validateImplementingFieldArguments(intfName, obj.Name, "type", intfField, implField); err != nil {
 					return err
 				}
-				if intfField.Directives.Get("deprecated") == nil && implField.Directives.Get("deprecated") != nil {
-					return errors.Errorf("interface %q field %q is not deprecated but implementing type %q marks it as deprecated", intfName, f, obj.Name)
+				if err := validateImplementingFieldDeprecation(intfName, obj.Name, "type", intfField, implField); err != nil {
+					return err
 				}
 			}
 			obj.Interfaces[i] = intf
@@ -275,6 +275,13 @@ func validateImplementingFieldArguments(interfaceName, implementerName, implemen
 		}
 	}
 
+	return nil
+}
+
+func validateImplementingFieldDeprecation(interfaceName, implementerName, implementerKind string, intfField, implField *ast.FieldDefinition) error {
+	if intfField.Directives.Get("deprecated") == nil && implField.Directives.Get("deprecated") != nil {
+		return errors.Errorf("interface %q field %q is not deprecated but implementing %s %q marks it as deprecated", interfaceName, intfField.Name, implementerKind, implementerName)
+	}
 	return nil
 }
 

--- a/internal/validation/overlap_fuzz_test.go
+++ b/internal/validation/overlap_fuzz_test.go
@@ -71,7 +71,7 @@ func FuzzValidateOverlapMixed(f *testing.F) {
 			return
 		}
 		// Use overlap limit to bound cost.
-		errs := v.Validate(s, doc, nil, 0, 10_000)
+		errs := v.Validate(s, doc, nil, 0, 10_000, false)
 		// Ensure no panic (implicit). Optionally sanity check: errors slice must not be ridiculously huge.
 		if len(errs) > 1000 {
 			t.Fatalf("too many errors: %d", len(errs))

--- a/internal/validation/validate_max_depth_test.go
+++ b/internal/validation/validate_max_depth_test.go
@@ -83,7 +83,7 @@ func (tc maxDepthTestCase) Run(t *testing.T, s *ast.Schema) {
 			t.Fatal(qErr)
 		}
 
-		errs := Validate(s, doc, nil, tc.depth, 0)
+		errs := Validate(s, doc, nil, tc.depth, 0, false)
 		if len(tc.expectedErrors) > 0 {
 			if len(errs) > 0 {
 				for _, expected := range tc.expectedErrors {
@@ -489,7 +489,7 @@ func TestMaxDepthValidation(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			context := newContext(s, doc, tc.maxDepth, 0)
+			context := newContext(s, doc, tc.maxDepth, 0, false)
 			op := doc.Operations[0]
 
 			opc := &opContext{context: context, ops: doc.Operations}

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -39,6 +39,7 @@ type context struct {
 	usedVars             map[*ast.OperationDefinition]varSet
 	fieldMap             map[*ast.Field]fieldInfo
 	overlapValidated     map[selectionPair]bool
+	allowDeprecatedUsage bool
 	maxDepth             int
 	overlapPairLimit     int
 	overlapPairsObserved int
@@ -57,26 +58,34 @@ func (c *context) addErrMultiLoc(locs []errors.Location, rule string, format str
 	})
 }
 
+func (c *context) addDeprecatedErr(loc errors.Location, format string, a ...any) {
+	if c.allowDeprecatedUsage {
+		return
+	}
+	c.addErr(loc, "NoDeprecatedCustomRule", format, a...)
+}
+
 type opContext struct {
 	*context
 	ops []*ast.OperationDefinition
 }
 
-func newContext(s *ast.Schema, doc *ast.ExecutableDefinition, maxDepth int, overlapPairLimit int) *context {
+func newContext(s *ast.Schema, doc *ast.ExecutableDefinition, maxDepth int, overlapPairLimit int, allowDeprecatedUsage bool) *context {
 	return &context{
-		schema:           s,
-		doc:              doc,
-		opErrs:           make(map[*ast.OperationDefinition][]*errors.QueryError),
-		usedVars:         make(map[*ast.OperationDefinition]varSet),
-		fieldMap:         make(map[*ast.Field]fieldInfo),
-		overlapValidated: make(map[selectionPair]bool),
-		maxDepth:         maxDepth,
-		overlapPairLimit: overlapPairLimit,
+		schema:               s,
+		doc:                  doc,
+		opErrs:               make(map[*ast.OperationDefinition][]*errors.QueryError),
+		usedVars:             make(map[*ast.OperationDefinition]varSet),
+		fieldMap:             make(map[*ast.Field]fieldInfo),
+		overlapValidated:     make(map[selectionPair]bool),
+		allowDeprecatedUsage: allowDeprecatedUsage,
+		maxDepth:             maxDepth,
+		overlapPairLimit:     overlapPairLimit,
 	}
 }
 
-func Validate(s *ast.Schema, doc *ast.ExecutableDefinition, variables map[string]any, maxDepth int, overlapPairLimit int) []*errors.QueryError {
-	c := newContext(s, doc, maxDepth, overlapPairLimit)
+func Validate(s *ast.Schema, doc *ast.ExecutableDefinition, variables map[string]any, maxDepth int, overlapPairLimit int, allowDeprecatedUsage bool) []*errors.QueryError {
+	c := newContext(s, doc, maxDepth, overlapPairLimit, allowDeprecatedUsage)
 
 	opNames := make(nameSet, len(doc.Operations))
 	fragUsedBy := make(map[*ast.FragmentDefinition][]*ast.OperationDefinition)
@@ -629,7 +638,7 @@ func validateSelection(c *opContext, sel ast.Selection, t ast.NamedType) {
 		validateArgumentLiterals(c, sel.Arguments)
 		if f != nil {
 			if reason, ok := deprecatedReason(f.Directives); ok && t != nil {
-				c.addErr(sel.Name.Loc, "NoDeprecatedCustomRule", "The field %s.%s is deprecated. %s", t.TypeName(), fieldName, reason)
+				c.addDeprecatedErr(sel.Name.Loc, "The field %s.%s is deprecated. %s", t.TypeName(), fieldName, reason)
 			}
 
 			validateArgumentTypes(c, sel.Arguments, f.Arguments, sel.Alias.Loc,
@@ -644,7 +653,7 @@ func validateSelection(c *opContext, sel ast.Selection, t ast.NamedType) {
 						continue
 					}
 					if reason, ok := deprecatedReason(argDecl.Directives); ok {
-						c.addErr(selArg.Name.Loc, "NoDeprecatedCustomRule", "Field %q argument %q is deprecated. %s", t.TypeName()+"."+fieldName, selArg.Name.Name, reason)
+						c.addDeprecatedErr(selArg.Name.Loc, "Field %q argument %q is deprecated. %s", t.TypeName()+"."+fieldName, selArg.Name.Name, reason)
 					}
 				}
 
@@ -659,7 +668,7 @@ func validateSelection(c *opContext, sel ast.Selection, t ast.NamedType) {
 							continue
 						}
 						if reason, ok := deprecatedReason(argDecl.Directives); ok {
-							c.addErr(selArg.Name.Loc, "NoDeprecatedCustomRule", "Directive %q argument %q is deprecated. %s", "@"+directive.Name.Name, selArg.Name.Name, reason)
+							c.addDeprecatedErr(selArg.Name.Loc, "Directive %q argument %q is deprecated. %s", "@"+directive.Name.Name, selArg.Name.Name, reason)
 						}
 					}
 				}
@@ -1079,7 +1088,7 @@ func validateDirectives(c *opContext, loc string, directives ast.DirectiveList) 
 					continue
 				}
 				if reason, ok := deprecatedReason(argDecl.Directives); ok {
-					c.addErr(selArg.Name.Loc, "NoDeprecatedCustomRule", "Directive %q argument %q is deprecated. %s", "@"+dirName, selArg.Name.Name, reason)
+					c.addDeprecatedErr(selArg.Name.Loc, "Directive %q argument %q is deprecated. %s", "@"+dirName, selArg.Name.Name, reason)
 				}
 			}
 		}
@@ -1268,7 +1277,7 @@ func validateValueType(c *opContext, v ast.Value, t ast.Type) (bool, errors.Loca
 				continue
 			}
 			if depReason, deprecated := deprecatedReason(option.Directives); deprecated {
-				c.addErr(lit.Location(), "NoDeprecatedCustomRule", "The enum value %q is deprecated. %s", enumType.Name+"."+option.EnumValue, depReason)
+				c.addDeprecatedErr(lit.Location(), "The enum value %q is deprecated. %s", enumType.Name+"."+option.EnumValue, depReason)
 			}
 			break
 		}
@@ -1303,7 +1312,7 @@ func validateValueType(c *opContext, v ast.Value, t ast.Type) (bool, errors.Loca
 				return false, f.Name.Loc, fmt.Sprintf("Field %q is not defined by type %q.%s", name, t.Name, suggestion)
 			}
 			if depReason, deprecated := deprecatedReason(iv.Directives); deprecated {
-				c.addErr(f.Name.Loc, "NoDeprecatedCustomRule", "The input field %s.%s is deprecated. %s", t.Name, iv.Name.Name, depReason)
+				c.addDeprecatedErr(f.Name.Loc, "The input field %s.%s is deprecated. %s", t.Name, iv.Name.Name, depReason)
 			}
 			if ok, errLoc, reason := validateValueType(c, f.Value, iv.Type); !ok {
 				return false, errLoc, reason

--- a/internal/validation/validation_bench_test.go
+++ b/internal/validation/validation_bench_test.go
@@ -65,7 +65,7 @@ func BenchmarkValidate(b *testing.B) {
 		b.Run(tc.name, func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
-				benchErrs = validation.Validate(s, doc, nil, 0, 0)
+				benchErrs = validation.Validate(s, doc, nil, 0, 0, false)
 			}
 		})
 	}
@@ -91,7 +91,7 @@ func BenchmarkValidateWorstCaseAliasCollision(b *testing.B) {
 		b.Run("alias-collision-"+strconv.Itoa(n), func(b *testing.B) {
 			b.ReportAllocs()
 			for b.Loop() {
-				benchErrs = validation.Validate(s, doc, nil, 0, 0)
+				benchErrs = validation.Validate(s, doc, nil, 0, 0, false)
 			}
 
 			if b.N > 0 && expectedPairs > 0 {

--- a/internal/validation/validation_test.go
+++ b/internal/validation/validation_test.go
@@ -82,7 +82,7 @@ func TestValidate(t *testing.T) {
 			if err != nil {
 				t.Fatalf("failed to parse query: %s", err)
 			}
-			errs := validation.Validate(schemas[test.Schema], d, test.Vars, 0, 0)
+			errs := validation.Validate(schemas[test.Schema], d, test.Vars, 0, 0, false)
 			got := []*errors.QueryError{}
 			for _, err := range errs {
 				if err.Rule == test.Rule {
@@ -96,6 +96,34 @@ func TestValidate(t *testing.T) {
 				t.Errorf("wrong errors for rule %q\nexpected: %v\ngot:      %v", test.Rule, test.Errors, got)
 			}
 		})
+	}
+}
+
+func TestValidateAllowDeprecatedUsage(t *testing.T) {
+	t.Parallel()
+
+	s, err := schema.ParseSchema(`
+		type Query {
+			deprecatedField: String! @deprecated(reason: "Use replacementField")
+		}
+	`, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	doc, qErr := query.Parse(`query { deprecatedField }`)
+	if qErr != nil {
+		t.Fatal(qErr)
+	}
+
+	errs := validation.Validate(s, doc, nil, 0, 0, false)
+	if len(errs) != 1 || errs[0].Rule != "NoDeprecatedCustomRule" {
+		t.Fatalf("expected NoDeprecatedCustomRule error, got %#v", errs)
+	}
+
+	errs = validation.Validate(s, doc, nil, 0, 0, true)
+	if len(errs) != 0 {
+		t.Fatalf("expected no validation errors when deprecated usage is allowed, got %#v", errs)
 	}
 }
 

--- a/subscriptions.go
+++ b/subscriptions.go
@@ -40,7 +40,7 @@ func (s *Schema) subscribe(ctx context.Context, queryString string, operationNam
 	}
 
 	validationFinish := s.validationTracer.TraceValidation(ctx)
-	errs := validation.Validate(s.schema, doc, variables, s.maxDepth, s.overlapPairLimit)
+	errs := validation.Validate(s.schema, doc, variables, s.maxDepth, s.overlapPairLimit, s.allowDeprecatedUsage)
 	validationFinish(errs)
 	if len(errs) != 0 {
 		return sendAndReturnClosed(&Response{Errors: errs})


### PR DESCRIPTION
This PR adds the schema parse option `AllowDeprecatedUsage`. With this option, the server will resolve fields and
arguments that have been annotated as `@deprecated` in `.graphql`, which is the pre-v1.10.0 behavior. This PR does not change the default behavior.

The purpose of the PR is to make `graphql-go` convenient (again) for situations where a grace period is required between deprecation and removal.

I have not found specific wording in the GraphQL specification (at https://spec.graphql.org/September2025/#sec--deprecated) either way; it says neither "deprecated fields must be resolved" nor "resolving a deprecated fields must return an error". In this situation I think the reasonable, least intrusive shape of this PR is to leave current default behavior as is, while making the legacy behavior optional.
