### PR TITLE
fix: reject undefined input object fields supplied via variables

### DIFF
--- a/graphql_test.go
+++ b/graphql_test.go
@@ -4670,6 +4670,64 @@ func TestQueryVariablesValidation(t *testing.T) {
 			Locations: []gqlerrors.Location{{Line: 3, Column: 5}},
 			Rule:      "VariablesOfCorrectType",
 		}},
+	}, {
+		// An entry not defined by the input object type must raise an error. The
+		// literal path already rejects this (see validateValueType); values arriving
+		// through a variable must be held to the same rule, otherwise the undefined
+		// entry is silently discarded and the request succeeds.
+		Schema: graphql.MustParseSchema(`
+			input SearchFilter {
+				required: String!
+				optional: String
+			}
+
+			type SearchResults {
+				match: String
+			}
+
+			type Query {
+				search(filter: SearchFilter!): [SearchResults!]!
+			}`, &queryVarResolver{}, graphql.UseFieldResolvers()),
+		Query: `
+			query q($filter: SearchFilter!) {
+				search(filter: $filter) {
+					match
+				}
+			}`,
+		Variables: map[string]any{"filter": map[string]any{"required": "a", "undefined": "b"}},
+		ExpectedErrors: []*gqlerrors.QueryError{{
+			Message:   "Variable \"filter\" has invalid value.\nField \"undefined\" is not defined by type \"SearchFilter\".",
+			Locations: []gqlerrors.Location{{Line: 2, Column: 12}},
+			Rule:      "VariablesOfCorrectType",
+		}},
+	}, {
+		// A near-miss name should suggest what the caller probably meant, matching
+		// the suggestion the literal path already produces.
+		Schema: graphql.MustParseSchema(`
+			input SearchFilter {
+				required: String!
+				optional: String
+			}
+
+			type SearchResults {
+				match: String
+			}
+
+			type Query {
+				search(filter: SearchFilter!): [SearchResults!]!
+			}`, &queryVarResolver{}, graphql.UseFieldResolvers()),
+		Query: `
+			query q($filter: SearchFilter!) {
+				search(filter: $filter) {
+					match
+				}
+			}`,
+		Variables: map[string]any{"filter": map[string]any{"required": "a", "optionl": "b"}},
+		ExpectedErrors: []*gqlerrors.QueryError{{
+			Message:   "Variable \"filter\" has invalid value.\nField \"optionl\" is not defined by type \"SearchFilter\". Did you mean \"optional\"?",
+			Locations: []gqlerrors.Location{{Line: 2, Column: 12}},
+			Rule:      "VariablesOfCorrectType",
+		}},
 	}})
 }
 

--- a/internal/validation/validation.go
+++ b/internal/validation/validation.go
@@ -270,6 +270,23 @@ func validateValue(c *opContext, v *ast.InputValueDefinition, val any, t ast.Typ
 			c.addErr(v.Loc, "VariablesOfCorrectType", "Variable \"%s\" has invalid type %T.\nExpected type \"%s\", found %s.", v.Name.Name, val, t, val)
 			return
 		}
+		// Entries not defined by the type must raise a request error. Iterating the
+		// declared fields alone cannot see them, so walk the supplied map too. The
+		// literal path (validateValueType, case *ast.InputObject) already enforces
+		// this; without the same check here, an undefined entry supplied through a
+		// variable is silently dropped and the request succeeds.
+		unknown := make([]string, 0)
+		for name := range in {
+			if t.Values.Get(name) == nil {
+				unknown = append(unknown, name)
+			}
+		}
+		// Map iteration order is random; sort so repeated runs report identically.
+		slices.Sort(unknown)
+		for _, name := range unknown {
+			suggestion := makeSuggestion("Did you mean", t.Values.Names(), name)
+			c.addErr(v.Loc, "VariablesOfCorrectType", "Variable \"%s\" has invalid value.\nField %q is not defined by type %q.%s", v.Name.Name, name, t.Name, suggestion)
+		}
 		for _, f := range t.Values {
 			fieldVal := in[f.Name.Name]
 			validateValue(c, f, fieldVal, f.Type)


### PR DESCRIPTION
## Problem

An input object value supplied through a **variable** is accepted even when it contains entries the input object type does not define. The undefined entries are silently discarded and the request succeeds. The same value written as a **literal** in the query is correctly rejected.

```graphql
input SearchFilter { required: String!  optional: String }
```

```graphql
# rejected today (correct)
query { search(filter: {required: "a", undefined: "b"}) { match } }
# => Field "undefined" is not defined by type "SearchFilter".

# accepted today (should be an error)
query q($filter: SearchFilter!) { search(filter: $filter) { match } }
# variables: {"filter": {"required": "a", "undefined": "b"}}
# => {"data": {...}}
```

This is easy to hit in practice: a client that misnames a field gets a success response and a partially-applied input, with nothing to indicate a value was dropped.

## Cause

`validateValue`'s `*ast.InputObject` case iterates the type's **declared** fields and looks each one up in the supplied map:

```go
for _, f := range t.Values {
    fieldVal := in[f.Name.Name]
    validateValue(c, f, fieldVal, f.Type)
}
```

An entry present in the map but absent from the type is never visited. `validateValueType` (the literal path) iterates the other direction — provided fields, looked up in the type — and already reports `Field "x" is not defined by type "Y"`, which is why literals are caught.

## Spec

Section 3.10, Input Coercion, requires the error, and names the variable case explicitly:

> The value for an input object should be an input object literal or an unordered map supplied by a variable, otherwise a request error must be raised. In either case, the input object literal or unordered map **must not contain any entries with names not defined by a field of this input object type, otherwise a request error must be raised.**

Section 6.1.2 routes variable values through those same coercion rules. graphql-js rejects this case in `coerceInputValue`.

## Change

Walk the supplied map as well, reporting entries not defined by the type, and reuse the existing `makeSuggestion` helper so the message matches the literal path. Undefined entries are collected and sorted before being reported, so Go's randomized map iteration order does not make the error output vary between runs.

Two cases added to `TestQueryVariablesValidation`, covering the rejection and the did-you-mean suggestion. The full test suite passes (`go test -count=1 ./...`).

## Relationship to #292

#292 ("Query variables are not validated") fixed the *missing-required-key* direction of this same literal-vs-variable asymmetry. This is the *unknown-key* counterpart, which that change did not cover.

It is also structurally invisible to the graphql-js parity work in #708: graphql-js catches this at execution-time coercion rather than in a validation rule, so importing the validation rules could not surface it.

## Note, not addressed here

The `@oneOf` exactly-one-key constraint appears to have the same asymmetry — enforced for literals, not for values arriving via variables. I left it out to keep this diff focused, but I'm happy to follow up if you'd like it in the same PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)